### PR TITLE
Support configuring a certificate fingerprint

### DIFF
--- a/src/Elastic.Transport/Components/Connection/HttpWebRequestConnection.cs
+++ b/src/Elastic.Transport/Components/Connection/HttpWebRequestConnection.cs
@@ -11,6 +11,8 @@ using System.Linq;
 using System.Net;
 using System.Net.NetworkInformation;
 using System.Net.Security;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
 using System.Threading;
 using System.Threading.Tasks;
 using Elastic.Transport.Diagnostics;
@@ -238,6 +240,20 @@ namespace Elastic.Transport
 				request.ClientCertificates.AddRange(requestData.ClientCertificates);
 		}
 
+		private string ComparableFingerprint(string fingerprint)
+		{
+			var finalFingerprint = fingerprint;
+			if (fingerprint.Contains(':'))
+			{
+				finalFingerprint = fingerprint.Replace(":", string.Empty);
+			}
+			else if (fingerprint.Contains('-'))
+			{
+				finalFingerprint = fingerprint.Replace("-", string.Empty);
+			}
+			return finalFingerprint;
+		}
+
 		/// <summary> Hook for subclasses override the certificate validation on <paramref name="request"/> </summary>
 		protected virtual void SetServerCertificateValidationCallBackIfNeeded(HttpWebRequest request, RequestData requestData)
 		{
@@ -246,10 +262,27 @@ namespace Elastic.Transport
 			//Only assign if one is defined on connection settings and a subclass has not already set one
 			if (callback != null && request.ServerCertificateValidationCallback == null)
 				request.ServerCertificateValidationCallback = new RemoteCertificateValidationCallback(callback);
+			else if (!string.IsNullOrEmpty(requestData.ConnectionSettings.CertificateFingerprint))
+			{
+				request.ServerCertificateValidationCallback = new RemoteCertificateValidationCallback((request, cert, chain, policyErrors) =>
+				{
+					using var alg = SHA256.Create();
+					var sha256FingerprintBytes = alg.ComputeHash(cert.GetRawCertData());
+					var sha256Fingerprint = BitConverter.ToString(sha256FingerprintBytes);
+
+					if (sha256Fingerprint.Equals(requestData.ConnectionSettings.CertificateFingerprint, StringComparison.OrdinalIgnoreCase))
+						return true;
+
+					var expectedThumbprint = ComparableFingerprint(requestData.ConnectionSettings.CertificateFingerprint);
+					var actualThumbprint = ComparableFingerprint(sha256Fingerprint);
+
+					return expectedThumbprint.Equals(actualThumbprint, StringComparison.OrdinalIgnoreCase);
+				});
+			}
 #else
-				if (callback != null)
-					throw new Exception("Mono misses ServerCertificateValidationCallback on HttpWebRequest");
-			#endif
+			if (callback != null)
+				throw new Exception("Mono misses ServerCertificateValidationCallback on HttpWebRequest");
+#endif
 		}
 
 		private static HttpWebRequest CreateWebRequest(RequestData requestData)

--- a/src/Elastic.Transport/Configuration/ITransportConfiguration.cs
+++ b/src/Elastic.Transport/Configuration/ITransportConfiguration.cs
@@ -201,6 +201,12 @@ namespace Elastic.Transport
 		Func<object, X509Certificate, X509Chain, SslPolicyErrors, bool> ServerCertificateValidationCallback { get; }
 
 		/// <summary>
+		/// During development, the server certificate fingerprint may be provided. When present, it is used to validate the
+		/// certificate sent by the server. The fingerprint is expected to be the hex string representing the SHA256 public key fingerprint.
+		/// </summary>
+		string CertificateFingerprint { get; }
+
+		/// <summary>
 		/// Configure the client to skip deserialization of certain status codes e.g: you run Elasticsearch behind a proxy that returns an unexpected
 		/// json format
 		/// </summary>

--- a/src/Elastic.Transport/Configuration/TransportConfiguration.cs
+++ b/src/Elastic.Transport/Configuration/TransportConfiguration.cs
@@ -190,6 +190,7 @@ namespace Elastic.Transport
 		private bool _enableTcpStats;
 		private bool _enableThreadPoolStats;
 		private UserAgent _userAgent;
+		private string _certificateFingerprint;
 
 
 		private readonly Func<HttpMethod, int, bool> _statusCodeToResponseSuccess;
@@ -270,6 +271,7 @@ namespace Elastic.Transport
 		ITransportSerializer ITransportConfiguration.RequestResponseSerializer => UseThisRequestResponseSerializer;
 		TimeSpan ITransportConfiguration.RequestTimeout => _requestTimeout;
 		TimeSpan ITransportConfiguration.DnsRefreshTimeout => _dnsRefreshTimeout;
+		string ITransportConfiguration.CertificateFingerprint => _certificateFingerprint;
 
 		Func<object, X509Certificate, X509Chain, SslPolicyErrors, bool> ITransportConfiguration.ServerCertificateValidationCallback =>
 			_serverCertificateValidationCallback;
@@ -364,6 +366,9 @@ namespace Elastic.Transport
 
 		/// <inheritdoc cref="ITransportConfiguration.DnsRefreshTimeout"/>
 		public T DnsRefreshTimeout(TimeSpan timeout) => Assign(timeout, (a, v) => a._dnsRefreshTimeout = v);
+
+		/// <inheritdoc cref="ITransportConfiguration.CertificateFingerprint"/>
+		public T CertificateFingerprint(string fingerprint) => Assign(fingerprint, (a, v) => a._certificateFingerprint = v);
 
 		/// <summary>
 		/// If your connection has to go through proxy, use this method to specify the proxy url


### PR DESCRIPTION
This feature will be required during development in v8.0 as the server will be configured with security enabled and a self-signed cert. The fingerprint of that certificate can be used to connect. This is not expected to be used during production.

- Add configuration option to provide a fingerprint
- Update connections to validate the certificate using the fingerprint when present
