### PR TITLE
Remove allocations on success path

### DIFF
--- a/benchmarks/Elastic.Transport.Benchmarks/TransportBenchmarks.cs
+++ b/benchmarks/Elastic.Transport.Benchmarks/TransportBenchmarks.cs
@@ -23,16 +23,9 @@ namespace Elastic.Transport.Benchmarks
 		}
 
 		[Benchmark]
-		public void TransportSuccessfulRequestBenchmark() => _transport.Get<EmptyResponse>("/");
+		public void TransportSuccessfulRequestBenchmark() => _transport.Get<VoidResponse>("/");
 
 		[Benchmark]
-		public async Task TransportSuccessfulAsyncRequestBenchmark() => await _transport.GetAsync<EmptyResponse>("/");
-
-		private class EmptyResponse : TransportResponse
-		{
-			public EmptyResponse() : base() { }
-
-			public ApiCallDetails ApiCall { get; set; }
-		}
+		public async Task TransportSuccessfulAsyncRequestBenchmark() => await _transport.GetAsync<VoidResponse>("/");
 	}
 }

--- a/benchmarks/Elastic.Transport.Profiling/Elastic.Transport.Profiling.csproj
+++ b/benchmarks/Elastic.Transport.Profiling/Elastic.Transport.Profiling.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="JetBrains.Profiler.Api" Version="1.1.8" />
+    <PackageReference Include="JetBrains.Profiler.Api" Version="1.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/benchmarks/Elastic.Transport.Profiling/Program.cs
+++ b/benchmarks/Elastic.Transport.Profiling/Program.cs
@@ -2,7 +2,6 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
-using System;
 using System.Threading.Tasks;
 using Elastic.Transport.Products.Elasticsearch;
 using JetBrains.Profiler.Api;
@@ -19,23 +18,20 @@ namespace Elastic.Transport.Profiling
 			var config = new TransportConfiguration(new Uri("http://localhost:9200"), new ElasticsearchProductRegistration());
 			var transport = new DefaultHttpTransport(config);
 
-			_ = await transport.GetAsync<VoidResponse>("/");
+			// WARMUP
+			for (var i = 0; i < 50; i++) _ = await transport.GetAsync<VoidResponse>("/");
 
-			MemoryProfiler.GetSnapshot("before-many-requests");
-
-			for (var i = 0; i < 1_000; i++) _ = await transport.GetAsync<VoidResponse>("/");
-
-			MemoryProfiler.GetSnapshot("after-many-requests");
-			//MeasureProfiler.StopCollectingData();
+			MemoryProfiler.GetSnapshot("before-100-requests");
+			for (var i = 0; i < 100; i++) _ = await transport.GetAsync<VoidResponse>("/");
+			MemoryProfiler.GetSnapshot("after-100-requests");
 
 			await Task.Delay(1000);
-
 			MemoryProfiler.ForceGc();
+
 			MemoryProfiler.GetSnapshot("before-final-request");
 			_ = await transport.GetAsync<VoidResponse>("/");
 			MemoryProfiler.GetSnapshot("after-final-request");
 
-			MemoryProfiler.ForceGc();
 			MemoryProfiler.GetSnapshot("end");
 		}
 	}

--- a/benchmarks/Elastic.Transport.Profiling/Program.cs
+++ b/benchmarks/Elastic.Transport.Profiling/Program.cs
@@ -2,6 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using System;
 using System.Threading.Tasks;
 using Elastic.Transport.Products.Elasticsearch;
 using JetBrains.Profiler.Api;

