### PR TITLE
Port fix for client exception message to avoid double period on .NET Framework

### DIFF
--- a/src/Elastic.Transport/Components/Pipeline/RequestPipeline.cs
+++ b/src/Elastic.Transport/Components/Pipeline/RequestPipeline.cs
@@ -260,7 +260,7 @@ namespace Elastic.Transport
 				}
 			}
 
-			exceptionMessage += $". Call: {resource}";
+			exceptionMessage += !exceptionMessage.EndsWith(".", StringComparison.Ordinal) ? $". Call: {resource}" : $" Call: {resource}";
 			if (response != null && _productRegistration.TryGetServerErrorReason(response, out var reason))
 				exceptionMessage += $". ServerError: {reason}";
 


### PR DESCRIPTION
Ported from https://github.com/elastic/elasticsearch-net/pull/5572