### PR TITLE
Bring default for IsBypassed inline with actual implementation

### DIFF
--- a/src/Elastic.Transport/Components/TransportClient/WebProxy.cs
+++ b/src/Elastic.Transport/Components/TransportClient/WebProxy.cs
@@ -18,6 +18,6 @@ internal class WebProxy : IWebProxy
 
 	public Uri GetProxy(Uri destination) => _uri;
 
-	public bool IsBypassed(Uri host) => host.IsLoopback;
+	public bool IsBypassed(Uri host) => false;
 }
 #endif

--- a/tests/Elastic.Elasticsearch.IntegrationTests/Elastic.Elasticsearch.IntegrationTests.csproj
+++ b/tests/Elastic.Elasticsearch.IntegrationTests/Elastic.Elasticsearch.IntegrationTests.csproj
@@ -9,7 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Elastic.Elasticsearch.Xunit" Version="0.4.1" />
+        <PackageReference Include="Elastic.Elasticsearch.Xunit" Version="0.4.3" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">


### PR DESCRIPTION
This brings our `IWebProxy` implementation inline with the one shipped in netfx/standard/.

```csharp
/// <summary>Gets or sets a value that indicates whether to bypass the proxy server for local addresses.</summary>
/// <returns>
/// <see langword="true" /> to bypass the proxy server for local addresses; otherwise, <see langword="false" />. The default value is <see langword="false" />.</returns>
public bool BypassProxyOnLocal { get; set; }
```