### PR TITLE
Add support for response header parsing

### DIFF
--- a/src/Elastic.Transport/Components/Pipeline/RequestData.cs
+++ b/src/Elastic.Transport/Components/Pipeline/RequestData.cs
@@ -106,35 +106,41 @@ namespace Elastic.Transport
 			TransferEncodingChunked = local?.TransferEncodingChunked ?? global.TransferEncodingChunked;
 			TcpStats = local?.EnableTcpStats ?? global.EnableTcpStats;
 			ThreadPoolStats = local?.EnableThreadPoolStats ?? global.EnableThreadPoolStats;
+			ParseAllHeaders = local?.ParseAllHeaders ?? global.ParseAllHeaders ?? false;
+
+			if (local is not null)
+			{
+				ResponseHeadersToParse = local.ResponseHeadersToParse;
+				ResponseHeadersToParse.UnionWith(global.ResponseHeadersToParse);
+			}
+			else
+			{
+				ResponseHeadersToParse = global.ResponseHeadersToParse;
+			}
 		}
 
 		private readonly string _path;
 
 		public string Accept { get; }
 		public IReadOnlyCollection<int> AllowedStatusCodes { get; }
-
 		public IAuthenticationHeader AuthenticationHeader { get; }
-
 		public X509CertificateCollection ClientCertificates { get; }
 		public ITransportConfiguration ConnectionSettings { get; }
 		public CustomResponseBuilderBase CustomResponseBuilder { get; }
 		public bool DisableAutomaticProxyDetection { get; }
-
+		public HeadersList ResponseHeadersToParse { get; }
+		public bool ParseAllHeaders { get; }
 		public NameValueCollection Headers { get; }
 		public bool HttpCompression { get; }
 		public int KeepAliveInterval { get; }
 		public int KeepAliveTime { get; }
 		public bool MadeItToResponse { get; set; }
 		public IMemoryStreamFactory MemoryStreamFactory { get; }
-
 		public HttpMethod Method { get; }
 
