### PR TITLE
Fixed serialization of types like ICollection<TEnum> in UrlFormatter

### DIFF
--- a/src/Elastic.Transport/Requests/UrlFormatter.cs
+++ b/src/Elastic.Transport/Requests/UrlFormatter.cs
@@ -53,9 +53,19 @@ public sealed class UrlFormatter : IFormatProvider, ICustomFormatter
 			case DateTimeOffset offset: return offset.ToString("o");
 			case IEnumerable<object> pns:
 				return string.Join(",", pns.Select(o => ResolveUrlParameterOrDefault(o, settings)));
+			case Array pns:
+				return CreateString(ConvertArrayToEnumerable(pns), settings);
 			case TimeSpan timeSpan: return timeSpan.ToTimeUnit();
 			default:
 				return ResolveUrlParameterOrDefault(value, settings);
+		}
+	}
+
+	private static IEnumerable<object> ConvertArrayToEnumerable(Array array)
+	{
+		for (var i = array.GetLowerBound(0); i <= array.GetUpperBound(0); i++)
+		{
+			yield return array.GetValue(i);
 		}
 	}
 

--- a/src/Elastic.Transport/Requests/UrlFormatter.cs
+++ b/src/Elastic.Transport/Requests/UrlFormatter.cs
@@ -41,7 +41,7 @@ public sealed class UrlFormatter : IFormatProvider, ICustomFormatter
 	public string CreateString(object value) => CreateString(value, _settings);
 
 	/// <summary> Creates a query string representation for <paramref name="value"/> </summary>
-	public static string CreateString(object value, ITransportConfiguration settings)
+	public static string? CreateString(object? value, ITransportConfiguration settings)
 	{
 		switch (value)
 		{
@@ -52,21 +52,22 @@ public sealed class UrlFormatter : IFormatProvider, ICustomFormatter
 			case bool b: return b ? "true" : "false";
 			case DateTimeOffset offset: return offset.ToString("o");
 			case IEnumerable<object> pns:
-				return string.Join(",", pns.Select(o => ResolveUrlParameterOrDefault(o, settings)));
+				return CreateStringFromIEnumerable(pns, settings);
 			case Array pns:
-				return CreateString(ConvertArrayToEnumerable(pns), settings);
+				return CreateStringFromIEnumerable(ConvertArrayToEnumerable(pns), settings);
 			case TimeSpan timeSpan: return timeSpan.ToTimeUnit();
 			default:
 				return ResolveUrlParameterOrDefault(value, settings);
 		}
 	}
 
+	private static string CreateStringFromIEnumerable(IEnumerable<object> value, ITransportConfiguration settings) =>
+		string.Join(",", value.Select(o => ResolveUrlParameterOrDefault(o, settings)));
+
 	private static IEnumerable<object> ConvertArrayToEnumerable(Array array)
 	{
 		for (var i = array.GetLowerBound(0); i <= array.GetUpperBound(0); i++)
-		{
 			yield return array.GetValue(i);
-		}
 	}
 
 	private static string ResolveUrlParameterOrDefault(object value, ITransportConfiguration settings) =>


### PR DESCRIPTION
The current UrlFormatter code doesn't serialize correctly the types like:
```cs
ICollection<TEnum> 
```
, where TEnum is some Enum type, for example:
```cs
ICollection<Elastic.Clients.Elasticsearch.ExpandWildcard>
```

value of this type will be serialized as:
```
Elastic.Clients.Elasticsearch.ExpandWildcard[]
```

The reason is that ICollection<Elastic.Clients.Elasticsearch.ExpandWildcard> is not compatible with IEnumerable&lt;object> and in  
 the following code:
```cs
	public static string CreateString(object value, ITransportConfiguration settings)
	{
		switch (value)
		{
			case null: return null;
			case string s: return s;
			case string[] ss: return string.Join(",", ss);
			case Enum e: return e.GetStringValue();
			case bool b: return b ? "true" : "false";
			case DateTimeOffset offset: return offset.ToString("o");
			case IEnumerable<object> pns:
				return string.Join(",", pns.Select(o => ResolveUrlParameterOrDefault(o, settings)));
			case TimeSpan timeSpan: return timeSpan.ToTimeUnit();
			default:
				return ResolveUrlParameterOrDefault(value, settings);
		}
	}
```

for value of this type the "default" branch is executed, creating the result mentioned before. The related issue in Elasticsearch.Net project: https://github.com/elastic/elasticsearch-net/issues/7823

To fix this problem we need to add additional branch where the value is matched against Array type.

