### PR TITLE
Add .NET 5.0 TFM and sync HttpClient

### DIFF
--- a/src/Elastic.Transport/Components/Connection/HttpConnection.cs
+++ b/src/Elastic.Transport/Components/Connection/HttpConnection.cs
@@ -90,7 +90,11 @@ namespace Elastic.Transport
 					if (requestData.ThreadPoolStats)
 						threadPoolStats = ThreadPoolStats.GetStats();
 
+#if NET5_0
+					responseMessage = client.Send(requestMessage, HttpCompletionOption.ResponseHeadersRead);
+#else
 					responseMessage = client.SendAsync(requestMessage, HttpCompletionOption.ResponseHeadersRead).GetAwaiter().GetResult();
+#endif
 					statusCode = (int)responseMessage.StatusCode;
 					d.EndState = statusCode;
 				}
@@ -102,7 +106,12 @@ namespace Elastic.Transport
 				if (responseMessage.Content != null)
 				{
 					receive = DiagnosticSource.Diagnose(DiagnosticSources.HttpConnection.ReceiveBody, requestData, statusCode);
+
+#if NET5_0
+					responseStream = responseMessage.Content.ReadAsStream();
+#else
 					responseStream = responseMessage.Content.ReadAsStreamAsync().GetAwaiter().GetResult();
+#endif
 				}
 			}
 			catch (TaskCanceledException e)

--- a/src/Elastic.Transport/Elastic.Transport.csproj
+++ b/src/Elastic.Transport/Elastic.Transport.csproj
@@ -12,7 +12,7 @@
   <PropertyGroup>
     <IsPackable>true</IsPackable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net461;net5.0</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
 


### PR DESCRIPTION
In .NET 5.0, HttpClient now includes sync APIs which can be used to avoid manual sync over async code. I have added the .NET 5.0 TFM so that we can produce packages for .NET 5.0 which use these new APIs.