### PR TITLE
Fix NRE when using bad authentication and ping is enabled.

### DIFF
--- a/src/Elastic.Transport/Components/Pipeline/PipelineException.cs
+++ b/src/Elastic.Transport/Components/Pipeline/PipelineException.cs
@@ -35,7 +35,7 @@ public class PipelineException : Exception
 		|| FailureReason == PipelineFailure.PingFailure;
 
 	/// <summary> The response that triggered this exception </summary>
-	public TransportResponse Response { get; internal set; }
+	public TransportResponse? Response { get; internal set; }
 
 	private static string GetMessage(PipelineFailure failure) =>
 		failure switch

--- a/src/Elastic.Transport/Components/Pipeline/RequestData.cs
+++ b/src/Elastic.Transport/Components/Pipeline/RequestData.cs
@@ -140,7 +140,7 @@ public sealed class RequestData
 	public MemoryStreamFactory MemoryStreamFactory { get; }
 	public HttpMethod Method { get; }
 
-	public Node Node
+	public Node? Node
 	{
 		get => _node;
 		set
@@ -240,7 +240,7 @@ public sealed class RequestData
 			// - 404 responses from ES8 don't include the vendored header
 			// - ES8 EQL responses don't include vendored type
 
-			|| trimmedAccept.Contains("application/vnd.elasticsearch+json") && trimmedResponseMimeType.StartsWith(DefaultMimeType, StringComparison.OrdinalIgnoreCase); 
+			|| trimmedAccept.Contains("application/vnd.elasticsearch+json") && trimmedResponseMimeType.StartsWith(DefaultMimeType, StringComparison.OrdinalIgnoreCase);
 	}
 
 	public static string ToQueryString(NameValueCollection collection) => collection.ToQueryString();

--- a/src/Elastic.Transport/Components/Pipeline/RequestPipeline.cs
+++ b/src/Elastic.Transport/Components/Pipeline/RequestPipeline.cs
@@ -94,13 +94,13 @@ public abstract class RequestPipeline : IDisposable
 
 	public abstract void AuditCancellationRequested();
 
-	public abstract TransportException CreateClientException<TResponse>(TResponse response, ApiCallDetails callDetails, RequestData data,
-		List<PipelineException> seenExceptions)
+	public abstract TransportException? CreateClientException<TResponse>(TResponse? response, ApiCallDetails? callDetails,
+		RequestData data, List<PipelineException> seenExceptions)
 		where TResponse : TransportResponse, new();
 #pragma warning restore 1591
 
 	/// <summary>
-	/// 
+	///
 	/// </summary>
 	public void Dispose()
 	{
@@ -109,7 +109,7 @@ public abstract class RequestPipeline : IDisposable
 	}
 
 	/// <summary>
-	/// 
+	///
 	/// </summary>
 	/// <param name="disposing"></param>
 	protected virtual void Dispose(bool disposing)
@@ -126,7 +126,7 @@ public abstract class RequestPipeline : IDisposable
 	}
 
 	/// <summary>
-	/// 
+	///
 	/// </summary>
 	protected virtual void DisposeManagedResources() { }
 }

--- a/src/Elastic.Transport/DefaultHttpTransport.cs
+++ b/src/Elastic.Transport/DefaultHttpTransport.cs
@@ -126,12 +126,12 @@ public class DefaultHttpTransport<TConfiguration> : HttpTransport<TConfiguration
 	private RequestPipelineFactory<TConfiguration> PipelineProvider { get; }
 
 	/// <summary>
-	/// 
+	///
 	/// </summary>
 	public override TConfiguration Settings { get; }
 
 	/// <summary>
-	/// 
+	///
 	/// </summary>
 	/// <typeparam name="TResponse"></typeparam>
 	/// <param name="method"></param>
@@ -139,8 +139,7 @@ public class DefaultHttpTransport<TConfiguration> : HttpTransport<TConfiguration
 	/// <param name="data"></param>
 	/// <param name="requestParameters"></param>
 	/// <returns></returns>
-	public override TResponse Request<TResponse>(HttpMethod method, string path, PostData data = null,
-		RequestParameters requestParameters = null)
+	public override TResponse Request<TResponse>(HttpMethod method, string path, PostData? data = null, RequestParameters? requestParameters = null)
 	{
 		using var pipeline =
 			PipelineProvider.Create(Settings, DateTimeProvider, MemoryStreamFactory, requestParameters);
@@ -217,7 +216,7 @@ public class DefaultHttpTransport<TConfiguration> : HttpTransport<TConfiguration
 	}
 
 	/// <summary>
-	/// 
+	///
 	/// </summary>
 	/// <typeparam name="TResponse"></typeparam>
 	/// <param name="method"></param>
