### PR TITLE
Request ContentType Check may throw NRE

### DIFF
--- a/src/Elastic.Transport/Components/TransportClient/HttpTransportClient.cs
+++ b/src/Elastic.Transport/Components/TransportClient/HttpTransportClient.cs
@@ -86,7 +86,7 @@ public class HttpTransportClient : TransportClient
 			requestData.MadeItToResponse = true;
 			responseHeaders = ParseHeaders(requestData, responseMessage, responseHeaders);
 			contentLength = responseMessage.Content.Headers.ContentLength ?? -1;
-			mimeType = responseMessage.Content.Headers.ContentType.ToString();
+			mimeType = responseMessage.Content.Headers.ContentType?.ToString();
 
 			if (responseMessage.Content != null)
 			{
@@ -150,14 +150,14 @@ public class HttpTransportClient : TransportClient
 					.ConfigureAwait(false);
 				statusCode = (int)responseMessage.StatusCode;
 			}
-				
+
 			requestData.MadeItToResponse = true;
 			mimeType = responseMessage.Content.Headers.ContentType?.ToString();
 			contentLength = responseMessage.Content.Headers.ContentLength ?? -1;
 			responseHeaders = ParseHeaders(requestData, responseMessage, responseHeaders);
 
 			if (responseMessage.Content != null)
-			{				
+			{
 				responseStream = await responseMessage.Content.ReadAsStreamAsync().ConfigureAwait(false);
 			}
 		}


### PR DESCRIPTION
Ensure ContentType check handles possible null on synchronous code path too.

The asynchronous codepath already included the proper null coalescing operator:

https://github.com/elastic/elastic-transport-net/blob/fix/null-ref-synchronous-request/src/Elastic.Transport/Components/TransportClient/HttpTransportClient.cs#L155

Fixes: https://github.com/elastic/elastic-transport-net/issues/76
