### PR TITLE
Include OriginialException.Message in default to string for ApiCallDetails

### DIFF
--- a/src/Elastic.Transport/Products/Elasticsearch/ElasticsearchResponse.cs
+++ b/src/Elastic.Transport/Products/Elasticsearch/ElasticsearchResponse.cs
@@ -83,7 +83,7 @@ public abstract class ElasticsearchResponse : TransportResponse
 	///
 	/// </summary>
 	[JsonIgnore]
-	public ElasticsearchServerError ElasticsearchServerError { get; internal set; }
+	public ElasticsearchServerError? ElasticsearchServerError { get; internal set; }
 
 	/// <summary>
 	///
@@ -107,9 +107,7 @@ public abstract class ElasticsearchResponse : TransportResponse
 	protected virtual void DebugIsValid(StringBuilder sb) { }
 
 	/// <summary>
-	///
+	/// A custom <see cref="ToString"/> implementation that returns <see cref="DebugInformation"/>
 	/// </summary>
-	/// <returns></returns>
-	public override string ToString() =>
-		$"{(!IsValidResponse ? "Inv" : "V")}alid response built from a {ApiCallDetails?.ToString().ToCamelCase()}";
+	public override string ToString() => DebugInformation;
 }

--- a/src/Elastic.Transport/Products/Elasticsearch/ElasticsearchResponse.cs
+++ b/src/Elastic.Transport/Products/Elasticsearch/ElasticsearchResponse.cs
@@ -32,7 +32,7 @@ public abstract class ElasticsearchResponse : TransportResponse
 	}
 
 	/// <summary>
-	/// 
+	///
 	/// </summary>
 	[JsonIgnore]
 	public string DebugInformation
@@ -46,7 +46,7 @@ public abstract class ElasticsearchResponse : TransportResponse
 			if (!IsValidResponse)
 				DebugIsValid(sb);
 
-			if (ApiCallDetails.ParsedHeaders is not null && ApiCallDetails.ParsedHeaders.TryGetValue("warning", out var warnings))
+			if (ApiCallDetails?.ParsedHeaders is not null && ApiCallDetails.ParsedHeaders.TryGetValue("warning", out var warnings))
 			{
 				sb.AppendLine($"# Server indicated warnings:");
 
@@ -80,20 +80,20 @@ public abstract class ElasticsearchResponse : TransportResponse
 	}
 
 	/// <summary>
-	/// 
+	///
 	/// </summary>
 	[JsonIgnore]
 	public ElasticsearchServerError ElasticsearchServerError { get; internal set; }
 
 	/// <summary>
