### PR TITLE
Fixing bug with TestableResponseFactory (#64)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,19 @@ what happened.
 
 Further more `DiagnosticSources` exists for various purposes e.g (de)serialization times, time to first byte & various counters
 
+## Mocking response objects for testing
 
+`TestableResponseFactory` can be used to create response objects for use in unit tests.
+
+Example code using the [Moq](https://github.com/moq/moq) library:
+
+```cs
+var response = TestableResponseFactory.CreateSuccessfulResponse<SearchResponse<Document>>(new(), 200);
+var mock = new Mock<ElasticsearchClient>();
+mock
+  .Setup(m => m.SearchAsync<Document>(It.IsAny<SearchRequest>(), It.IsAny<CancellationToken>()))
+  .ReturnsAsync(response);
+```
 
 
 

--- a/src/Elastic.Transport/Responses/TestableResponseFactory.cs
+++ b/src/Elastic.Transport/Responses/TestableResponseFactory.cs
@@ -29,7 +29,14 @@ public static class TestableResponseFactory
 	/// <returns>The <typeparamref name="T"/> response configured with the provided status code where <see cref="ApiCallDetails.HasSuccessfulStatusCode"/> will be set using <paramref name="statusCodeRepresentsSuccess"/>.</returns>
 	public static T CreateResponse<T>(T response, int httpStatusCode, bool statusCodeRepresentsSuccess) where T : TransportResponse
 	{
-		var apiCallDetails = new ApiCallDetails { HttpStatusCode = httpStatusCode, HasSuccessfulStatusCode = statusCodeRepresentsSuccess };
+		var apiCallDetails = new ApiCallDetails
+		{
+			HttpStatusCode = httpStatusCode,
+			HasSuccessfulStatusCode = statusCodeRepresentsSuccess,
+			HasExpectedContentType = true,
+			TransportConfiguration = new TransportConfiguration()
+		};
+
 		return CreateResponse<T>(response, apiCallDetails);
 	}
 

--- a/tests/Elastic.Transport.Tests/Responses/TestableResponseFactory.cs
+++ b/tests/Elastic.Transport.Tests/Responses/TestableResponseFactory.cs
@@ -1,0 +1,88 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using Elastic.Transport.Products.Elasticsearch;
+using FluentAssertions;
+using Xunit;
+
+namespace Elastic.Transport.Tests;
+
+public class TestableResponseFactoryTests
+{
+	/// <summary>
+	/// Class used for testing purposes only
+	/// </summary>
+	private class TestableResponse : ElasticsearchResponse { }
+
+	[Fact]
+	public void CreateSuccessfulResponse_ShouldBeValid()
+	{
+		var response = TestableResponseFactory.CreateSuccessfulResponse<TestableResponse>(new(), 200);
+		response.IsValidResponse.Should().BeTrue();
+	}
+
+	[Fact]
+	public void CreateSuccessfulResponse_ApiCallDetailsShouldContainStatusCode()
+	{
+		var response = TestableResponseFactory.CreateSuccessfulResponse<TestableResponse>(new(), 200);
+		response.ApiCallDetails.HttpStatusCode.Should().Be(200);
+	}
+
+	[Fact]
+	public void CreateSuccessfulResponse_ApiCallDetailsShouldBeSuccessful()
+	{
+		var response = TestableResponseFactory.CreateSuccessfulResponse<TestableResponse>(new(), 200);
+		response.ApiCallDetails.HasSuccessfulStatusCode.Should().BeTrue();
+	}
+
+	[Fact]
+	public void CreateResponse_GivenBadResponse_ShouldNotBeValid()
+	{
+		var response = TestableResponseFactory.CreateResponse<TestableResponse>(new(), 400, false);
+		response.IsValidResponse.Should().BeFalse();
+	}
+
+	[Fact]
+	public void CreateResponse_ApiCallDetailsShouldContainStatusCode()
+	{
+		var response = TestableResponseFactory.CreateResponse<TestableResponse>(new(), 400, false);
+		response.ApiCallDetails.HttpStatusCode.Should().Be(400);
+	}
+
+	[Fact]
+	public void CreateResponse_ApiCallDetailsShouldNotBeSuccessful()
+	{
+		var response = TestableResponseFactory.CreateResponse<TestableResponse>(new(), 400, false);
+		response.ApiCallDetails.HasSuccessfulStatusCode.Should().BeFalse();
+	}
+
+	[Fact]
+	public void CreateResponse_ResponseShouldIncludeDebugInfo()
+	{
+		var response = TestableResponseFactory.CreateResponse<TestableResponse>(new(), 400, false);
+		response.DebugInformation.Should().NotBeNull();
+	}
+
+	[Fact]
+	public void CreateResponse_OriginalExceptionShouldBeNull()
+	{
+		var response = TestableResponseFactory.CreateResponse<TestableResponse>(new(), 400, false);
+		response.TryGetOriginalException(out var exception);
+		exception.Should().BeNull();
+	}
+
+	[Fact]
+	public void CreateResponse_ElasticsearchServerErrorShouldBeNull()
+	{
+		var response = TestableResponseFactory.CreateResponse<TestableResponse>(new(), 400, false);
+		response.ElasticsearchServerError.Should().BeNull();
+	}
+
+	[Fact]
+	public void CreateResponse_ElasticsearchWarningsShouldBeEmpty()
+	{
+		var response = TestableResponseFactory.CreateResponse<TestableResponse>(new(), 400, false);
+		response.ElasticsearchWarnings.Should().BeEmpty();
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/elastic/elastic-transport-net/issues/64

- Adding required fields for ApiCallDetails to be considered "successfull"
- Adding TestableResponseFactory unit tests
- Updating README with an example of using TestableResponseFactory
