### PR TITLE
Ensure ResponseBuilder is new()'ed only once

### DIFF
--- a/src/Elastic.Transport/Components/Pipeline/ResponseBuilder.cs
+++ b/src/Elastic.Transport/Components/Pipeline/ResponseBuilder.cs
@@ -17,6 +17,9 @@ namespace Elastic.Transport;
 /// </summary>
 public abstract class ResponseBuilder
 {
+	/// <summary> Exposes a default response builder to implementers without sharing more internal types to handle empty errors</summary>
+	public static ResponseBuilder Default { get; } = new DefaultResponseBuilder<EmptyError>();
+
 	/// <summary>
 	/// Create an instance of <typeparamref name="TResponse" /> from <paramref name="responseStream" />
 	/// </summary>

--- a/src/Elastic.Transport/Products/DefaultProductRegistration.cs
+++ b/src/Elastic.Transport/Products/DefaultProductRegistration.cs
@@ -51,9 +51,6 @@ public sealed class DefaultProductRegistration : ProductRegistration
 	/// <inheritdoc cref="ProductRegistration.MetaHeaderProvider"/>
 	public override MetaHeaderProvider MetaHeaderProvider => _metaHeaderProvider;
 
-	/// <inheritdoc cref="ProductRegistration.ResponseBuilder"/>
-	public override ResponseBuilder ResponseBuilder { get; } = new DefaultResponseBuilder<EmptyError>();
-
 	/// <inheritdoc cref="ProductRegistration.DefaultMimeType"/>
 	public override string DefaultMimeType => null;
 

--- a/src/Elastic.Transport/Products/DefaultProductRegistration.cs
+++ b/src/Elastic.Transport/Products/DefaultProductRegistration.cs
@@ -20,24 +20,24 @@ public sealed class DefaultProductRegistration : ProductRegistration
 	private readonly MetaHeaderProvider _metaHeaderProvider;
 
 	/// <summary>
-	/// 
+	///
 	/// </summary>
 	public DefaultProductRegistration() => _metaHeaderProvider = new DefaultMetaHeaderProvider(typeof(HttpTransport), ServiceIdentifier);
 
 	/// <summary> A static instance of <see cref="DefaultProductRegistration"/> to promote reuse </summary>
-	public static DefaultProductRegistration Default { get; } = new DefaultProductRegistration();
+	public static DefaultProductRegistration Default { get; } = new();
 
 	/// <inheritdoc cref="ProductRegistration.Name"/>
-	public override string Name { get; } = "elastic-transport-net";
+	public override string Name => "elastic-transport-net";
 
 	/// <inheritdoc cref="ProductRegistration.ServiceIdentifier"/>
 	public override string? ServiceIdentifier => "et";
 
 	/// <inheritdoc cref="ProductRegistration.SupportsPing"/>
-	public override bool SupportsPing { get; } = false;
+	public override bool SupportsPing => false;
 
 	/// <inheritdoc cref="ProductRegistration.SupportsSniff"/>
-	public override bool SupportsSniff { get; } = false;
+	public override bool SupportsSniff => false;
 
 	/// <inheritdoc cref="ProductRegistration.SniffOrder"/>
 	public override int SniffOrder(Node node) => -1;
@@ -52,7 +52,7 @@ public sealed class DefaultProductRegistration : ProductRegistration
 	public override MetaHeaderProvider MetaHeaderProvider => _metaHeaderProvider;
 
 	/// <inheritdoc cref="ProductRegistration.ResponseBuilder"/>
-	public override ResponseBuilder ResponseBuilder => new DefaultResponseBuilder<EmptyError>();
+	public override ResponseBuilder ResponseBuilder { get; } = new DefaultResponseBuilder<EmptyError>();
 
 	/// <inheritdoc cref="ProductRegistration.DefaultMimeType"/>
 	public override string DefaultMimeType => null;

--- a/src/Elastic.Transport/Products/ProductRegistration.cs
+++ b/src/Elastic.Transport/Products/ProductRegistration.cs
@@ -110,12 +110,12 @@ public abstract class ProductRegistration
 	public abstract bool TryGetServerErrorReason<TResponse>(TResponse response, out string reason) where TResponse : TransportResponse;
 
 	/// <summary>
-	/// TODO
+	/// Allows product implementations to inject a metadata header to all outgoing requests
 	/// </summary>
 	public abstract MetaHeaderProvider MetaHeaderProvider { get; }
 
 	/// <summary>
-	/// TODO
+	/// Allows product implementations to take full control of building transport responses if needed.
 	/// </summary>
-	public abstract ResponseBuilder ResponseBuilder { get; }
+	public virtual ResponseBuilder ResponseBuilder => ResponseBuilder.Default;
 }

--- a/src/Elastic.Transport/Requests/MetaData/MetaHeaderProvider.cs
+++ b/src/Elastic.Transport/Requests/MetaData/MetaHeaderProvider.cs
@@ -5,19 +5,13 @@
 namespace Elastic.Transport;
 
 /// <summary>
-/// TODO
+/// Injects a metadata header into all outgoing requests
 /// </summary>
 public abstract class MetaHeaderProvider
 {
-	/// <summary>
-	/// 
-	/// </summary>
+	/// <summary>Header name </summary>
 	public abstract string HeaderName { get; }
 
-	/// <summary>
-	/// TODO
-	/// </summary>
-	/// <param name="requestData"></param>
-	/// <returns></returns>
+	/// <summary> Produces the header value based on current outgoing <paramref name="requestData"/> </summary>
 	public abstract string ProduceHeaderValue(RequestData requestData);
 }


### PR DESCRIPTION
In most cases this already only gets read once but that puts the onus on the reader.
