### PR TITLE
Improvements to reflection version info

### DIFF
--- a/Playground/Playground.csproj
+++ b/Playground/Playground.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.0.4" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\src\Elastic.Transport\Elastic.Transport.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Playground/Program.cs
+++ b/Playground/Program.cs
@@ -1,0 +1,5 @@
+using Elastic.Transport.Products.Elasticsearch;
+
+var registration = new ElasticsearchProductRegistration(typeof(Elastic.Clients.Elasticsearch.ElasticsearchClient));
+
+Console.WriteLine(registration.DefaultMimeType ?? "NOT SPECIFIED");

--- a/Playground/Program.cs
+++ b/Playground/Program.cs
@@ -1,3 +1,7 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
 using Elastic.Transport.Products.Elasticsearch;
 
 var registration = new ElasticsearchProductRegistration(typeof(Elastic.Clients.Elasticsearch.ElasticsearchClient));

--- a/elastic-transport-net.sln
+++ b/elastic-transport-net.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29806.167
+# Visual Studio Version 17
+VisualStudioVersion = 17.4.33213.308
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "scripts", "build\scripts\scripts.fsproj", "{4779DD6F-AE49-4A80-9F67-D9F2DB05E557}"
 EndProject
@@ -40,6 +40,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Elastic.Transport.Integrati
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Elastic.Transport.Profiling", "benchmarks\Elastic.Transport.Profiling\Elastic.Transport.Profiling.csproj", "{ED4E89BE-FBE9-4876-979C-63A0E3BC5419}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Playground", "Playground\Playground.csproj", "{5EE4DC72-B337-448B-802A-6158F4D90667}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -74,6 +76,10 @@ Global
 		{ED4E89BE-FBE9-4876-979C-63A0E3BC5419}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{ED4E89BE-FBE9-4876-979C-63A0E3BC5419}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{ED4E89BE-FBE9-4876-979C-63A0E3BC5419}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5EE4DC72-B337-448B-802A-6158F4D90667}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5EE4DC72-B337-448B-802A-6158F4D90667}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5EE4DC72-B337-448B-802A-6158F4D90667}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5EE4DC72-B337-448B-802A-6158F4D90667}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -86,6 +92,7 @@ Global
 		{DABC7F0B-6174-4B2D-8F17-5E36C1CE43EF} = {BBB0AC81-F09D-4895-84E2-7E933D608E78}
 		{3B27DE76-1188-4078-8828-67AFD39BAC10} = {3582B07D-C2B0-49CC-B676-EAF806EB010E}
 		{ED4E89BE-FBE9-4876-979C-63A0E3BC5419} = {BBB0AC81-F09D-4895-84E2-7E933D608E78}
+		{5EE4DC72-B337-448B-802A-6158F4D90667} = {7610B796-BB3E-4CB2-8296-79BBFF6D23FC}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {7F60C4BB-6216-4E50-B1E4-9C38EB484843}

--- a/src/Elastic.Transport/Products/Elasticsearch/ElasticsearchProductRegistration.cs
+++ b/src/Elastic.Transport/Products/Elasticsearch/ElasticsearchProductRegistration.cs
@@ -35,7 +35,11 @@ public class ElasticsearchProductRegistration : ProductRegistration
 	{
 		var clientVersionInfo = ReflectionVersionInfo.Create(markerType);
 		_metaHeaderProvider = new DefaultMetaHeaderProvider(clientVersionInfo, "es");
-		_clientMajorVersion = clientVersionInfo.Version.Major;
+
+		// Only set this if we have a version.
+		// If we don't have a version we won't apply the vendor-based REST API compatibilty Accept header.
+		if (clientVersionInfo.Version.Major > 0)
+			_clientMajorVersion = clientVersionInfo.Version.Major;
 	}
 
 	/// <summary> A static instance of <see cref="ElasticsearchProductRegistration"/> to promote reuse </summary>

--- a/src/Elastic.Transport/Requests/MetaData/ReflectionVersionInfo.cs
+++ b/src/Elastic.Transport/Requests/MetaData/ReflectionVersionInfo.cs
@@ -37,7 +37,7 @@ internal sealed class ReflectionVersionInfo : VersionInfo
 	{
 		try
 		{
-			var productVersion = type.Assembly?.GetCustomAttribute<AssemblyFileVersionAttribute>().Version ?? EmptyVersion;
+			var productVersion = type.Assembly?.GetCustomAttribute<AssemblyFileVersionAttribute>()?.Version ?? EmptyVersion;
 
 			if (productVersion == EmptyVersion)
 				productVersion = FileVersionInfo.GetVersionInfo(type.Assembly.Location)?.ProductVersion ?? EmptyVersion;

--- a/src/Elastic.Transport/Requests/MetaData/ReflectionVersionInfo.cs
+++ b/src/Elastic.Transport/Requests/MetaData/ReflectionVersionInfo.cs
@@ -37,7 +37,10 @@ internal sealed class ReflectionVersionInfo : VersionInfo
 	{
 		try
 		{
-			var productVersion = FileVersionInfo.GetVersionInfo(type.GetTypeInfo().Assembly.Location)?.ProductVersion ?? EmptyVersion;
+			var productVersion = type.Assembly?.GetCustomAttribute<AssemblyFileVersionAttribute>().Version ?? EmptyVersion;
+
+			if (productVersion == EmptyVersion)
+				productVersion = FileVersionInfo.GetVersionInfo(type.Assembly.Location)?.ProductVersion ?? EmptyVersion;
 
 			if (productVersion == EmptyVersion)
 				productVersion = Assembly.GetAssembly(type).GetName().Version.ToString();

--- a/tests/Elastic.Transport.IntegrationTests/Elastic.Transport.IntegrationTests.csproj
+++ b/tests/Elastic.Transport.IntegrationTests/Elastic.Transport.IntegrationTests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.0.2" />
+    <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.0.4" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.0" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/tests/Elastic.Transport.IntegrationTests/Http/ApiCompatibilityHeaderTests.cs
+++ b/tests/Elastic.Transport.IntegrationTests/Http/ApiCompatibilityHeaderTests.cs
@@ -13,16 +13,12 @@ using Xunit;
 
 namespace Elastic.Transport.IntegrationTests.Http;
 
-/// <summary>
-/// Tests that the test framework loads a controller and the exposed transport can talk to its endpoints.
-/// Tests runs against a server that started up once and its server instance shared among many test classes
-/// </summary>
-public class MetaHeaderTests : AssemblyServerTestsBase
+public class ApiCompatibilityHeaderTests : AssemblyServerTestsBase
 {
-	public MetaHeaderTests(TransportTestServer instance) : base(instance) { }
+	public ApiCompatibilityHeaderTests(TransportTestServer instance) : base(instance) { }
 
 	[Fact]
-	public async Task AddsExpectedMetaHeader()
+	public async Task AddsExpectedVendorInformationForRestApiCompaitbility()
 	{
 		var connection = new TestableHttpConnection(responseMessage =>
 		{


### PR DESCRIPTION
Fixes #61 

- Add playground project
- Avoid creating vendor API version compatibility default mime type if version unknown
- Attempt to get version from the AssemblyFileVersionAttribute
- Update test naming
- Ensure we check for null attribute
- Refactor ReflectionVersionInfo for robustness
