### PR TITLE
[PERF] Reduce heap allocations in common paths

### DIFF
--- a/Elastic.Transport.Profiling/Elastic.Transport.Profiling.csproj
+++ b/Elastic.Transport.Profiling/Elastic.Transport.Profiling.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net5.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="JetBrains.Profiler.Api" Version="1.1.8" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\src\Elastic.Transport\Elastic.Transport.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Elastic.Transport.Profiling/Program.cs
+++ b/Elastic.Transport.Profiling/Program.cs
@@ -1,0 +1,44 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.Threading.Tasks;
+using Elastic.Transport.Products.Elasticsearch;
+using JetBrains.Profiler.Api;
+
+namespace Elastic.Transport.Profiling
+{
+	internal class Program
+	{
+		private static async Task Main()
+		{
+			MemoryProfiler.CollectAllocations(true);
+
+			//MeasureProfiler.StartCollectingData();
+			MemoryProfiler.GetSnapshot("start");
+
+			var config = new TransportConfiguration(new Uri("http://localhost:9200"), new ElasticsearchProductRegistration());
+			var transport = new Transport(config);
+
+			_ = await transport.GetAsync<VoidResponse>("/");
+
+			MemoryProfiler.GetSnapshot("before-many-requests");
+
+			for (var i = 0; i < 1_000; i++) _ = await transport.GetAsync<VoidResponse>("/");
+
+			MemoryProfiler.GetSnapshot("after-many-requests");
+			//MeasureProfiler.StopCollectingData();
+
+			await Task.Delay(1000);
+
+			MemoryProfiler.ForceGc();
+			MemoryProfiler.GetSnapshot("before-final-request");
+			_ = await transport.GetAsync<VoidResponse>("/");
+			MemoryProfiler.GetSnapshot("after-final-request");
+
+			MemoryProfiler.ForceGc();
+			MemoryProfiler.GetSnapshot("end");
+		}
+	}
+}

--- a/build/scripts/CommandLine.fs
+++ b/build/scripts/CommandLine.fs
@@ -1,3 +1,7 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
 module CommandLine
 
 open Argu

--- a/build/scripts/Paths.fs
+++ b/build/scripts/Paths.fs
@@ -1,3 +1,7 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
 module Paths
 
 open System

--- a/build/scripts/Program.fs
+++ b/build/scripts/Program.fs
@@ -1,4 +1,4 @@
-﻿// Licensed to Elasticsearch B.V under one or more agreements.
+// Licensed to Elasticsearch B.V under one or more agreements.
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 

--- a/build/scripts/Program.fs
+++ b/build/scripts/Program.fs
@@ -1,4 +1,8 @@
-﻿module Program
+﻿// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+module Program
 
 open Argu
 open Bullseye

--- a/build/scripts/Targets.fs
+++ b/build/scripts/Targets.fs
@@ -1,3 +1,7 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
 module Targets
 
 open Argu

--- a/elastic-transport-net.sln
+++ b/elastic-transport-net.sln
@@ -36,7 +36,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "benchmarks", "benchmarks", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Elastic.Transport.Benchmarks", "benchmarks\Elastic.Transport.Benchmarks\Elastic.Transport.Benchmarks.csproj", "{DABC7F0B-6174-4B2D-8F17-5E36C1CE43EF}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elastic.Transport.IntegrationTests", "tests\Elastic.Transport.IntegrationTests\Elastic.Transport.IntegrationTests.csproj", "{3B27DE76-1188-4078-8828-67AFD39BAC10}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Elastic.Transport.IntegrationTests", "tests\Elastic.Transport.IntegrationTests\Elastic.Transport.IntegrationTests.csproj", "{3B27DE76-1188-4078-8828-67AFD39BAC10}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Elastic.Transport.Profiling", "Elastic.Transport.Profiling\Elastic.Transport.Profiling.csproj", "{A80AF98C-743F-4877-BACF-2BB9E881E57C}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -68,6 +70,10 @@ Global
 		{3B27DE76-1188-4078-8828-67AFD39BAC10}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{3B27DE76-1188-4078-8828-67AFD39BAC10}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{3B27DE76-1188-4078-8828-67AFD39BAC10}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A80AF98C-743F-4877-BACF-2BB9E881E57C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A80AF98C-743F-4877-BACF-2BB9E881E57C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A80AF98C-743F-4877-BACF-2BB9E881E57C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A80AF98C-743F-4877-BACF-2BB9E881E57C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -79,6 +85,7 @@ Global
 		{79EAF3D6-87AE-49F0-8928-07EBA2876A75} = {3582B07D-C2B0-49CC-B676-EAF806EB010E}
 		{DABC7F0B-6174-4B2D-8F17-5E36C1CE43EF} = {BBB0AC81-F09D-4895-84E2-7E933D608E78}
 		{3B27DE76-1188-4078-8828-67AFD39BAC10} = {3582B07D-C2B0-49CC-B676-EAF806EB010E}
+		{A80AF98C-743F-4877-BACF-2BB9E881E57C} = {BBB0AC81-F09D-4895-84E2-7E933D608E78}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7F60C4BB-6216-4E50-B1E4-9C38EB484843}

--- a/src/Elastic.Transport/Components/Pipeline/IRequestPipeline.cs
+++ b/src/Elastic.Transport/Components/Pipeline/IRequestPipeline.cs
@@ -20,8 +20,9 @@ namespace Elastic.Transport
 		/// </summary>
 		List<Audit> AuditTrail { get; }
 
