### PR TITLE
Add integration tests for Transport

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -16,6 +16,9 @@
     
     <DefineConstants Condition="'$(TargetFramework)'=='net461'">$(DefineConstants);FULLFRAMEWORK</DefineConstants>
     <DefineConstants Condition="$(DefineConstants.Contains(FULLFRAMEWORK)) == False">$(DefineConstants);DOTNETCORE</DefineConstants>
+    <DefineConstants Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net5.0'))">$(DefineConstants);NET5_COMPATIBLE</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition="">
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="MinVer" Version="2.3.1" PrivateAssets="all" />

--- a/elastic-transport-net.sln
+++ b/elastic-transport-net.sln
@@ -36,6 +36,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "benchmarks", "benchmarks", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Elastic.Transport.Benchmarks", "benchmarks\Elastic.Transport.Benchmarks\Elastic.Transport.Benchmarks.csproj", "{DABC7F0B-6174-4B2D-8F17-5E36C1CE43EF}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elastic.Transport.IntegrationTests", "tests\Elastic.Transport.IntegrationTests\Elastic.Transport.IntegrationTests.csproj", "{3B27DE76-1188-4078-8828-67AFD39BAC10}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -62,6 +64,10 @@ Global
 		{DABC7F0B-6174-4B2D-8F17-5E36C1CE43EF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{DABC7F0B-6174-4B2D-8F17-5E36C1CE43EF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{DABC7F0B-6174-4B2D-8F17-5E36C1CE43EF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3B27DE76-1188-4078-8828-67AFD39BAC10}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3B27DE76-1188-4078-8828-67AFD39BAC10}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3B27DE76-1188-4078-8828-67AFD39BAC10}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3B27DE76-1188-4078-8828-67AFD39BAC10}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -72,6 +78,7 @@ Global
 		{9B54DFFE-2B86-4F04-A9C4-5DE12FBADD77} = {7610B796-BB3E-4CB2-8296-79BBFF6D23FC}
 		{79EAF3D6-87AE-49F0-8928-07EBA2876A75} = {3582B07D-C2B0-49CC-B676-EAF806EB010E}
 		{DABC7F0B-6174-4B2D-8F17-5E36C1CE43EF} = {BBB0AC81-F09D-4895-84E2-7E933D608E78}
+		{3B27DE76-1188-4078-8828-67AFD39BAC10} = {3582B07D-C2B0-49CC-B676-EAF806EB010E}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7F60C4BB-6216-4E50-B1E4-9C38EB484843}

--- a/src/Elastic.Transport/Components/Connection/Content/RequestDataContent.cs
+++ b/src/Elastic.Transport/Components/Connection/Content/RequestDataContent.cs
@@ -25,7 +25,10 @@ namespace Elastic.Transport
 	internal class RequestDataContent : HttpContent
 	{
 		private readonly RequestData _requestData;
-		private readonly Func<RequestData, CompleteTaskOnCloseStream, RequestDataContent, TransportContext, CancellationToken, Task> _onStreamAvailableAsync;
+
+		private readonly Func<RequestData, CompleteTaskOnCloseStream, RequestDataContent, TransportContext, CancellationToken, Task>
+			_onStreamAvailableAsync;
+
 		private readonly Action<RequestData, CompleteTaskOnCloseStream, RequestDataContent, TransportContext> _onStreamAvailable;
 		private readonly CancellationToken _token;
 
@@ -42,11 +45,11 @@ namespace Elastic.Transport
 				if (data.HttpCompression)
 					stream = new GZipStream(stream, CompressionMode.Compress, false);
 
-				using(stream)
+				using (stream)
 					data.PostData.Write(stream, data.ConnectionSettings);
 			}
 
-			_onStreamAvailable= OnStreamAvailable;
+			_onStreamAvailable = OnStreamAvailable;
 		}
 
 		public RequestDataContent(RequestData requestData, CancellationToken token)
@@ -57,7 +60,9 @@ namespace Elastic.Transport
 			if (requestData.HttpCompression)
 				Headers.ContentEncoding.Add("gzip");
 
-			async Task OnStreamAvailableAsync(RequestData data, Stream stream, HttpContent content, TransportContext context, CancellationToken ctx = default)
+			async Task OnStreamAvailableAsync(RequestData data, Stream stream, HttpContent content, TransportContext context,
+				CancellationToken ctx = default
+			)
 			{
 				if (data.HttpCompression)
 					stream = new GZipStream(stream, CompressionMode.Compress, false);
@@ -65,7 +70,7 @@ namespace Elastic.Transport
 #if NET5_COMPATIBLE
 				await
 #endif
-					using (stream)
+				using (stream)
 					await data.PostData.WriteAsync(stream, data.ConnectionSettings, ctx).ConfigureAwait(false);
 			}
 
