### PR TITLE
Refactor InMemoryConnection to InMemoryTransportClient

### DIFF
--- a/benchmarks/Elastic.Transport.Benchmarks/TransportBenchmarks.cs
+++ b/benchmarks/Elastic.Transport.Benchmarks/TransportBenchmarks.cs
@@ -15,7 +15,7 @@ namespace Elastic.Transport.Benchmarks
 		[GlobalSetup]
 		public void Setup()
 		{
-			var connection = new InMemoryConnection();
+			var connection = new InMemoryTransportClient();
 			var pool = new SingleNodePool(new Uri("http://localhost:9200"));
 			var settings = new TransportConfiguration(pool, connection);
 

--- a/src/Elastic.Transport.VirtualizedCluster/Audit/Auditor.cs
+++ b/src/Elastic.Transport.VirtualizedCluster/Audit/Auditor.cs
@@ -125,7 +125,7 @@ public sealed class Auditor
 		_cluster.ClientThrows(false);
 		AssertPoolBeforeCall?.Invoke(_cluster.ConnectionPool);
 
-		Action call = () => { Response = _cluster.ClientCall(callTrace?.RequestOverrides); };
+		var call = () => { Response = _cluster.ClientCall(callTrace?.RequestOverrides); };
 		call();
 
 		if (Response.ApiCallDetails.HasSuccessfulStatusCodeAndExpectedContentType) throw new Exception("Expected call to not be valid");
@@ -140,7 +140,7 @@ public sealed class Auditor
 
 		_clusterAsync ??= Cluster();
 		_clusterAsync.ClientThrows(false);
-		Func<Task> callAsync = async () => { ResponseAsync = await _clusterAsync.ClientCallAsync(callTrace?.RequestOverrides).ConfigureAwait(false); };
+		var callAsync = async () => { ResponseAsync = await _clusterAsync.ClientCallAsync(callTrace?.RequestOverrides).ConfigureAwait(false); };
 		await callAsync().ConfigureAwait(false);
 		if (Response.ApiCallDetails.HasSuccessfulStatusCodeAndExpectedContentType) throw new Exception("Expected call to not be valid");
 		exception = ResponseAsync.ApiCallDetails.OriginalException as TransportException;

--- a/src/Elastic.Transport.VirtualizedCluster/Components/SealedVirtualCluster.cs
+++ b/src/Elastic.Transport.VirtualizedCluster/Components/SealedVirtualCluster.cs
@@ -23,7 +23,7 @@ public sealed class SealedVirtualCluster
 	internal SealedVirtualCluster(VirtualCluster cluster, NodePool pool, TestableDateTimeProvider dateTimeProvider, MockProductRegistration productRegistration)
 	{
 		_connectionPool = pool;
-		_connection = new VirtualClusterConnection(cluster, dateTimeProvider);
+		_connection = new VirtualClusterTransportClient(cluster, dateTimeProvider);
 		_dateTimeProvider = dateTimeProvider;
 		_productRegistration = productRegistration;
 	}
@@ -44,7 +44,7 @@ public sealed class SealedVirtualCluster
 	/// Allows you to create an instance of `<see cref="VirtualClusterConnection"/> using the DSL provided by <see cref="Virtual"/>
 	/// </summary>
 	/// <param name="selector">Provide custom configuration options</param>
-	public VirtualClusterConnection VirtualClusterConnection(Func<TransportConfiguration, TransportConfiguration> selector = null) =>
+	public VirtualClusterTransportClient VirtualClusterConnection(Func<TransportConfiguration, TransportConfiguration> selector = null) =>
 		new VirtualizedCluster(_dateTimeProvider, selector == null ? CreateSettings() : selector(CreateSettings()))
 			.Connection;
 }

--- a/src/Elastic.Transport.VirtualizedCluster/Components/VirtualClusterConnection.cs
+++ b/src/Elastic.Transport.VirtualizedCluster/Components/VirtualClusterConnection.cs
@@ -30,7 +30,7 @@ namespace Elastic.Transport.VirtualizedCluster.Components;
 /// <see cref="SealedVirtualCluster.VirtualClusterConnection"/> becomes available
 /// </pre>
 /// </summary>