-		public Node Node 
+		public Node Node
 		{
-			get
-			{
-				return _node; 
-			}
+			get => _node;
 			set
 			{
 				// We want the Uri to regenerate when the node changes
@@ -147,14 +153,11 @@ namespace Elastic.Transport
 		public PipelineFailure OnFailurePipelineFailure => MadeItToResponse ? PipelineFailure.BadResponse : PipelineFailure.BadRequest;
 		public string PathAndQuery { get; }
 		public TimeSpan PingTimeout { get; }
-
 		public bool Pipelined { get; }
 		public PostData PostData { get; }
 		public string ProxyAddress { get; }
 		public SecureString ProxyPassword { get; }
-
 		public string ProxyUsername { get; }
-
 		// TODO: rename to ContentType in 8.0.0
 		public string RequestMimeType { get; }
 		public TimeSpan RequestTimeout { get; }

--- a/src/Elastic.Transport/Configuration/HeadersList.cs
+++ b/src/Elastic.Transport/Configuration/HeadersList.cs
@@ -1,0 +1,94 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Elastic.Transport
+{
+	/// <summary>
+	/// Represents a unique, case-insensitive collection of header names.
+	/// </summary>
+	public struct HeadersList : IEnumerable<string>
+	{
+		private List<string> _headers;
+
+		/// <summary>
+		/// Create a new <see cref="HeadersList"/> from an existing enumerable of header names.
+		/// Duplicate names, including those which only differ by case, will be ignored.
+		/// </summary>
+		/// <param name="headers">The header names to initialise the <see cref="HeadersList"/> with.</param>
+		public HeadersList(IEnumerable<string> headers)
+		{
+			_headers = new List<string>();
+
+			foreach (var header in headers)
+				TryAdd(header);
+		}
+
+		/// <summary>
+		/// Create a new <see cref="HeadersList"/> initialised with a single header name.
+		/// </summary>
+		/// <param name="header">The header name to initialise the <see cref="HeadersList"/> with.</param>
+		public HeadersList(string header) => _headers = new List<string> { header };
+
+		/// <summary>
+		/// Gets the number of elements contained in the <see cref="HeadersList"/>.
+		/// </summary>
+		public int Count => _headers is null ? 0 : _headers.Count;
+
+		/// <summary>
+		/// Attempt to add a header to the <see cref="HeadersList"/>.
+		/// Duplicate names, including those which only differ by case, will be ignored.
+		/// </summary>
+		/// <param name="header">The header name to add to the <see cref="HeadersList"/>.</param>
+		/// <returns></returns>
+		public bool TryAdd(string header)
+		{
+			if (_headers is null)
+			{
+				_headers = new List<string>()
+				{
+					header
+				};
+				return true;
+			}
+
+			if (!_headers.Contains(header, StringComparer.OrdinalIgnoreCase))
+			{
+				_headers.Add(header);
+				return true;
+			}
+
+			return false;
+		}
+
+		/// <summary>
+		/// Attempt to remove a header from the list if it is present.
+		/// </summary>
+		/// <param name="header">The header name to remove from the <see cref="HeadersList"/>.</param>
+		public void Remove(string header)
+		{
+			if (_headers is null) return;
+			_headers.RemoveAll(s => s.Equals(header, StringComparison.OrdinalIgnoreCase));
+		}
+
+		/// <summary>
+		/// Modifies the current <see cref="HeadersList"/> to contain all elements that are present in itself, the specified collection, or both.
+		/// </summary>
+		/// <param name="other">The collection to compare to the current <see cref="HeadersList"/> object.</param>
+		public void UnionWith(IEnumerable<string> other)
+		{
+			foreach (var header in other)
+				TryAdd(header);
+		}
+
+		/// <inheritdoc />
+		public IEnumerator<string> GetEnumerator() => _headers?.GetEnumerator() ?? (IEnumerator<string>)Array.Empty<string>().GetEnumerator();
+
+		IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+	}
+}

--- a/src/Elastic.Transport/Configuration/ITransportConfiguration.cs
+++ b/src/Elastic.Transport/Configuration/ITransportConfiguration.cs
@@ -152,6 +152,11 @@ namespace Elastic.Transport
 		Action<RequestData> OnRequestDataCreated { get; }
 
 		/// <summary>
+		/// When enabled, all headers from the HTTP response will be included in the <see cref="IApiCallDetails"/>.
+		/// </summary>
+		bool? ParseAllHeaders { get; }
+
+		/// <summary>
 		/// The timeout in milliseconds to use for ping requests, which are issued to determine whether a node is alive
 		/// </summary>
 		TimeSpan? PingTimeout { get; }
@@ -183,6 +188,12 @@ namespace Elastic.Transport
 		/// The timeout in milliseconds for each request to Elasticsearch
 		/// </summary>
 		TimeSpan RequestTimeout { get; }
+
+		/// <summary>
+		/// A <see cref="HeadersList"/> containing the names of all HTTP response headers to attempt to parse and
+		/// included on the <see cref="IApiCallDetails"/>.
+		/// </summary>
+		HeadersList ResponseHeadersToParse { get; }
 
 		/// <summary>
 		/// Register a ServerCertificateValidationCallback per request

--- a/src/Elastic.Transport/Configuration/RequestConfiguration.cs
+++ b/src/Elastic.Transport/Configuration/RequestConfiguration.cs
@@ -79,6 +79,9 @@ namespace Elastic.Transport
 		/// </summary>
 		string OpaqueId { get; set; }
 
+		/// <inheritdoc cref="ITransportConfiguration.ParseAllHeaders"/>
+		bool? ParseAllHeaders { get; set; }
+
 		/// <summary>
 		/// The ping timeout for this specific request
 		/// </summary>
@@ -88,6 +91,9 @@ namespace Elastic.Transport
 		/// The timeout for this specific request, takes precedence over the global timeout settings
 		/// </summary>
 		TimeSpan? RequestTimeout { get; set; }
+
+		/// <inheritdoc cref="ITransportConfiguration.ResponseHeadersToParse"/>
+		HeadersList ResponseHeadersToParse { get; set; }
 
 		/// <summary>
 		/// Submit the request on behalf in the context of a different shield user
@@ -162,6 +168,10 @@ namespace Elastic.Transport
 		public bool? EnableTcpStats { get; set; }
 		/// <inheritdoc />
 		public bool? EnableThreadPoolStats { get; set; }
+		/// <inheritdoc />
+		public HeadersList ResponseHeadersToParse { get; set; }
+		/// <inheritdoc />
+		public bool? ParseAllHeaders { get; set; }
 	}
 
 	/// <inheritdoc cref="IRequestConfiguration"/>
@@ -190,6 +200,10 @@ namespace Elastic.Transport
 			Self.Headers = config?.Headers;
 			Self.EnableTcpStats = config?.EnableTcpStats;
 			Self.EnableThreadPoolStats = config?.EnableThreadPoolStats;
+			Self.ParseAllHeaders = config?.ParseAllHeaders;
+
+			if (config?.ResponseHeadersToParse is not null)
+				Self.ResponseHeadersToParse = config.ResponseHeadersToParse;
 		}
 
 		string IRequestConfiguration.Accept { get; set; }