--- a/src/Elastic.Transport/Components/Pipeline/DefaultRequestPipeline.cs
+++ b/src/Elastic.Transport/Components/Pipeline/DefaultRequestPipeline.cs
@@ -278,13 +278,13 @@ public class DefaultRequestPipeline<TConfiguration> : RequestPipeline
 	}
 
 	public override TransportException? CreateClientException<TResponse>(TResponse response, ApiCallDetails? callDetails,
-		RequestData data, List<PipelineException> seenExceptions)
+		RequestData data, List<PipelineException>? seenExceptions)
 	{
 		if (callDetails?.HasSuccessfulStatusCodeAndExpectedContentType ?? false) return null;
 
 		var pipelineFailure = data.OnFailurePipelineFailure;
 		var innerException = callDetails?.OriginalException;
-		if (seenExceptions.HasAny(out var exs))
+		if (seenExceptions is not null && seenExceptions.HasAny(out var exs))
 		{
 			pipelineFailure = exs.Last().FailureReason;
 			innerException = exs.AsAggregateOrFirst();
@@ -656,7 +656,7 @@ public class DefaultRequestPipeline<TConfiguration> : RequestPipeline
 		}
 	}
 
-	public override void ThrowNoNodesAttempted(RequestData requestData, List<PipelineException> seenExceptions)
+	public override void ThrowNoNodesAttempted(RequestData requestData, List<PipelineException>? seenExceptions)
 	{
 		var clientException = new TransportException(PipelineFailure.NoNodesAttempted, RequestPipelineStatics.NoNodesAttemptedMessage,
 			(Exception)null);

--- a/src/Elastic.Transport/Components/Pipeline/RequestPipeline.cs
+++ b/src/Elastic.Transport/Components/Pipeline/RequestPipeline.cs
@@ -90,12 +90,12 @@ public abstract class RequestPipeline : IDisposable
 	public abstract void BadResponse<TResponse>(ref TResponse response, ApiCallDetails callDetails, RequestData data, TransportException exception)
 		where TResponse : TransportResponse, new();
 
-	public abstract void ThrowNoNodesAttempted(RequestData requestData, List<PipelineException> seenExceptions);
+	public abstract void ThrowNoNodesAttempted(RequestData requestData, List<PipelineException>? seenExceptions);
 
 	public abstract void AuditCancellationRequested();
 
 	public abstract TransportException? CreateClientException<TResponse>(TResponse? response, ApiCallDetails? callDetails,
-		RequestData data, List<PipelineException> seenExceptions)
+		RequestData data, List<PipelineException>? seenExceptions)
 		where TResponse : TransportResponse, new();
 #pragma warning restore 1591
 

--- a/src/Elastic.Transport/DefaultHttpTransport.cs
+++ b/src/Elastic.Transport/DefaultHttpTransport.cs
@@ -193,7 +193,6 @@ public class DefaultHttpTransport<TConfiguration> : HttpTransport<TConfiguration
 				}
 				catch (PipelineException pipelineException) when (!pipelineException.Recoverable)
 				{
-					seenExceptions ??= new List<PipelineException>();
 					HandlePipelineException(ref response, pipelineException, pipeline, node, ref seenExceptions);
 					break;
 				}

--- a/src/Elastic.Transport/Exceptions/UnexpectedTransportException.cs
+++ b/src/Elastic.Transport/Exceptions/UnexpectedTransportException.cs
@@ -15,7 +15,7 @@ namespace Elastic.Transport;
 public class UnexpectedTransportException : TransportException
 {
 	/// <inheritdoc cref="UnexpectedTransportException"/>
-	public UnexpectedTransportException(Exception killerException, IReadOnlyCollection<PipelineException> seenExceptions)
+	public UnexpectedTransportException(Exception killerException, IReadOnlyCollection<PipelineException>? seenExceptions)
 		: base(PipelineFailure.Unexpected, killerException?.Message ?? "An unexpected exception occurred.", killerException) =>
 			SeenExceptions = seenExceptions ?? EmptyReadOnly<PipelineException>.Collection;
 


### PR DESCRIPTION
Fixes #90 

Removes allocation of empty `List<PipelineException>` when there are no exceptions to capture. This saves 2 objects and 56B per request.