-public class VirtualClusterConnection : InMemoryConnection
+public class VirtualClusterTransportClient : InMemoryTransportClient
 {
 	private static readonly object Lock = new();
 
@@ -41,7 +41,7 @@ public class VirtualClusterConnection : InMemoryConnection
 	private MockProductRegistration _productRegistration;
 	private IDictionary<int, State> _calls = new Dictionary<int, State>();
 
-	internal VirtualClusterConnection(VirtualCluster cluster, TestableDateTimeProvider dateTimeProvider)
+	internal VirtualClusterTransportClient(VirtualCluster cluster, TestableDateTimeProvider dateTimeProvider)
 	{
 		UpdateCluster(cluster);
 		_dateTimeProvider = dateTimeProvider;
@@ -49,10 +49,10 @@ public class VirtualClusterConnection : InMemoryConnection
 	}
 
 	/// <summary>
-	/// Create a <see cref="VirtualClusterConnection"/> instance that always returns a successful response.
+	/// Create a <see cref="VirtualClusterTransportClient"/> instance that always returns a successful response.
 	/// </summary>
 	/// <param name="response">The bytes to be returned on every API call invocation</param>
-	public static VirtualClusterConnection Success(byte[] response) =>
+	public static VirtualClusterTransportClient Success(byte[] response) =>
 		Virtual.Elasticsearch
 			.Bootstrap(1)
 			.ClientCalls(r => r.SucceedAlways().ReturnByteResponse(response))
@@ -61,9 +61,9 @@ public class VirtualClusterConnection : InMemoryConnection
 			.Connection;
 
 	/// <summary>
-	/// Create a <see cref="VirtualClusterConnection"/> instance that always returns a failed response.
+	/// Create a <see cref="VirtualClusterTransportClient"/> instance that always returns a failed response.
 	/// </summary>
-	public static VirtualClusterConnection Error() =>
+	public static VirtualClusterTransportClient Error() =>
 		Virtual.Elasticsearch
 			.Bootstrap(1)
 			.ClientCalls(r => r.FailAlways(400))

--- a/src/Elastic.Transport.VirtualizedCluster/Components/VirtualizedCluster.cs
+++ b/src/Elastic.Transport.VirtualizedCluster/Components/VirtualizedCluster.cs
@@ -48,7 +48,7 @@ public class VirtualizedCluster
 		};
 	}
 
-	public VirtualClusterConnection Connection => Transport.Settings.Connection as VirtualClusterConnection;
+	public VirtualClusterTransportClient Connection => Transport.Settings.Connection as VirtualClusterTransportClient;
 	public NodePool ConnectionPool => Transport.Settings.NodePool;
 	public HttpTransport<ITransportConfiguration> Transport => _exposingRequestPipeline?.Transport;
 

--- a/src/Elastic.Transport.VirtualizedCluster/Products/MockProductRegistration.cs
+++ b/src/Elastic.Transport.VirtualizedCluster/Products/MockProductRegistration.cs
@@ -9,7 +9,7 @@ using Elastic.Transport.VirtualizedCluster.Components;
 namespace Elastic.Transport.VirtualizedCluster.Products;
 
 /// <summary>