@@ -213,6 +227,8 @@ namespace Elastic.Transport
 		NameValueCollection IRequestConfiguration.Headers { get; set; }
 		bool? IRequestConfiguration.EnableTcpStats { get; set; }
 		bool? IRequestConfiguration.EnableThreadPoolStats { get; set; }
+		HeadersList IRequestConfiguration.ResponseHeadersToParse { get; set; }
+		bool? IRequestConfiguration.ParseAllHeaders { get; set; }
 
 		/// <inheritdoc cref="IRequestConfiguration.RunAs"/>
 		public RequestConfigurationDescriptor RunAs(string username)
@@ -366,6 +382,20 @@ namespace Elastic.Transport
 		public RequestConfigurationDescriptor EnableThreadPoolStats(bool? enableThreadPoolStats = true)
 		{
 			Self.EnableThreadPoolStats = enableThreadPoolStats;
+			return this;
+		}
+
+		/// <inheritdoc cref="IRequestConfiguration.ParseAllHeaders"/>
+		public RequestConfigurationDescriptor ParseAllHeaders(bool? enable = true)
+		{
+			Self.ParseAllHeaders = enable;
+			return this;
+		}
+
+		/// <inheritdoc cref="IRequestConfiguration.ResponseHeadersToParse"/>
+		public RequestConfigurationDescriptor ResponseHeadersToParse(IEnumerable<string> headers)
+		{
+			Self.ResponseHeadersToParse = new HeadersList(headers);
 			return this;
 		}
 	}

--- a/src/Elastic.Transport/Configuration/TransportConfiguration.cs
+++ b/src/Elastic.Transport/Configuration/TransportConfiguration.cs
@@ -32,7 +32,7 @@ namespace Elastic.Transport
 		/// As the old curl based handler is known to bleed TCP connections:
 		/// <para>https://github.com/dotnet/runtime/issues/22366</para>
 		/// </summary>
-        private static bool UsingCurlHandler
+		private static bool UsingCurlHandler
 		{
 			get
 			{
@@ -191,7 +191,8 @@ namespace Elastic.Transport
 		private bool _enableThreadPoolStats;
 		private UserAgent _userAgent;
 
-		private Func<HttpMethod, int, bool> _statusCodeToResponseSuccess;
+
+		private readonly Func<HttpMethod, int, bool> _statusCodeToResponseSuccess;
 
 		/// <summary>
 		/// <inheritdoc cref="TransportConfiguration"/>
@@ -226,6 +227,7 @@ namespace Elastic.Transport
 				_enableHttpCompression = true;
 			}
 
+			_headersToParse = _productRegistration.ResponseHeadersToParse;
 		}
 
 		/// <summary>
@@ -427,6 +429,22 @@ namespace Elastic.Transport
 		// ReSharper disable once VirtualMemberNeverOverridden.Global
 		// ReSharper disable once MemberCanBeProtected.Global
 		public virtual T PrettyJson(bool b = true) => Assign(b, (a, v) => a._prettyJson = v);
+
+		private bool? _parseAllHeaders;
+		bool? ITransportConfiguration.ParseAllHeaders => _parseAllHeaders;
+
+		/// <inheritdoc cref="ITransportConfiguration.ParseAllHeaders"/>
+		public virtual T ParseAllHeaders(bool b = true) => Assign(b, (a, v) => a._parseAllHeaders = v);
+
+		private HeadersList _headersToParse;
+		HeadersList ITransportConfiguration.ResponseHeadersToParse => _headersToParse;
+
+		/// <inheritdoc cref="ITransportConfiguration.ResponseHeadersToParse"/>
+		public virtual T ResponseHeadersToParse(HeadersList headersToParse)
+		{
+			_headersToParse.UnionWith(headersToParse);
+			return (T)this;
+		}
 
 		/// <inheritdoc cref="ITransportConfiguration.ServerCertificateValidationCallback"/>
 		public T ServerCertificateValidationCallback(Func<object, X509Certificate, X509Chain, SslPolicyErrors, bool> callback) =>

