### PR TITLE
Emit OpenTelemetry compatible Activity on CallProductEndpoint

### DIFF
--- a/src/Elastic.Transport/Components/Pipeline/DefaultRequestPipeline.cs
+++ b/src/Elastic.Transport/Components/Pipeline/DefaultRequestPipeline.cs
@@ -181,7 +181,6 @@ public class DefaultRequestPipeline<TConfiguration> : RequestPipeline
 			activity?.AddTag("db.system", "elasticsearch");
 			activity?.AddTag("http.method", requestData.Method);
 
-
 			activity?.AddTag("http.url", requestData.Uri.AbsoluteUri);
 			activity?.AddTag("net.peer.name", requestData.Uri.Host);
 			activity?.AddTag("net.peer.port", requestData.Uri.Port);
@@ -219,7 +218,6 @@ public class DefaultRequestPipeline<TConfiguration> : RequestPipeline
 		{
 			activity?.AddTag("db.system", "elasticsearch");
 			activity?.AddTag("http.method", requestData.Method);
-
 
 			activity?.AddTag("http.url", requestData.Uri.AbsoluteUri);
 			activity?.AddTag("net.peer.name", requestData.Uri.Host);

--- a/src/Elastic.Transport/Components/Pipeline/RequestData.cs
+++ b/src/Elastic.Transport/Components/Pipeline/RequestData.cs
@@ -39,7 +39,7 @@ public sealed class RequestData
 	)
 		: this(method, data, global, local?.RequestConfiguration, memoryStreamFactory)
 	{
-		_path = path;
+		Path = path;
 		CustomResponseBuilder = local?.CustomResponseBuilder;
 		PathAndQuery = CreatePathWithQueryStrings(path, ConnectionSettings, local);
 	}
@@ -121,7 +121,7 @@ public sealed class RequestData
 		}
 	}
 
-	private readonly string _path;
+	public string Path { get; }
 
 	public string Accept { get; }
 	public IReadOnlyCollection<int> AllowedStatusCodes { get; }
@@ -193,7 +193,7 @@ public sealed class RequestData
 
 	public bool IsAsync { get; internal set; }
 
-	public override string ToString() => $"{Method.GetStringValue()} {_path}";
+	public override string ToString() => $"{Method.GetStringValue()} {Path}";
 
 	// TODO This feels like its in the wrong place
 	private string CreatePathWithQueryStrings(string path, ITransportConfiguration global, RequestParameters request)

--- a/tests/Elastic.Transport.Tests/ActivityTest.cs
+++ b/tests/Elastic.Transport.Tests/ActivityTest.cs
@@ -1,0 +1,59 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+using Elastic.Transport.Diagnostics.Auditing;
+using Elastic.Transport.VirtualizedCluster;
+using Elastic.Transport.VirtualizedCluster.Audit;
+using Elastic.Transport.VirtualizedCluster.Rules;
+using FluentAssertions;
+using Xunit;
+
+namespace Elastic.Transport.Tests;
+
+/// <summary>
+/// Asserts that <see cref="DefaultRequestPipeline{TConfiguration}"/> emits OpenTelemetry compatible Activities.
+/// </summary>
+public class ActivityTest
+{
+	[Fact]
+	public async Task BasicOpenTelemetryTest()
+	{
+		Activity oTelActivity = null;
+		var listener = new ActivityListener
+		{
+			ActivityStarted = _ => { },
+			ActivityStopped = activity => oTelActivity = activity,
+			ShouldListenTo = activitySource => activitySource.Name == "Elastic.Transport.RequestPipeline",
+			Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData
+		};
+		ActivitySource.AddActivityListener(listener);
+
+		var audit =
+			new Auditor(() => Virtual.Elasticsearch
+				.Bootstrap(1)
+				.ClientCalls(r => r.Succeeds(TimesHelper.Once).ReturnResponse(new { x = 1 }))
+				.StaticNodePool()
+				.Settings(s => s.DisablePing().EnableDebugMode())
+			);
+		_ = await audit.TraceCalls(
+			new ClientCall { { AuditEvent.HealthyResponse, 9200, response => { } }, }
+		);
+
+		oTelActivity.Should().NotBeNull();
+
+		oTelActivity.Kind.Should().Be(ActivityKind.Client);
+
+		oTelActivity.DisplayName.Should().Be("Elasticsearch: GET /");
+		oTelActivity.OperationName.Should().Be("Elasticsearch: GET /");
+
+		oTelActivity.Tags.Should().Contain(n => n.Key == "db.system" && n.Value == "elasticsearch");
+		oTelActivity.Tags.Should().Contain(n => n.Key == "http.url" && n.Value == "http://localhost:9200/");
+		oTelActivity.Tags.Should().Contain(n => n.Key == "net.peer.name" && n.Value == "localhost");
+
+		oTelActivity.Status.Should().Be(ActivityStatusCode.Ok);
+	}
+}


### PR DESCRIPTION
Part of https://github.com/elastic/elastic-transport-net/issues/56. Work-in-progress.

`elastic-transport-net` already emits [`Activity`](https://learn.microsoft.com/en-us/dotnet/api/system.diagnostics.activity?view=net-7.0) for specific events. These were originally introduced, so our APM .NET Agent can listen to those and create APM Spans based on those events.

However, those Activities don't follow the OpenTelemetry spec - they rely on passing a strongly types object at start and end, and then the listener needs to cast those objects.

This PR changes it for `CallProductEndpoint`: it now emits `Activity` which follows [the OpenTelemetry spec](https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/trace/semantic_conventions/database.md).