-/// Makes sure <see cref="VirtualClusterConnection"/> is mockable by providing a different sniff response based on the current <see cref="ProductRegistration"/>
+/// Makes sure <see cref="VirtualClusterTransportClient"/> is mockable by providing a different sniff response based on the current <see cref="ProductRegistration"/>
 /// </summary>
 public abstract class MockProductRegistration
 {
@@ -28,7 +28,7 @@ public abstract class MockProductRegistration
 	public abstract byte[] CreateSniffResponseBytes(IReadOnlyList<Node> nodes, string stackVersion, string publishAddressOverride, bool returnFullyQualifiedDomainNames);
 
 	/// <summary>
-	/// see <see cref="VirtualClusterConnection.Request{TResponse}"/> uses this to determine if the current request is a sniff request and should follow
+	/// see <see cref="VirtualClusterTransportClient.Request{TResponse}"/> uses this to determine if the current request is a sniff request and should follow
 	/// the sniffing rules
 	/// </summary>
 	public abstract bool IsSniffRequest(RequestData requestData);

--- a/src/Elastic.Transport/Components/TransportClient/InMemoryTransportClient.cs
+++ b/src/Elastic.Transport/Components/TransportClient/InMemoryTransportClient.cs
@@ -15,7 +15,7 @@ namespace Elastic.Transport;
 /// <summary>
 /// An implementation of <see cref="TransportClient"/> designed to not actually do any IO and services requests from an in memory byte buffer
 /// </summary>
-public class InMemoryConnection : TransportClient
+public class InMemoryTransportClient : TransportClient
 {
 	private static readonly byte[] EmptyBody = Encoding.UTF8.GetBytes("");
 	private readonly string _contentType;
@@ -28,10 +28,10 @@ public class InMemoryConnection : TransportClient
 	/// Every request will succeed with this overload, note that it won't actually return mocked responses
 	/// so using this overload might fail if you are using it to test high level bits that need to deserialize the response.
 	/// </summary>
-	public InMemoryConnection() => _statusCode = 200;
+	public InMemoryTransportClient() => _statusCode = 200;
 
-	/// <inheritdoc cref="InMemoryConnection"/>
-	public InMemoryConnection(byte[] responseBody, int statusCode = 200, Exception exception = null, string contentType = RequestData.DefaultMimeType, Dictionary<string, IEnumerable<string>> headers = null)
+	/// <inheritdoc cref="InMemoryTransportClient"/>
+	public InMemoryTransportClient(byte[] responseBody, int statusCode = 200, Exception exception = null, string contentType = RequestData.DefaultMimeType, Dictionary<string, IEnumerable<string>> headers = null)
 	{
 		_responseBody = responseBody;
 		_statusCode = statusCode;

--- a/tests/Elastic.Transport.Tests/Plumbing/InMemoryConnectionFactory.cs
+++ b/tests/Elastic.Transport.Tests/Plumbing/InMemoryConnectionFactory.cs
@@ -10,7 +10,7 @@ namespace Elastic.Transport.Tests.Plumbing
 	{
 		public static TransportConfiguration Create()
 		{
-			var connection = new InMemoryConnection();
+			var connection = new InMemoryTransportClient();
 			var pool = new SingleNodePool(new Uri("http://localhost:9200"));
 			var settings = new TransportConfiguration(pool, connection);
 			return settings;

--- a/tests/Elastic.Transport.Tests/VolatileUpdates.cs
+++ b/tests/Elastic.Transport.Tests/VolatileUpdates.cs
@@ -26,7 +26,7 @@ namespace Elastic.Transport.Tests
 			var uris = Enumerable.Range(9200, _numberOfNodes).Select(p => new Uri("http://localhost:" + p));
 			var sniffingPool = new SniffingNodePool(uris, false);
 
-			Action callSniffing = () => AssertCreateView(sniffingPool);
+			var callSniffing = () => AssertCreateView(sniffingPool);
 
 			callSniffing.Should().NotThrow();
 		}
@@ -36,7 +36,7 @@ namespace Elastic.Transport.Tests
 			var uris = Enumerable.Range(9200, _numberOfNodes).Select(p => new Uri("http://localhost:" + p));
 			var staticPool = new StaticNodePool(uris, false);
 
-			Action callStatic = () => AssertCreateView(staticPool);
+			var callStatic = () => AssertCreateView(staticPool);
 
 			callStatic.Should().NotThrow();
 		}
@@ -54,13 +54,9 @@ namespace Elastic.Transport.Tests
 		private Thread CreateReadAndUpdateThread(NodePool pool) => new Thread(() =>
 		{
 			for (var i = 0; i < 1000; i++)
-			{
 				foreach (var _ in CallGetNext(pool))
-				{
 					if (_random.Next(10) % 2 == 0)
 						pool.Reseed(_update);
-				}
-			}
 		});
 
 		private IEnumerable<int> CallGetNext(NodePool pool)


### PR DESCRIPTION
Renamed occurrences of `InMemoryConnection` to `InMemoryTransportClient` and `VirtualClusterConnection` to `VirtualClusterTransportClient`. This change provides a more accurate naming of the classes, reflecting the base component they implement.