--- a/src/Elastic.Transport/Products/DefaultProductRegistration.cs
+++ b/src/Elastic.Transport/Products/DefaultProductRegistration.cs
@@ -4,11 +4,13 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace Elastic.Transport.Products
 {
+
 	/// <summary>
 	/// A default non-descriptive product registration that does not support sniffing and pinging.
 	/// Can be used to connect to unknown services before they develop their own <see cref="IProductRegistration"/>
@@ -16,6 +18,8 @@ namespace Elastic.Transport.Products
 	/// </summary>
 	public class ProductRegistration : IProductRegistration
 	{
+		private readonly HeadersList _headers = new();
+
 		/// <summary> A static instance of <see cref="ProductRegistration"/> to promote reuse </summary>
 		public static ProductRegistration Default { get; } = new ProductRegistration();
 
@@ -33,6 +37,9 @@ namespace Elastic.Transport.Products
 
 		/// <inheritdoc cref="IProductRegistration.NodePredicate"/>
 		public bool NodePredicate(Node node) => true;
+
+		/// <inheritdoc cref="IProductRegistration.ResponseHeadersToParse"/>
+		public HeadersList ResponseHeadersToParse => _headers;
 
 		/// <inheritdoc cref="IProductRegistration.HttpStatusCodeClassifier"/>
 		public bool HttpStatusCodeClassifier(HttpMethod method, int statusCode) =>

--- a/src/Elastic.Transport/Products/Elasticsearch/ElasticsearchProductRegistration.cs
+++ b/src/Elastic.Transport/Products/Elasticsearch/ElasticsearchProductRegistration.cs
@@ -19,6 +19,17 @@ namespace Elastic.Transport.Products.Elasticsearch
 	/// </summary>
 	public class ElasticsearchProductRegistration : IProductRegistration
 	{
+		private readonly HeadersList _headers;
+
+		/// <summary>
+		/// Create a new instance of the Elasticsearch product registration.
+		/// </summary>
+		public ElasticsearchProductRegistration()
+		{
+			_headers = new HeadersList();
+			_headers.TryAdd("warning");
+		}
+
 		/// <summary> A static instance of <see cref="ElasticsearchProductRegistration"/> to promote reuse </summary>
 		public static IProductRegistration Default { get; } = new ElasticsearchProductRegistration();
 
@@ -30,6 +41,9 @@ namespace Elastic.Transport.Products.Elasticsearch
 
 		/// <inheritdoc cref="IProductRegistration.SupportsSniff"/>
 		public bool SupportsSniff { get; } = true;
+
+		/// <inheritdoc cref="IProductRegistration.ResponseHeadersToParse"/>
+		public HeadersList ResponseHeadersToParse => _headers;
 
 		/// <summary> Exposes the path used for sniffing in Elasticsearch </summary>
 		public const string SniffPath = "_nodes/http,settings";

--- a/src/Elastic.Transport/Products/IProductRegistration.cs
+++ b/src/Elastic.Transport/Products/IProductRegistration.cs
@@ -41,6 +41,11 @@ namespace Elastic.Transport.Products
 		bool SupportsSniff { get; }
 
 		/// <summary>
+		/// The set of headers to parse from all requests by default. These can be added to any consumer specific requirements.
+		/// </summary>
+		HeadersList ResponseHeadersToParse { get; }
+
+		/// <summary>
 		/// Create an instance of <see cref="RequestData"/> that describes where and how to ping see <paramref name="node" />
 		/// <para>All the parameters of this method correspond with <see cref="RequestData"/>'s constructor</para>
 		/// </summary>

--- a/src/Elastic.Transport/Responses/HttpDetails/ApiCallDetails.cs
+++ b/src/Elastic.Transport/Responses/HttpDetails/ApiCallDetails.cs
@@ -44,9 +44,6 @@ namespace Elastic.Transport
 			}
 		}
 
-		/// <inheritdoc cref="IApiCallDetails.DeprecationWarnings"/>
-		public IEnumerable<string> DeprecationWarnings { get; set; }
-
 		/// <inheritdoc cref="IApiCallDetails.HttpMethod"/>
 		public HttpMethod HttpMethod { get; set; }
 

--- a/src/Elastic.Transport/Responses/HttpDetails/ApiCallDetails.cs
+++ b/src/Elastic.Transport/Responses/HttpDetails/ApiCallDetails.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Collections.Specialized;
 using System.Net.NetworkInformation;
 using System.Text;
 using Elastic.Transport.Diagnostics;
@@ -80,6 +81,9 @@ namespace Elastic.Transport
 
 		/// <inheritdoc cref="IApiCallDetails.DebugInformation"/>
 		public ITransportConfiguration ConnectionConfiguration { get; set; }
+
+		/// <inheritdoc cref="IApiCallDetails.ParsedHeaders"/>
+		public ReadOnlyDictionary<string, IEnumerable<string>> ParsedHeaders { get; set; }
 
 		/// <inheritdoc cref="IApiCallDetails.DebugInformation"/>
 		public override string ToString() =>

--- a/src/Elastic.Transport/Responses/HttpDetails/IApiCallDetails.cs
+++ b/src/Elastic.Transport/Responses/HttpDetails/IApiCallDetails.cs
@@ -5,7 +5,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Collections.Specialized;
 using System.Diagnostics;
 using System.Net.NetworkInformation;
 using Elastic.Transport.Diagnostics;
@@ -43,12 +42,6 @@ namespace Elastic.Transport
 		/// Reference to the connection configuration that yielded this response.
 		/// </summary>
 		ITransportConfiguration ConnectionConfiguration { get; }
-
-		/// <summary>
-		/// A collection of deprecation warnings returned from the product being interfaced with.
-		/// <para>Used to signal that the request uses an API feature that is marked as deprecated.</para>
-		/// </summary>
-		IEnumerable<string> DeprecationWarnings { get; }
 
 		/// <summary>
 		/// The HTTP method used by the request.

--- a/src/Elastic.Transport/Responses/HttpDetails/IApiCallDetails.cs
+++ b/src/Elastic.Transport/Responses/HttpDetails/IApiCallDetails.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Collections.Specialized;
 using System.Diagnostics;
 using System.Net.NetworkInformation;
 using Elastic.Transport.Diagnostics;
@@ -63,11 +64,18 @@ namespace Elastic.Transport
 		/// </summary>
 		Exception OriginalException { get; }
 
-        /// <summary>
-        /// The request body bytes.
-        /// <para>NOTE: Only set when disable direct streaming is set for the request.</para>
-        /// </summary>
-        [DebuggerDisplay("{RequestBodyInBytes != null ? System.Text.Encoding.UTF8.GetString(RequestBodyInBytes) : null,nq}")]
+		/// <summary>
+		/// A dictionary of the headers parsed from the HTTP response.
+		/// When no headers have been configured for parsing, or no matching headers were found,
+		/// this will be null.
+		/// </summary>
+		ReadOnlyDictionary<string, IEnumerable<string>> ParsedHeaders { get; }
+
+		/// <summary>
+		/// The request body bytes.
+		/// <para>NOTE: Only set when disable direct streaming is set for the request.</para>
+		/// </summary>
+		[DebuggerDisplay("{RequestBodyInBytes != null ? System.Text.Encoding.UTF8.GetString(RequestBodyInBytes) : null,nq}")]
 		byte[] RequestBodyInBytes { get; }
 
         /// <summary>

--- a/src/Elastic.Transport/Responses/ResponseStatics.cs
+++ b/src/Elastic.Transport/Responses/ResponseStatics.cs
@@ -27,12 +27,6 @@ namespace Elastic.Transport
 		/// <inheritdoc cref="ResponseStatics"/>
 		public static string DebugInformationBuilder(IApiCallDetails r, StringBuilder sb)
 		{
-			if (r.DeprecationWarnings.HasAny(out var warnings))
-			{
-				sb.AppendLine($"# Server indicated deprecations:");
-				foreach (var deprecation in warnings)
-					sb.AppendLine($"- {deprecation}");
-			}
 			sb.AppendLine($"# Audit trail of this API call:");
 			var auditTrail = (r.AuditTrail ?? Enumerable.Empty<Audit>()).ToList();
 			DebugAuditTrail(auditTrail, sb);

--- a/src/Elastic.Transport/Responses/TransportResponseBase.cs
+++ b/src/Elastic.Transport/Responses/TransportResponseBase.cs
@@ -60,11 +60,8 @@ namespace Elastic.Transport
 		{
 			get => ApiCall.ThreadPoolStats;
 			set => ApiCall.ThreadPoolStats = value;
-		}
+		}		
 
-		/// <inheritdoc cref="IApiCallDetails.DeprecationWarnings"/>
-		[JsonIgnore]
-		public IEnumerable<string> DeprecationWarnings => ApiCall.DeprecationWarnings;
 		/// <inheritdoc cref="IApiCallDetails.SuccessOrKnownError"/>
 		[JsonIgnore]
 		public bool SuccessOrKnownError => ApiCall.SuccessOrKnownError;

--- a/src/Elastic.Transport/Responses/TransportResponseBase.cs
+++ b/src/Elastic.Transport/Responses/TransportResponseBase.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Collections.Specialized;
 using System.Net.NetworkInformation;
 using System.Text.Json.Serialization;
 using Elastic.Transport.Diagnostics;
@@ -27,11 +28,9 @@ namespace Elastic.Transport
 	/// </summary>
 	public abstract class TransportResponseBase : IApiCallDetails, ITransportResponse
 	{
-
 		/// <inheritdoc />
 		[JsonIgnore]
 		public IApiCallDetails ApiCall { get; set; }
-
 
 		/// <inheritdoc cref="IApiCallDetails.TcpStats"/>
 		[JsonIgnore]
@@ -97,6 +96,10 @@ namespace Elastic.Transport
 		/// <inheritdoc cref="IApiCallDetails.RequestBodyInBytes"/>
 		[JsonIgnore]
 		public byte[] RequestBodyInBytes => ApiCall.RequestBodyInBytes;
+
+		/// <inheritdoc cref="IApiCallDetails.ParsedHeaders"/>
+		[JsonIgnore]
+		public ReadOnlyDictionary<string, IEnumerable<string>> ParsedHeaders => ApiCall.ParsedHeaders;
 
 		/// <inheritdoc cref="IApiCallDetails.DebugInformation"/>
 		public override string ToString() => ApiCall.ToString();

--- a/tests/Elastic.Transport.Tests/Configuration/HeadersListTests.cs
+++ b/tests/Elastic.Transport.Tests/Configuration/HeadersListTests.cs
@@ -1,0 +1,78 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Linq;
+using FluentAssertions;
+using Xunit;
+
+namespace Elastic.Transport.Tests.Configuration
+{
+	public class HeadersListTests
+	{
+		[Fact]
+		public void TryAdd_SkipsDuplicates()
+		{
+			var sut = new HeadersList(new[] { "header-one", "header-two" });
+
+			sut.TryAdd("header-one");
+			sut.TryAdd("header-TWO");
+
+			sut.Count.Should().Be(2);
+			sut.First().Should().Be("header-one");
+			sut.Last().Should().Be("header-two");
+		}
+
+		[Fact]
+		public void TryAdd_RemovesExpectedHeader()
+		{
+			var sut = new HeadersList(new[] { "header-one", "header-two" });
+
+			sut.Remove("header-one");
+
+			sut.Count.Should().Be(1);
+			sut.Single().Should().Be("header-two");
+		}
+
+		[Fact]
+		public void TryAdd_RemovesAreCaseInsensitive()
+		{
+			var sut = new HeadersList(new[] { "header-one", "header-two" });
+
+			sut.Remove("header-ONE");
+
+			sut.Count.Should().Be(1);
+			sut.Single().Should().Be("header-two");
+		}
+
+		[Fact]
+		public void TryAdd_UnionWithSkipsDuplicates()
+		{
+			var headers = new HeadersList(new[] { "header-ONE", "header-THREE" });
+
+			var sut = new HeadersList(new[] { "header-one", "header-two" });
+			sut.UnionWith(headers);
+
+			sut.Count.Should().Be(3);
+
+			var count = 0;
+			foreach (var header in sut)
+			{
+				count++;
+
+				switch (count)
+				{
+					case 1:
+						header.Should().Be("header-one");
+						break;
+					case 2:
+						header.Should().Be("header-two");
+						break;
+					case 3:
+						header.Should().Be("header-THREE");
+						break;
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
- Add configuration for transport and requests that accepts a collection of header names to be parsed from the response.
- Add configuration for production registration so that products may define headers that are parsed from every request.
- Update `IApiCallDetails` to expose parsed headers
- Connections now parse any configured headers from the response
- Removes `DeprecationWarnings` on the `IApiCallDetails` as those may be product-specific and can be implemented within the client by accessing the `ParsedHeaders`.

This PR is a prerequisite for supporting product checking in the v8 clients.