-	/// 
+	///
 	/// </summary>
 	/// <param name="exception"></param>
 	/// <returns></returns>
 	// TODO: We need nullable annotations here ideally as exception is not null when the return value is true.
 	public bool TryGetOriginalException(out Exception? exception)
 	{
-		if (ApiCallDetails.OriginalException is not null)
+		if (ApiCallDetails?.OriginalException is not null)
 		{
 			exception = ApiCallDetails.OriginalException;
 			return true;
@@ -107,9 +107,9 @@ public abstract class ElasticsearchResponse : TransportResponse
 	protected virtual void DebugIsValid(StringBuilder sb) { }
 
 	/// <summary>
-	/// 
+	///
 	/// </summary>
 	/// <returns></returns>
 	public override string ToString() =>
-		$"{(!IsValidResponse ? "Inv" : "V")}alid Elastic.Clients.Elasticsearch response built from a {ApiCallDetails?.ToString().ToCamelCase()}";
+		$"{(!IsValidResponse ? "Inv" : "V")}alid response built from a {ApiCallDetails?.ToString().ToCamelCase()}";
 }

--- a/src/Elastic.Transport/Responses/HttpDetails/ApiCallDetails.cs
+++ b/src/Elastic.Transport/Responses/HttpDetails/ApiCallDetails.cs
@@ -17,7 +17,7 @@ namespace Elastic.Transport;
 /// </summary>
 public sealed class ApiCallDetails
 {
-	private string _debugInformation;
+	private string? _debugInformation;
 
 	internal ApiCallDetails() { }
 

--- a/src/Elastic.Transport/Responses/HttpDetails/ApiCallDetails.cs
+++ b/src/Elastic.Transport/Responses/HttpDetails/ApiCallDetails.cs
@@ -13,7 +13,7 @@ using Elastic.Transport.Extensions;
 namespace Elastic.Transport;
 
 /// <summary>
-/// 
+///
 /// </summary>
 public sealed class ApiCallDetails
 {
@@ -22,22 +22,22 @@ public sealed class ApiCallDetails
 	internal ApiCallDetails() { }
 
 	/// <summary>
-	/// 
+	///
 	/// </summary>>
 	public IEnumerable<Audit> AuditTrail { get; internal set; }
 
 	/// <summary>
-	/// 
+	///
 	/// </summary>
 	internal IReadOnlyDictionary<string, ThreadPoolStatistics> ThreadPoolStats { get; set; }
 
 	/// <summary>
-	/// 
+	///
 	/// </summary>
 	internal IReadOnlyDictionary<TcpState, int> TcpStats { get; set; }
 
 	/// <summary>
-	/// 
+	///
 	/// </summary>
 	public string DebugInformation
 	{
@@ -55,49 +55,49 @@ public sealed class ApiCallDetails
 	}
 
 	/// <summary>
-	/// 
+	///
 	/// </summary>
 	public HttpMethod HttpMethod { get; internal set; }
 
 	/// <summary>
-	/// 
+	///
 	/// </summary>
 	public int? HttpStatusCode { get; internal set; }
 
 	/// <summary>
-	/// 
+	///
 	/// </summary>
-	public Exception OriginalException { get; internal set; }
+	public Exception? OriginalException { get; internal set; }
 
 	/// <summary>
-	/// 
+	///
 	/// </summary>
 	public byte[] RequestBodyInBytes { get; internal set; }
 
 	/// <summary>
-	/// 
+	///
 	/// </summary>
 	public byte[] ResponseBodyInBytes { get; internal set; }
 
 	/// <summary>
-	/// 
+	///
 	/// </summary>
 	internal string ResponseMimeType { get; set; }
 
 	/// <summary>
-	/// 
+	///
 	/// </summary>
 	public bool HasSuccessfulStatusCode { get; internal set; }
 
 	/// <summary>
-	/// 
+	///
 	/// </summary>
 	public bool HasExpectedContentType { get; internal set; }
 
 	internal bool HasSuccessfulStatusCodeAndExpectedContentType => HasSuccessfulStatusCode && HasExpectedContentType;
 
 	/// <summary>
-	/// 
+	///
 	/// </summary>
 	internal bool SuccessOrKnownError =>
 		HasSuccessfulStatusCodeAndExpectedContentType
@@ -109,23 +109,23 @@ public sealed class ApiCallDetails
 				&& HasExpectedContentType;
 
 	/// <summary>
-	/// 
+	///
 	/// </summary>
-	public Uri Uri { get; internal set; }
+	public Uri? Uri { get; internal set; }
 
 	/// <summary>
-	/// 
+	///
 	/// </summary>
 	internal ITransportConfiguration TransportConfiguration { get; set; }
 
 	/// <summary>
-	/// 
+	///
 	/// </summary>
 	internal IReadOnlyDictionary<string, IEnumerable<string>> ParsedHeaders { get; set; }
 		= EmptyReadOnly<string, IEnumerable<string>>.Dictionary;
 
 	/// <summary>
-	/// 
+	///
 	/// </summary>
 	/// <param name="key"></param>
 	/// <param name="headerValues"></param>
@@ -142,6 +142,13 @@ public sealed class ApiCallDetails
 	/// <summary>
 	/// A string summarising the API call.
 	/// </summary>
-	public override string ToString() =>
-		$"{(HasSuccessfulStatusCodeAndExpectedContentType ? "S" : "Uns")}uccessful ({HttpStatusCode}) low level call on {HttpMethod.GetStringValue()}: {(Uri is not null ? Uri.PathAndQuery: "UNKNOWN URI")}";
+	public override string ToString()
+	{
+		var sb = new StringBuilder();
+		sb.Append($"{(HasSuccessfulStatusCodeAndExpectedContentType ? "S" : "Uns")}uccessful ({HttpStatusCode}) low level call on ");
+		sb.AppendLine($"{HttpMethod.GetStringValue()}: {(Uri is not null ? Uri.PathAndQuery : "UNKNOWN URI")}");
+		if (OriginalException is not null)
+			sb.AppendLine($" Exception: {OriginalException.Message}");
+		return sb.ToString();
+	}
 }

--- a/src/Elastic.Transport/Responses/ResponseStatics.cs
+++ b/src/Elastic.Transport/Responses/ResponseStatics.cs
@@ -26,12 +26,13 @@ internal static class ResponseStatics
 	/// <inheritdoc cref="ResponseStatics"/>
 	public static string DebugInformationBuilder(ApiCallDetails r, StringBuilder sb)
 	{
+
 		sb.AppendLine($"# Audit trail of this API call:");
 
 		var auditTrail = (r.AuditTrail ?? Enumerable.Empty<Audit>()).ToList();
 
 		if (!r.TransportConfiguration.DisableAuditTrail)
-		{			
+		{
 			DebugAuditTrail(auditTrail, sb);
 		}
 		else

--- a/src/Elastic.Transport/Responses/TransportResponse.cs
+++ b/src/Elastic.Transport/Responses/TransportResponse.cs
@@ -29,3 +29,4 @@ public abstract class TransportResponse
 	[JsonIgnore]
 	public ApiCallDetails ApiCallDetails { get; internal set; }
 }
+


### PR DESCRIPTION
Relates to: https://github.com/elastic/elastic-ingest-dotnet/pull/37

Ensures we caught exceptions are reported in the .ToString() implementations for any `TransportResponse`