@@ -93,8 +98,8 @@ namespace Elastic.Transport
 			var source = CancellationTokenSource.CreateLinkedTokenSource(_token, cancellationToken);
 			var serializeToStreamTask = new TaskCompletionSource<bool>();
 			var wrappedStream = new CompleteTaskOnCloseStream(stream, serializeToStreamTask);
-            await _onStreamAvailableAsync(_requestData, wrappedStream, this, context, source.Token).ConfigureAwait(false);
-            await serializeToStreamTask.Task.ConfigureAwait(false);
+			await _onStreamAvailableAsync(_requestData, wrappedStream, this, context, source.Token).ConfigureAwait(false);
+			await serializeToStreamTask.Task.ConfigureAwait(false);
 		}
 
 #if NET5_COMPATIBLE
@@ -102,8 +107,8 @@ namespace Elastic.Transport
 		{
 			var serializeToStreamTask = new TaskCompletionSource<bool>();
 			using var wrappedStream = new CompleteTaskOnCloseStream(stream, serializeToStreamTask);
-            _onStreamAvailable(_requestData, wrappedStream, this, context);
-            //await serializeToStreamTask.Task.ConfigureAwait(false);
+			_onStreamAvailable(_requestData, wrappedStream, this, context);
+			//await serializeToStreamTask.Task.ConfigureAwait(false);
 		}
 #endif
 