@@ -228,7 +227,7 @@ public class DefaultHttpTransport<TConfiguration> : HttpTransport<TConfiguration
 	/// <returns></returns>
 	/// <exception cref="UnexpectedTransportException"></exception>
 	public override async Task<TResponse> RequestAsync<TResponse>(HttpMethod method, string path,
-		PostData data = null, RequestParameters requestParameters = null,
+		PostData? data = null, RequestParameters? requestParameters = null,
 		CancellationToken cancellationToken = default)
 	{
 		using var pipeline =
@@ -343,7 +342,7 @@ public class DefaultHttpTransport<TConfiguration> : HttpTransport<TConfiguration
 
 	private TResponse FinalizeResponse<TResponse>(RequestData requestData, RequestPipeline pipeline,
 		List<PipelineException> seenExceptions,
-		TResponse response
+		TResponse? response
 	) where TResponse : TransportResponse, new()
 	{
 		if (requestData.Node == null) //foreach never ran
@@ -359,11 +358,11 @@ public class DefaultHttpTransport<TConfiguration> : HttpTransport<TConfiguration
 		return response;
 	}
 
-	private static ApiCallDetails GetMostRecentCallDetails<TResponse>(TResponse response,
+	private static ApiCallDetails? GetMostRecentCallDetails<TResponse>(TResponse? response,
 		IEnumerable<PipelineException> seenExceptions)
 		where TResponse : TransportResponse, new()
 	{
-		var callDetails = response?.ApiCallDetails ?? seenExceptions.LastOrDefault(e => e.Response.ApiCallDetails != null)?.Response.ApiCallDetails;
+		var callDetails = response?.ApiCallDetails ?? seenExceptions.LastOrDefault(e => e.Response?.ApiCallDetails != null)?.Response?.ApiCallDetails;
 		return callDetails;
 	}
 

--- a/src/Elastic.Transport/HttpTransport.cs
+++ b/src/Elastic.Transport/HttpTransport.cs
@@ -18,16 +18,16 @@ public abstract class HttpTransport
 	public abstract TResponse Request<TResponse>(
 		HttpMethod method,
 		string path,
-		PostData data = null,
-		RequestParameters requestParameters = null)
+		PostData? data = null,
+		RequestParameters? requestParameters = null)
 		where TResponse : TransportResponse, new();
 
 	/// <inheritdoc cref="Request{TResponse}" />
 	public abstract Task<TResponse> RequestAsync<TResponse>(
 		HttpMethod method,
 		string path,
-		PostData data = null,
-		RequestParameters requestParameters = null,
+		PostData? data = null,
+		RequestParameters? requestParameters = null,
 		CancellationToken cancellationToken = default)
 		where TResponse : TransportResponse, new();
 }

--- a/tests/Elastic.Elasticsearch.IntegrationTests/DefaultCluster.cs
+++ b/tests/Elastic.Elasticsearch.IntegrationTests/DefaultCluster.cs
@@ -5,6 +5,7 @@
 using Elastic.Elasticsearch.Ephemeral;
 using Elastic.Elasticsearch.Xunit;
 using Elastic.Transport;
+using Elastic.Transport.Products.Elasticsearch;
 using Xunit;
 using Xunit.Abstractions;
 using static Elastic.Elasticsearch.Ephemeral.ClusterAuthentication;
@@ -28,7 +29,7 @@ public class DefaultCluster : XunitClusterBase
 				: "localhost");
 			var nodes = NodesUris(hostName);
 			var connectionPool = new StaticNodePool(nodes);
-			var settings = new TransportConfiguration(connectionPool)
+			var settings = new TransportConfiguration(connectionPool, productRegistration: ElasticsearchProductRegistration.Default)
 				.Proxy(new Uri("http://ipv4.fiddler:8080"), null!, null!)
 				.RequestTimeout(TimeSpan.FromSeconds(5))
 				.ServerCertificateValidationCallback(CertificateValidations.AllowAll)

--- a/tests/Elastic.Elasticsearch.IntegrationTests/SecurityClusterTests.cs
+++ b/tests/Elastic.Elasticsearch.IntegrationTests/SecurityClusterTests.cs
@@ -29,4 +29,18 @@ public class SecurityClusterTests : IntegrationTestBase<SecurityCluster>
 		response.ApiCallDetails.Should().NotBeNull();
 		response.ApiCallDetails.HasSuccessfulStatusCode.Should().BeTrue();
 	}
+
+	[Fact]
+	public void SyncRequestDoesNotThrowOnBadAuth()
+	{
+		var response = Transport.Request<StringResponse>(GET, "/", null, new DefaultRequestParameters
+		{
+			RequestConfiguration = new RequestConfiguration
+			{
+				AuthenticationHeader = new BasicAuthentication("unknown-user", "bad-password")
+			}
+		});
+		response.ApiCallDetails.Should().NotBeNull();
+		response.ApiCallDetails.HasSuccessfulStatusCode.Should().BeFalse();
+	}
 }


### PR DESCRIPTION
This could result in a NRE GetMostRecentDetails() since it assumes
PipelineExceptions has a response or a response is already available.

But part of the job from its parent callsite `FinalizeResponse` is
to create a response if one is missing in these case through
`pipeline.BadResponse()` later on.