-		/// <summary> Should the workflow attempt the initial sniff as requested by
-		/// <see cref="ITransportConfiguration.SniffsOnStartup"/>
+		/// <summary>
+		/// Should the workflow attempt the initial sniff as requested by
+		/// <see cref="ITransportConfiguration.SniffsOnStartup" />
 		/// </summary>
 		bool FirstPoolUsageNeedsSniffing { get; }
 
@@ -50,6 +51,16 @@ namespace Elastic.Transport
 		void MarkAlive(Node node);
 
 		void MarkDead(Node node);
+
+		/// <summary>
+		/// Attempt to get a single node when the underlying connection pool contains only one node.
+		/// <para>
+		/// This provides an optimised path for single node pools by avoiding an Enumerator on each call.
+		/// </para>
+		/// </summary>
+		/// <param name="node"></param>
+		/// <returns><c>true</c> when a single node exists which has been set on the <paramref name="node" />.</returns>
+		bool TryGetSingleNode(out Node node);
 
 		IEnumerable<Node> NextNode();
 

--- a/src/Elastic.Transport/Components/Pipeline/RequestData.cs
+++ b/src/Elastic.Transport/Components/Pipeline/RequestData.cs
@@ -13,9 +13,11 @@ using Elastic.Transport.Extensions;
 namespace Elastic.Transport
 {
 	/// <summary>
-	/// Where and how <see cref="IConnection.Request{TResponse}"/> should connect to.
-	/// <para>Represents the cumulative configuration from <see cref="ITransportConfiguration"/>
-	/// and <see cref="IRequestConfiguration"/>.</para>
+	/// Where and how <see cref="IConnection.Request{TResponse}" /> should connect to.
+	/// <para>
+	/// Represents the cumulative configuration from <see cref="ITransportConfiguration" />
+	/// and <see cref="IRequestConfiguration" />.
+	/// </para>
 	/// </summary>
 	public class RequestData
 	{
@@ -25,6 +27,8 @@ namespace Elastic.Transport
 		public const string MimeTypeTextPlain = "text/plain";
 		public const string OpaqueIdHeader = "X-Opaque-Id";
 		public const string RunAsSecurityHeader = "es-security-runas-user";
+
+		private Uri _requestUri;
 
 		public RequestData(
 			HttpMethod method, string path,
@@ -134,7 +138,9 @@ namespace Elastic.Transport
 		public PostData PostData { get; }
 		public string ProxyAddress { get; }
 		public SecureString ProxyPassword { get; }
+
 		public string ProxyUsername { get; }
+
 		// TODO: rename to ContentType in 8.0.0
 		public string RequestMimeType { get; }
 		public TimeSpan RequestTimeout { get; }
@@ -146,7 +152,20 @@ namespace Elastic.Transport
 		public bool TcpStats { get; }
 		public bool ThreadPoolStats { get; }
 
-		public Uri Uri => Node != null ? new Uri(Node.Uri, PathAndQuery) : null;
+		/// <summary>
+		/// The <see cref="Uri" /> for the request.
+		/// </summary>
+		public Uri Uri
+		{
+			get
+			{
+				if (_requestUri is not null) return _requestUri;
+
+				_requestUri = Node is not null ? new Uri(Node.Uri, PathAndQuery) : null;
+				return _requestUri;
+			}
+		}
+
 		public TimeSpan DnsRefreshTimeout { get; }
 
 		public override string ToString() => $"{Method.GetStringValue()} {_path}";

--- a/src/Elastic.Transport/Components/Pipeline/RequestPipeline.cs
+++ b/src/Elastic.Transport/Components/Pipeline/RequestPipeline.cs
@@ -381,10 +381,10 @@ namespace Elastic.Transport
 			{
 				if (DepletedRetries) yield break;
 
-				foreach (var node in _connectionPool
-					.CreateView(LazyAuditable)
-					.TakeWhile(node => !DepletedRetries))
+				foreach (var node in _connectionPool.CreateView(LazyAuditable))
 				{
+					if (DepletedRetries) break;
+
 					if (!_nodePredicate(node)) continue;
 
 					yield return node;


### PR DESCRIPTION
Overall saving of up to 512 bytes, per request under certain configurations.

Adds `TryGetSingleNode` method on `IRequestPipeline` which allows consumers to avoid the Enumerator allocation per request when there is only a single node in the `IConnectionPool`. This reduces 56 bytes per request in such situations. This will be the case for example with an Elastic Cloud connection pool. I was a little unsure about adding this to the interface and we could consider dropping that, and in our code, check if the implementation is `RequestPipeline` and then optimising from there. Or this could be reviewed and perhaps we introduce an abstract class with the common behaviour that can be overridden.

Removes `TakeWhile` from the `NextNode` and implements the check manually, removing 72 bytes per request from LINQ usage.

Lazily caches the Uri on `RequestData` since this property is accessed at least three times and each time was allocating a new Uri. This saves 192 bytes per request.

Lazily create the `RequestConfiguration` used for ping and sniff requests rather than allocate this up front on each `RequestPipeline` instance. In cases where pinging and sniffing are disabled or not used (single node pools) this avoids 192 bytes per request.

Includes some Resharper automated code cleanup which has unfortunately moved a fair bit around.