### PR TITLE
Ensure TransportResponse has useful ToString()

### DIFF
--- a/src/Elastic.Transport/Responses/TransportResponse.cs
+++ b/src/Elastic.Transport/Responses/TransportResponse.cs
@@ -24,8 +24,12 @@ public abstract class TransportResponse<T> : TransportResponse
 public abstract class TransportResponse
 {
 	/// <summary>
-	/// 
+	///
 	/// </summary>
 	[JsonIgnore]
-	public ApiCallDetails ApiCallDetails { get; internal set; }
+	public ApiCallDetails? ApiCallDetails { get; internal set; }
+
+	/// <inheritdoc cref="object.ToString"/>
+	public override string ToString() => ApiCallDetails?.DebugInformation
+		?? $"{nameof(ApiCallDetails)} not set reverting to default ToString(): {base.ToString()}";
 }


### PR DESCRIPTION
If we have ApiCallDetails use that in the ToString() implementation.

Relates to: https://github.com/elastic/elastic-ingest-dotnet/pull/37

Will implement a similar PR to `ingest-dotnet` to create a more useful default `ElasticsearchTransportResponse` with a better tostring.