--- a/src/Elastic.Transport/Components/Connection/Content/RequestDataContent.cs
+++ b/src/Elastic.Transport/Components/Connection/Content/RequestDataContent.cs
@@ -25,45 +25,51 @@ namespace Elastic.Transport
 	internal class RequestDataContent : HttpContent
 	{
 		private readonly RequestData _requestData;
-		private readonly Func<RequestData, CompleteTaskOnCloseStream, RequestDataContent, TransportContext, Task> _onStreamAvailable;
+		private readonly Func<RequestData, CompleteTaskOnCloseStream, RequestDataContent, TransportContext, CancellationToken, Task> _onStreamAvailableAsync;
+		private readonly Action<RequestData, CompleteTaskOnCloseStream, RequestDataContent, TransportContext> _onStreamAvailable;
+		private readonly CancellationToken _token;
 
 		public RequestDataContent(RequestData requestData)
 		{
 			_requestData = requestData;
+			_token = default;
 			Headers.ContentType = new MediaTypeHeaderValue(requestData.RequestMimeType);
 			if (requestData.HttpCompression)
 				Headers.ContentEncoding.Add("gzip");
 
-			static Task OnStreamAvailable(RequestData data, Stream stream, HttpContent content, TransportContext context)
+			static void OnStreamAvailable(RequestData data, Stream stream, HttpContent content, TransportContext context)
 			{
 				if (data.HttpCompression)
 					stream = new GZipStream(stream, CompressionMode.Compress, false);
 
 				using(stream)
 					data.PostData.Write(stream, data.ConnectionSettings);
-
-				return Task.CompletedTask;
 			}
 
-			_onStreamAvailable = OnStreamAvailable;
+			_onStreamAvailable= OnStreamAvailable;
 		}
+
 		public RequestDataContent(RequestData requestData, CancellationToken token)
 		{
 			_requestData = requestData;
+			_token = token;
 			Headers.ContentType = new MediaTypeHeaderValue(requestData.RequestMimeType);
 			if (requestData.HttpCompression)
 				Headers.ContentEncoding.Add("gzip");
 
-			async Task OnStreamAvailable(RequestData data, Stream stream, HttpContent content, TransportContext context)
+			async Task OnStreamAvailableAsync(RequestData data, Stream stream, HttpContent content, TransportContext context, CancellationToken ctx = default)
 			{
 				if (data.HttpCompression)
 					stream = new GZipStream(stream, CompressionMode.Compress, false);
 
-				using (stream)
-					await data.PostData.WriteAsync(stream, data.ConnectionSettings, token).ConfigureAwait(false);
+#if NET5_COMPATIBLE
+				await
+#endif
+					using (stream)
+					await data.PostData.WriteAsync(stream, data.ConnectionSettings, ctx).ConfigureAwait(false);
 			}
 
-			_onStreamAvailable = OnStreamAvailable;
+			_onStreamAvailableAsync = OnStreamAvailableAsync;
 		}
 
 		/// <summary>
@@ -75,13 +81,32 @@ namespace Elastic.Transport
 		/// <param name="context">The associated <see cref="TransportContext"/>.</param>
 		/// <returns>A <see cref="Task"/> instance that is asynchronously serializing the object's content.</returns>
 		[SuppressMessage("Microsoft.Design", "CA1031:DoNotCatchGeneralExceptionTypes", Justification = "Exception is passed as task result.")]
-		protected override async Task SerializeToStreamAsync(Stream stream, TransportContext context)
+		protected override Task SerializeToStreamAsync(Stream stream, TransportContext context) =>
+			SerializeToStreamAsync(stream, context, default);
+
+		protected
+#if NET5_COMPATIBLE
+			override
+#endif
+			async Task SerializeToStreamAsync(Stream stream, TransportContext context, CancellationToken cancellationToken)
 		{
+			var source = CancellationTokenSource.CreateLinkedTokenSource(_token, cancellationToken);
 			var serializeToStreamTask = new TaskCompletionSource<bool>();
 			var wrappedStream = new CompleteTaskOnCloseStream(stream, serializeToStreamTask);
-            await _onStreamAvailable(_requestData, wrappedStream, this, context).ConfigureAwait(false);
+            await _onStreamAvailableAsync(_requestData, wrappedStream, this, context, source.Token).ConfigureAwait(false);
             await serializeToStreamTask.Task.ConfigureAwait(false);
 		}
+
+#if NET5_COMPATIBLE
+		protected override void SerializeToStream(Stream stream, TransportContext context, CancellationToken _)
+		{
+			var serializeToStreamTask = new TaskCompletionSource<bool>();
+			using var wrappedStream = new CompleteTaskOnCloseStream(stream, serializeToStreamTask);
+            _onStreamAvailable(_requestData, wrappedStream, this, context);
+            //await serializeToStreamTask.Task.ConfigureAwait(false);
+		}
+#endif
+
 
 		/// <summary>
 		/// Computes the length of the stream if possible.

--- a/src/Elastic.Transport/Components/Connection/Content/RequestDataContent.cs
+++ b/src/Elastic.Transport/Components/Connection/Content/RequestDataContent.cs
@@ -34,7 +34,7 @@ namespace Elastic.Transport
 			if (requestData.HttpCompression)
 				Headers.ContentEncoding.Add("gzip");
 
-			Task OnStreamAvailable(RequestData data, Stream stream, HttpContent content, TransportContext context)
+			static Task OnStreamAvailable(RequestData data, Stream stream, HttpContent content, TransportContext context)
 			{
 				if (data.HttpCompression)
 					stream = new GZipStream(stream, CompressionMode.Compress, false);

--- a/src/Elastic.Transport/TransportExtensions.cs
+++ b/src/Elastic.Transport/TransportExtensions.cs
@@ -38,7 +38,7 @@ namespace Elastic.Transport
 			transport.HeadAsync<VoidResponse>(path, ctx, parameters);
 
 		/// <summary>Perform a POST request</summary>
-		public static TResponse PostAsync<TResponse>(this ITransport transport, string path, PostData data, IRequestParameters parameters = null)
+		public static TResponse Post<TResponse>(this ITransport transport, string path, PostData data, IRequestParameters parameters = null)
 			where TResponse : class, ITransportResponse, new() =>
 			transport.Request<TResponse>(HttpMethod.POST, path, data, parameters);
 
@@ -48,21 +48,21 @@ namespace Elastic.Transport
 			transport.RequestAsync<TResponse>(HttpMethod.POST, path, ctx, data, parameters);
 
 		/// <summary>Perform a PUT request</summary>
-		public static TResponse PutAsync<TResponse>(this ITransport transport, string path, PostData data, IRequestParameters parameters = null)
+		public static TResponse Put<TResponse>(this ITransport transport, string path, PostData data, IRequestParameters parameters = null)
 			where TResponse : class, ITransportResponse, new() =>
 			transport.Request<TResponse>(HttpMethod.PUT, path, data, parameters);
 
-		/// <summary>Perform a GET request</summary>
+		/// <summary>Perform a PUT request</summary>
 		public static Task<TResponse> PutAsync<TResponse>(this ITransport transport, string path, PostData data, CancellationToken ctx = default, IRequestParameters parameters = null)
 			where TResponse : class, ITransportResponse, new() =>
 			transport.RequestAsync<TResponse>(HttpMethod.PUT, path, ctx, data, parameters);
 
 		/// <summary>Perform a DELETE request</summary>
-		public static TResponse DeleteAsync<TResponse>(this ITransport transport, string path, PostData data = null, IRequestParameters parameters = null)
+		public static TResponse Delete<TResponse>(this ITransport transport, string path, PostData data = null, IRequestParameters parameters = null)
 			where TResponse : class, ITransportResponse, new() =>
 			transport.Request<TResponse>(HttpMethod.DELETE, path, data, parameters);
 
-		/// <summary>Perform a GET request</summary>
+		/// <summary>Perform a DELETE request</summary>
 		public static Task<TResponse> DeleteAsync<TResponse>(this ITransport transport, string path, PostData data = null, CancellationToken ctx = default, IRequestParameters parameters = null)
 			where TResponse : class, ITransportResponse, new() =>
 			transport.RequestAsync<TResponse>(HttpMethod.DELETE, path, ctx, data, parameters);

--- a/tests/Elastic.Transport.IntegrationTests/Elastic.Transport.IntegrationTests.csproj
+++ b/tests/Elastic.Transport.IntegrationTests/Elastic.Transport.IntegrationTests.csproj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+    <IsTestProject>True</IsTestProject>
+    <IsPackable>false</IsPackable>
+    <NoWarn>CS8002</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.1" />
+
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="Xunit.Extensions.Ordering" Version="1.4.5" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
+    <PackageReference Include="coverlet.collector" Version="1.3.0" />
+    <PackageReference Include="Nullean.VsTest.Pretty.TestLogger" Version="0.3.0" />
+    <PackageReference Include="JunitXml.TestLogger" Version="2.1.78" />
+
+    <PackageReference Include="FluentAssertions" Version="5.10.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Elastic.Transport.VirtualizedCluster\Elastic.Transport.VirtualizedCluster.csproj" />
+  </ItemGroup>
+</Project>

--- a/tests/Elastic.Transport.IntegrationTests/Http/TransferEncodingChunckedTests.cs
+++ b/tests/Elastic.Transport.IntegrationTests/Http/TransferEncodingChunckedTests.cs
@@ -1,0 +1,118 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Elastic.Transport.IntegrationTests.Plumbing;
+using Elastic.Transport.IntegrationTests.Plumbing.Stubs;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Xunit;
+
+namespace Elastic.Transport.IntegrationTests.Http
+{
+	[ApiController, Route("[controller]")]
+	public class ChunkedController : ControllerBase
+	{
+		[HttpPost]
+		public async Task<JsonElement> Post([FromBody]JsonElement body) => await Task.FromResult(body);
+	}
+
+	public class TransferEncodingChunckedTests : AssemblyServerTestsBase
+	{
+		public TransferEncodingChunckedTests(TransportTestServer instance) : base(instance) { }
+
+
+		private static string BodyString = "{\"query\":{\"match_all\":{}}}";
+		private static PostData Body = PostData.String(BodyString);
+		private static readonly string Path = "/chunked";
+
+		private Transport Setup(
+			TestableHttpConnection connection,
+			Uri proxyAddress = null,
+			bool? disableAutomaticProxyDetection = null,
+			bool httpCompression = false,
+			bool transferEncodingChunked = false
+		)
+		{
+			var connectionPool = new SingleNodeConnectionPool(Server.Uri);
+			var config = new TransportConfiguration(connectionPool, connection)
+				.TransferEncodingChunked(transferEncodingChunked)
+				.EnableHttpCompression(httpCompression);
+			config = disableAutomaticProxyDetection.HasValue
+				? config.DisableAutomaticProxyDetection(disableAutomaticProxyDetection.Value)
+				//make sure we the requests in debugging proxy
+				: TransportTestServer.RerouteToProxyIfNeeded(config);
+
+			return new Transport(config);
+		}
+
+		/// <summary>
+		/// Setting HttpClientHandler.Proxy = null don't disable HttpClient automatic proxy detection.
+		/// It is disabled by setting Proxy to non-null value or by setting UseProxy = false.
+		/// </summary>
+		[Fact] public async Task HttpClientUseProxyShouldBeFalseWhenDisabledAutoProxyDetection()
+		{
+			var connection = new TestableHttpConnection();
+			var transport = Setup(connection, disableAutomaticProxyDetection: true);
+
+			var r = transport.Post<StringResponse>(Path, Body);
+			connection.LastHttpClientHandler.UseProxy.Should().BeFalse();
+			r.Body.Should().Be(BodyString);
+
+			r = await transport.PostAsync<StringResponse>(Path, Body, CancellationToken.None).ConfigureAwait(false);
+			connection.LastHttpClientHandler.UseProxy.Should().BeFalse();
+			r.Body.Should().Be(BodyString);
+		}
+
+		[Fact] public async Task HttpClientUseProxyShouldBeTrueWhenEnabledAutoProxyDetection()
+		{
+			var connection = new TestableHttpConnection();
+			var transport = Setup(connection);
+
+			transport.Post<StringResponse>(Path, Body);
+			connection.LastHttpClientHandler.UseProxy.Should().BeTrue();
+			await transport.PostAsync<StringResponse>(Path, Body, CancellationToken.None).ConfigureAwait(false);
+			connection.LastHttpClientHandler.UseProxy.Should().BeTrue();
+		}
+
+		[Fact] public async Task HttpClientUseTransferEncodingChunkedWhenTransferEncodingChunkedTrue()
+		{
+			var connection = new TestableHttpConnection(responseMessage =>
+			{
+				responseMessage.RequestMessage.Content.Headers.ContentLength.Should().BeNull();
+			});
+			var transport = Setup(connection, transferEncodingChunked: true);
+
+			transport.Post<StringResponse>(Path, Body);
+			await transport.PostAsync<StringResponse>(Path, Body, CancellationToken.None).ConfigureAwait(false);
+		}
+
+		[Fact] public async Task HttpClientSetsContentLengthWhenTransferEncodingChunkedFalse()
+		{
+			var connection = new TestableHttpConnection(responseMessage =>
+			{
+				responseMessage.RequestMessage.Content.Headers.ContentLength.Should().HaveValue();
+			});
+			var transport = Setup(connection, transferEncodingChunked: false);
+
+			transport.Post<StringResponse>(Path, Body);
+			await transport.PostAsync<StringResponse>(Path, Body, CancellationToken.None).ConfigureAwait(false);
+		}
+
+		[Fact] public async Task HttpClientSetsContentLengthWhenTransferEncodingChunkedHttpCompression()
+		{
+			var connection = new TestableHttpConnection(responseMessage =>
+			{
+				responseMessage.RequestMessage.Content.Headers.ContentLength.Should().HaveValue();
+			});
+			var transport = Setup(connection, transferEncodingChunked: false, httpCompression: true);
+
+			transport.Post<StringResponse>(Path, Body);
+			await transport.PostAsync<StringResponse>(Path, Body, CancellationToken.None).ConfigureAwait(false);
+		}
+	}
+}

--- a/tests/Elastic.Transport.IntegrationTests/Http/TransferEncodingChunckedTests.cs
+++ b/tests/Elastic.Transport.IntegrationTests/Http/TransferEncodingChunckedTests.cs
@@ -18,12 +18,12 @@ namespace Elastic.Transport.IntegrationTests.Http
 	public class ChunkedController : ControllerBase
 	{
 		[HttpPost]
-		public async Task<JsonElement> Post([FromBody]JsonElement body) => await Task.FromResult(body);
+		public Task<JsonElement> Post([FromBody]JsonElement body) => Task.FromResult(body);
 	}
 
-	public class TransferEncodingChunckedTests : AssemblyServerTestsBase
+	public class TransferEncodingChunkedTests : AssemblyServerTestsBase
 	{
-		public TransferEncodingChunckedTests(TransportTestServer instance) : base(instance) { }
+		public TransferEncodingChunkedTests(TransportTestServer instance) : base(instance) { }
 
 
 		private static string BodyString = "{\"query\":{\"match_all\":{}}}";

--- a/tests/Elastic.Transport.IntegrationTests/Http/TransferEncodingChunckedTests.cs
+++ b/tests/Elastic.Transport.IntegrationTests/Http/TransferEncodingChunckedTests.cs
@@ -26,9 +26,9 @@ namespace Elastic.Transport.IntegrationTests.Http
 		public TransferEncodingChunkedTests(TransportTestServer instance) : base(instance) { }
 
 
-		private static string BodyString = "{\"query\":{\"match_all\":{}}}";
-		private static PostData Body = PostData.String(BodyString);
-		private static readonly string Path = "/chunked";
+		private const string BodyString = "{\"query\":{\"match_all\":{}}}";
+		private static readonly PostData Body = PostData.String(BodyString);
+		private const string Path = "/chunked";
 
 		private Transport Setup(
 			TestableHttpConnection connection,

--- a/tests/Elastic.Transport.IntegrationTests/Plumbing/AssemblyServerTestsBase.cs
+++ b/tests/Elastic.Transport.IntegrationTests/Plumbing/AssemblyServerTestsBase.cs
@@ -1,0 +1,22 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using Xunit.Extensions.Ordering;
+
+namespace Elastic.Transport.IntegrationTests.Plumbing
+{
+	public class AssemblyServerTestsBase<TServer> : IAssemblyFixture<TServer> where TServer : class, ITransportTestServer
+	{
+		public AssemblyServerTestsBase(TServer instance) => Server = instance;
+
+		protected TServer Server { get; }
+
+		protected Transport Transport => Server.DefaultTransport;
+	}
+
+	public class AssemblyServerTestsBase : AssemblyServerTestsBase<TransportTestServer>
+	{
+		public AssemblyServerTestsBase(TransportTestServer instance) : base(instance) { }
+	}
+}

--- a/tests/Elastic.Transport.IntegrationTests/Plumbing/ClassServerTestsBase.cs
+++ b/tests/Elastic.Transport.IntegrationTests/Plumbing/ClassServerTestsBase.cs
@@ -1,0 +1,17 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using Xunit;
+
+namespace Elastic.Transport.IntegrationTests.Plumbing
+{
+	public class ClassServerTestsBase<TServer> : IClassFixture<TServer> where TServer : class, ITransportTestServer
+	{
+		public ClassServerTestsBase(TServer instance) => Server = instance;
+
+		protected TServer Server { get; }
+
+		protected Transport Transport => Server.DefaultTransport;
+	}
+}

--- a/tests/Elastic.Transport.IntegrationTests/Plumbing/DefaultStartup.cs
+++ b/tests/Elastic.Transport.IntegrationTests/Plumbing/DefaultStartup.cs
@@ -1,0 +1,45 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+namespace Elastic.Transport.IntegrationTests.Plumbing
+{
+	public class DefaultStartup
+	{
+		public DefaultStartup(IConfiguration configuration) => Configuration = configuration;
+
+		public IConfiguration Configuration { get; }
+
+		public void ConfigureServices(IServiceCollection services) => services.AddControllers();
+
+		public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+		{
+			if (env.IsDevelopment())
+			{
+				app.UseDeveloperExceptionPage();
+			}
+			else
+			{
+				app.UseHsts();
+			}
+
+			app.UseHttpsRedirection();
+			app.UseRouting();
+			app.UseEndpoints(endpoints =>
+			{
+				MapEndpoints(endpoints);
+				endpoints.MapControllerRoute("default", "{controller=Players}/{id?}");
+			});
+		}
+
+		protected virtual void MapEndpoints(IEndpointRouteBuilder endpoints) { }
+	}
+}

--- a/tests/Elastic.Transport.IntegrationTests/Plumbing/DefaultStartup.cs
+++ b/tests/Elastic.Transport.IntegrationTests/Plumbing/DefaultStartup.cs
@@ -36,7 +36,7 @@ namespace Elastic.Transport.IntegrationTests.Plumbing
 			app.UseEndpoints(endpoints =>
 			{
 				MapEndpoints(endpoints);
-				endpoints.MapControllerRoute("default", "{controller=Players}/{id?}");
+				endpoints.MapControllerRoute("default", "{controller=Default}/{id?}");
 			});
 		}
 

--- a/tests/Elastic.Transport.IntegrationTests/Plumbing/Examples/ControllerIntegrationTests.cs
+++ b/tests/Elastic.Transport.IntegrationTests/Plumbing/Examples/ControllerIntegrationTests.cs
@@ -1,0 +1,37 @@
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+// Feel free to delete these tests at some point, these are here as examples while we built out our test suite
+// A lot of integration tests need to be ported from elastic/elasticsearch-net
+namespace Elastic.Transport.IntegrationTests.Plumbing.Examples
+{
+	/// <summary>
+	/// Tests that the test framework loads a controller and the exposed transport can talk to its endpoints.
+	/// Tests runs against a server that started up once and its server instance shared among many test classes
+	/// </summary>
+	public class ControllerIntegrationTests : AssemblyServerTestsBase
+	{
+		public ControllerIntegrationTests(TransportTestServer instance) : base(instance) { }
+
+		[Fact]
+		public async Task CanCallIntoController()
+		{
+			var response = await Transport.GetAsync<StringResponse>("/dummy/20");
+			response.Success.Should().BeTrue("{0}", response.DebugInformation);
+		}
+	}
+
+	[ApiController, Route("[controller]")]
+	public class DummyController : ControllerBase
+	{
+		[HttpGet("{id}")]
+		public async Task<int> Get(int id) => await Task.FromResult(id * 3);
+	}
+
+}

--- a/tests/Elastic.Transport.IntegrationTests/Plumbing/Examples/EndpointIntegrationTests.cs
+++ b/tests/Elastic.Transport.IntegrationTests/Plumbing/Examples/EndpointIntegrationTests.cs
@@ -1,0 +1,47 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+namespace Elastic.Transport.IntegrationTests.Plumbing.Examples
+{
+	/// <summary>
+	/// Spins up a server just for the tests in this class, using a custom startup we attach a special endpoint handler
+	/// Since it extends <see cref="ClassServerTestsBase{TServer}"/> it server is only shared between the tests inside this class.
+	/// The server is also started and stopped after all the tests in this class run.
+	/// </summary>
+	public class EndpointIntegrationTests : ClassServerTestsBase<TransportTestServer<DummyStartup>>
+	{
+		public EndpointIntegrationTests(TransportTestServer<DummyStartup> instance) : base(instance) { }
+
+		[Fact]
+		public async Task CanCallIntoEndpoint()
+		{
+			var response = await Transport.GetAsync<StringResponse>(DummyStartup.Endpoint);
+			response.Success.Should().BeTrue("{0}", response.DebugInformation);
+		}
+	}
+
+	public class DummyStartup : DefaultStartup
+	{
+		public DummyStartup(IConfiguration configuration) : base(configuration) { }
+
+		public static string Endpoint { get; } = "buffered";
+
+		protected override void MapEndpoints(IEndpointRouteBuilder endpoints) =>
+			endpoints.MapGet("/buffered", async context =>
+			{
+				var name = context.Request.RouteValues["id"];
+				await context.Response.WriteAsync($"Hello {name}!");
+				await Task.Delay(1);
+				await context.Response.WriteAsync($"World!");
+			});
+	}
+}

--- a/tests/Elastic.Transport.IntegrationTests/Plumbing/Stubs/TestableClientHandler.cs
+++ b/tests/Elastic.Transport.IntegrationTests/Plumbing/Stubs/TestableClientHandler.cs
@@ -1,0 +1,26 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Elastic.Transport.IntegrationTests.Plumbing.Stubs
+{
+	public class TestableClientHandler : DelegatingHandler
+	{
+		private readonly Action<HttpResponseMessage> _responseAction;
+
+		public TestableClientHandler(HttpMessageHandler handler, Action<HttpResponseMessage> responseAction) : base(handler) =>
+			_responseAction = responseAction;
+
+		protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+		{
+			var response = await base.SendAsync(request, cancellationToken).ConfigureAwait(false);
+			_responseAction?.Invoke(response);
+			return response;
+		}
+	}
+}

--- a/tests/Elastic.Transport.IntegrationTests/Plumbing/Stubs/TestableHttpConnection.cs
+++ b/tests/Elastic.Transport.IntegrationTests/Plumbing/Stubs/TestableHttpConnection.cs
@@ -1,0 +1,47 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Elastic.Transport.IntegrationTests.Plumbing.Stubs
+{
+	public class TestableHttpConnection : HttpConnection
+	{
+		private readonly Action<HttpResponseMessage> _response;
+		private TestableClientHandler _handler;
+		public int CallCount { get; private set; }
+		public HttpClientHandler LastHttpClientHandler => (HttpClientHandler)_handler.InnerHandler;
+
+		public TestableHttpConnection(Action<HttpResponseMessage> response) => _response = response;
+
+		public TestableHttpConnection() { }
+
+		public override TResponse Request<TResponse>(RequestData requestData)
+		{
+			CallCount++;
+			return base.Request<TResponse>(requestData);
+		}
+
+		public override Task<TResponse> RequestAsync<TResponse>(RequestData requestData, CancellationToken cancellationToken)
+		{
+			CallCount++;
+			return base.RequestAsync<TResponse>(requestData, cancellationToken);
+		}
+
+		protected override HttpMessageHandler CreateHttpClientHandler(RequestData requestData)
+		{
+			_handler = new TestableClientHandler(base.CreateHttpClientHandler(requestData), _response);
+			return _handler;
+		}
+
+		protected override void DisposeManagedResources()
+		{
+			_handler?.Dispose();
+			base.DisposeManagedResources();
+		}
+	}
+}

--- a/tests/Elastic.Transport.IntegrationTests/Plumbing/TransportTestServer.cs
+++ b/tests/Elastic.Transport.IntegrationTests/Plumbing/TransportTestServer.cs
@@ -1,0 +1,102 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Xunit;
+
+[assembly: TestFramework("Xunit.Extensions.Ordering.TestFramework", "Xunit.Extensions.Ordering")]
+
+namespace Elastic.Transport.IntegrationTests.Plumbing
+{
+	public interface ITransportTestServer
+	{
+		Uri Uri { get;  }
+
+		Transport DefaultTransport { get;  }
+	}
+
+	public class TransportTestServer : TransportTestServer<DefaultStartup>
+	{
+		public static readonly ConcurrentQueue<int> PortNumbers = new(Enumerable.Range(3000, 100));
+		public static readonly bool RunningMitmProxy = Process.GetProcessesByName("mitmproxy").Any();
+		public static readonly bool RunningFiddler = Process.GetProcessesByName("fiddler").Any();
+		private static string Localhost => "localhost";
+		public static string LocalOrProxyHost => RunningFiddler || RunningMitmProxy ? "ipv4.fiddler" : Localhost;
+		public static TransportConfiguration RerouteToProxyIfNeeded(TransportConfiguration config)
+		{
+			if (!RunningMitmProxy) return config;
+
+			return config.Proxy(new Uri("http://127.0.0.1:8080"), null, (string)null);
+		}
+
+	}
+
+	public class TransportTestServer<TStartup> : ITransportTestServer, IDisposable, IAsyncDisposable, IAsyncLifetime
+		where TStartup : class
+	{
+		private readonly IWebHost _host;
+		private readonly int _port;
+
+
+		public TransportTestServer()
+		{
+			_port = TransportTestServer.PortNumbers.TryDequeue(out var p) ? p : throw new Exception("Failed to locate a portnumber");
+			var url = $"http://{TransportTestServer.LocalOrProxyHost}:{_port}";
+			Uri = new Uri(url);
+
+			var configuration =
+				new ConfigurationBuilder()
+					.AddInMemoryCollection(new Dictionary<string, string> { ["urls"] = url })
+					.Build();
+
+			_host =
+				new WebHostBuilder()
+					.UseKestrel()
+					.UseConfiguration(configuration)
+					.UseStartup<TStartup>()
+					.Build();
+
+			DefaultTransport = CreateTransport(c => new Transport(c));
+		}
+		public Uri Uri { get; }
+
+		public Transport DefaultTransport { get; }
+
+		public Transport CreateTransport(Func<TransportConfiguration, Transport> create) =>
+			create(TransportTestServer.RerouteToProxyIfNeeded(new TransportConfiguration(Uri)));
+
+		public async Task<TransportTestServer<TStartup>> StartAsync(CancellationToken token = default)
+		{
+			await _host.StartAsync(token);
+			return this;
+		}
+
+		public void Dispose()
+		{
+			_host?.Dispose();
+			TransportTestServer.PortNumbers.Enqueue(_port);
+		}
+
+		public Task InitializeAsync() => StartAsync();
+
+		Task IAsyncLifetime.DisposeAsync() => DisposeAsync().AsTask();
+
+
+		public ValueTask DisposeAsync()
+		{
+			Dispose();
+			return ValueTask.CompletedTask;
+		}
+
+
+	}
+}

--- a/tests/Elastic.Transport.IntegrationTests/Plumbing/TransportTestServer.cs
+++ b/tests/Elastic.Transport.IntegrationTests/Plumbing/TransportTestServer.cs
@@ -28,7 +28,7 @@ namespace Elastic.Transport.IntegrationTests.Plumbing
 	{
 		private static readonly bool RunningMitmProxy = Process.GetProcessesByName("mitmproxy").Any();
 		private static readonly bool RunningFiddler = Process.GetProcessesByName("fiddler").Any();
-		private static string Localhost => "localhost";
+		private static string Localhost => "127.0.0.1";
 		public static string LocalOrProxyHost => RunningFiddler || RunningMitmProxy ? "ipv4.fiddler" : Localhost;
 		public static TransportConfiguration RerouteToProxyIfNeeded(TransportConfiguration config)
 		{

--- a/tests/Elastic.Transport.IntegrationTests/Plumbing/WebHostExtensions.cs
+++ b/tests/Elastic.Transport.IntegrationTests/Plumbing/WebHostExtensions.cs
@@ -1,0 +1,27 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+
+namespace Elastic.Transport.IntegrationTests.Plumbing
+{
+	internal static class WebHostExtensions
+	{
+		internal static int GetServerPort(this IWebHost server)
+		{
+			var address = server.ServerFeatures.Get<IServerAddressesFeature>().Addresses.First();
+			var match = Regex.Match(address, @"^.+:(\d+)$");
+
+			if (!match.Success) throw new Exception($"Unable to parse port from address: {address}");
+
+			var port = int.TryParse(match.Groups[1].Value, out var p);
+			return port ? p : throw new Exception($"Unable to parse port to integer from address: {address}");
+		}
+
+	}
+}


### PR DESCRIPTION
- Add Elastic.Transport.IntegrationTests

Spins up kestrel either for the whole lifetime of the tests run or for the lifetime of the testclass.

- Implement SerializeToStream on HttpContent

This is a new override that needs to be implemented now that we target net5 explicitly. 

Uses new `$([MSBuild]::IsTargetFrameworkCompatible` check to validate introduce a `NET5_COMPATIBLE` constant. 
