### PR TITLE
Refactor OTel instrumentation

### DIFF
--- a/Playground/Playground.csproj
+++ b/Playground/Playground.csproj
@@ -8,11 +8,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.0.4" />
+    <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.9.2" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\src\Elastic.Transport\Elastic.Transport.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="Microsoft.NETFramework.ReferenceAssemblies.net461" Version="1.0.3" />
   </ItemGroup>
 
 </Project>

--- a/benchmarks/Elastic.Transport.Benchmarks/Elastic.Transport.Benchmarks.csproj
+++ b/benchmarks/Elastic.Transport.Benchmarks/Elastic.Transport.Benchmarks.csproj
@@ -16,4 +16,8 @@
     <ProjectReference Include="..\..\src\Elastic.Transport\Elastic.Transport.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Update="Microsoft.NETFramework.ReferenceAssemblies.net461" Version="1.0.3" />
+  </ItemGroup>
+
 </Project>

--- a/benchmarks/Elastic.Transport.Profiling/Elastic.Transport.Profiling.csproj
+++ b/benchmarks/Elastic.Transport.Profiling/Elastic.Transport.Profiling.csproj
@@ -13,4 +13,8 @@
     <ProjectReference Include="..\..\src\Elastic.Transport\Elastic.Transport.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Update="Microsoft.NETFramework.ReferenceAssemblies.net461" Version="1.0.3" />
+  </ItemGroup>
+
 </Project>

--- a/benchmarks/Elastic.Transport.Profiling/Program.cs
+++ b/benchmarks/Elastic.Transport.Profiling/Program.cs
@@ -16,7 +16,9 @@ namespace Elastic.Transport.Profiling
 			MemoryProfiler.CollectAllocations(true);
 			MemoryProfiler.GetSnapshot("start");
 
-			var config = new TransportConfiguration(new Uri("http://localhost:9200"), new ElasticsearchProductRegistration());
+			var config = new TransportConfiguration(new Uri("http://localhost:9200"),
+				new ElasticsearchProductRegistration(typeof(ElasticsearchProductRegistration)));
+
 			var transport = new DefaultHttpTransport(config);
 
 			// WARMUP

--- a/build/scripts/scripts.fsproj
+++ b/build/scripts/scripts.fsproj
@@ -19,4 +19,8 @@
     <Compile Include="Program.fs" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Update="Microsoft.NETFramework.ReferenceAssemblies.net461" Version="1.0.3" />
+  </ItemGroup>
+
 </Project>

--- a/src/Elastic.Transport.VirtualizedCluster/Elastic.Transport.VirtualizedCluster.csproj
+++ b/src/Elastic.Transport.VirtualizedCluster/Elastic.Transport.VirtualizedCluster.csproj
@@ -15,4 +15,8 @@
   <ItemGroup>
     <ProjectReference Include="..\Elastic.Transport\Elastic.Transport.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Update="Microsoft.NETFramework.ReferenceAssemblies.net461" Version="1.0.3" />
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.1.1" />
+  </ItemGroup>
 </Project>

--- a/src/Elastic.Transport/Components/NodePool/StaticNodePool.cs
+++ b/src/Elastic.Transport/Components/NodePool/StaticNodePool.cs
@@ -69,6 +69,7 @@ public class StaticNodePool : NodePool
 				UsingSsl = scheme == "https";
 			}
 			else if (scheme != node.Uri.Scheme)
+				// TODO - Diagnostic event here
 				throw new ArgumentException("Trying to instantiate a connection pool with mixed URI Schemes");
 		}
 

--- a/src/Elastic.Transport/Components/Pipeline/DefaultRequestPipeline.cs
+++ b/src/Elastic.Transport/Components/Pipeline/DefaultRequestPipeline.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Threading;
@@ -13,10 +12,6 @@ using Elastic.Transport.Diagnostics.Auditing;
 using Elastic.Transport.Extensions;
 using Elastic.Transport.Products;
 using static Elastic.Transport.Diagnostics.Auditing.AuditEvent;
-
-//#if NETSTANDARD2_0 || NETSTANDARD2_1
-//using System.Threading.Tasks.Extensions;
-//#endif
 
 namespace Elastic.Transport;
 
@@ -33,10 +28,8 @@ public class DefaultRequestPipeline<TConfiguration> : RequestPipeline
 	private readonly TConfiguration _settings;
 	private readonly ResponseBuilder _responseBuilder;
 
-	private static readonly ActivitySource _activitySource = new("Elastic.Transport.RequestPipeline");
-
 	private RequestConfiguration? _pingAndSniffRequestConfiguration;
-	private List<Audit> _auditTrail = null;
+	private List<Audit> _auditTrail = null;	
 
 	/// <inheritdoc cref="RequestPipeline" />
 	internal DefaultRequestPipeline(
@@ -174,34 +167,27 @@ public class DefaultRequestPipeline<TConfiguration> : RequestPipeline
 	}
 
 	public override TResponse CallProductEndpoint<TResponse>(RequestData requestData)
+		=> CallProductEndpointCoreAsync<TResponse>(false, requestData).EnsureCompleted();
+
+	public override Task<TResponse> CallProductEndpointAsync<TResponse>(RequestData requestData, CancellationToken cancellationToken = default)
+		=> CallProductEndpointCoreAsync<TResponse>(true, requestData, cancellationToken).AsTask();
+
+	private async ValueTask<TResponse> CallProductEndpointCoreAsync<TResponse>(bool isAsync, RequestData requestData, CancellationToken cancellationToken = default)
+		where TResponse : TransportResponse, new()
 	{
 		using var audit = Audit(HealthyResponse, requestData.Node);
 
 		if (audit is not null)
 			audit.PathAndQuery = requestData.PathAndQuery;
 
-		var activity = Activity.Current;
-		var isElasticClient = activity is not null && activity.GetCustomProperty("elastic.transport.client") is not null;
-
-		if (!isElasticClient)
-		{
-			activity = _activitySource.StartActivity($"Elastic.Transport: HTTP {requestData.Method}", ActivityKind.Client);
-		}
-
-		activity?.AddTag("http.method", requestData.Method);
-		activity?.AddTag("http.url", requestData.Uri.AbsoluteUri);
-		activity?.AddTag("net.peer.name", requestData.Uri.Host);
-		activity?.AddTag("net.peer.port", requestData.Uri.Port);
-
 		try
 		{
-			var response = _transportClient.Request<TResponse>(requestData);
+			TResponse response;
 
-#if NET6_0_OR_GREATER
-			activity?.SetStatus(response.ApiCallDetails.HasSuccessfulStatusCodeAndExpectedContentType ? ActivityStatusCode.Ok : ActivityStatusCode.Error);
-#endif
-
-			activity?.AddTag("http.status_code", response.ApiCallDetails.HttpStatusCode);
+			if (isAsync)
+				response = await _transportClient.RequestAsync<TResponse>(requestData, cancellationToken).ConfigureAwait(false);
+			else
+				response = _transportClient.Request<TResponse>(requestData);
 
 			response.ApiCallDetails.AuditTrail = AuditTrail;
 
@@ -217,63 +203,6 @@ public class DefaultRequestPipeline<TConfiguration> : RequestPipeline
 			audit.Event = requestData.OnFailureAuditEvent;
 			audit.Exception = e;
 			throw;
-		}
-		finally
-		{
-			if (!isElasticClient)
-				activity?.Dispose();
-		}
-	}
-
-	public override async Task<TResponse> CallProductEndpointAsync<TResponse>(RequestData requestData, CancellationToken cancellationToken)
-	{
-		using var audit = Audit(HealthyResponse, requestData.Node);
-
-		if (audit is not null)
-			audit.PathAndQuery = requestData.PathAndQuery;
-
-		var activity = Activity.Current;
-		var isElasticClient = activity is not null && activity.GetCustomProperty("elastic.transport.client") is not null;
-
-		if (!isElasticClient)
-		{
-			activity = _activitySource.StartActivity($"Elastic.Transport: HTTP {requestData.Method}", ActivityKind.Client);
-		}
-
-		activity?.AddTag("http.method", requestData.Method);
-		activity?.AddTag("http.url", requestData.Uri.AbsoluteUri);
-		activity?.AddTag("net.peer.name", requestData.Uri.Host);
-		activity?.AddTag("net.peer.port", requestData.Uri.Port);
-
-		try
-		{
-			var response = await _transportClient.RequestAsync<TResponse>(requestData, cancellationToken).ConfigureAwait(false);
-
-#if NET6_0_OR_GREATER
-			activity?.SetStatus(response.ApiCallDetails.HasSuccessfulStatusCodeAndExpectedContentType ? ActivityStatusCode.Ok : ActivityStatusCode.Error);
-#endif
-
-			activity?.AddTag("http.status_code", response.ApiCallDetails.HttpStatusCode);
-
-			response.ApiCallDetails.AuditTrail = AuditTrail;
-
-			ThrowBadAuthPipelineExceptionWhenNeeded(response.ApiCallDetails, response);
-
-			if (!response.ApiCallDetails.HasSuccessfulStatusCodeAndExpectedContentType && audit is not null)
-				audit.Event = requestData.OnFailureAuditEvent;
-
-			return response;
-		}
-		catch (Exception e) when (audit is not null)
-		{
-			audit.Event = requestData.OnFailureAuditEvent;
-			audit.Exception = e;
-			throw;
-		}
-		finally
-		{
-			if (!isElasticClient)
-				activity?.Dispose();
 		}
 	}
 
@@ -459,7 +388,12 @@ public class DefaultRequestPipeline<TConfiguration> : RequestPipeline
 		}
 	}
 
-	public override void Ping(Node node)
+	public override void Ping(Node node) => PingCoreAsync(false, node).EnsureCompleted();
+
+	public override Task PingAsync(Node node, CancellationToken cancellationToken = default)
+		=> PingCoreAsync(true, node, cancellationToken).AsTask();
+
+	public async ValueTask PingCoreAsync(bool isAsync, Node node, CancellationToken cancellationToken = default)
 	{
 		if (!_productRegistration.SupportsPing) return;
 		if (PingDisabled(node)) return;
@@ -471,9 +405,14 @@ public class DefaultRequestPipeline<TConfiguration> : RequestPipeline
 		if (audit is not null)
 			audit.PathAndQuery = pingData.PathAndQuery;
 
+		TransportResponse response;
+
 		try
 		{
-			var response = _productRegistration.Ping(_transportClient, pingData);
+			if (isAsync)
+				response = await _productRegistration.PingAsync(_transportClient, pingData, cancellationToken).ConfigureAwait(false);
+			else
+				response = _productRegistration.Ping(_transportClient, pingData);
 
 			ThrowBadAuthPipelineExceptionWhenNeeded(response.ApiCallDetails);
 
@@ -483,8 +422,7 @@ public class DefaultRequestPipeline<TConfiguration> : RequestPipeline
 		}
 		catch (Exception e)
 		{
-			var response = (e as PipelineException)?.Response;
-
+			response = (e as PipelineException)?.Response;
 			if (audit is not null)
 			{
 				audit.Event = PingFailure;
@@ -494,41 +432,12 @@ public class DefaultRequestPipeline<TConfiguration> : RequestPipeline
 		}
 	}
 
-	public override async Task PingAsync(Node node, CancellationToken cancellationToken)
-	{
-		if (!_productRegistration.SupportsPing) return;
-		if (PingDisabled(node)) return;
+	public override void Sniff() => SniffCoreAsync(false).EnsureCompleted();
 
-		var pingData = _productRegistration.CreatePingRequestData(node, PingAndSniffRequestConfiguration, _settings, _memoryStreamFactory);
+	public override Task SniffAsync(CancellationToken cancellationToken = default)
+		=> SniffCoreAsync(true, cancellationToken).AsTask();
 
-		using var audit = Audit(PingSuccess, node);
-
-		if (audit is not null)
-			audit.PathAndQuery = pingData.PathAndQuery;
-
-		try
-		{
-			var response = await _productRegistration.PingAsync(_transportClient, pingData, cancellationToken).ConfigureAwait(false);
-
-			ThrowBadAuthPipelineExceptionWhenNeeded(response.ApiCallDetails);
-
-			//ping should not silently accept bad but valid http responses
-			if (!response.ApiCallDetails.HasSuccessfulStatusCodeAndExpectedContentType)
-				throw new PipelineException(pingData.OnFailurePipelineFailure, response.ApiCallDetails.OriginalException) { Response = response };
-		}
-		catch (Exception e)
-		{
-			var response = (e as PipelineException)?.Response;
-			if (audit is not null)
-			{
-				audit.Event = PingFailure;
-				audit.Exception = e;
-			}
-			throw new PipelineException(PipelineFailure.PingFailure, e) { Response = response };
-		}
-	}
-
-	public override void Sniff()
+	public async ValueTask SniffCoreAsync(bool isAsync, CancellationToken cancellationToken = default)
 	{
 		if (!_productRegistration.SupportsSniff) return;
 
@@ -544,18 +453,27 @@ public class DefaultRequestPipeline<TConfiguration> : RequestPipeline
 			if (audit is not null)
 				audit.PathAndQuery = requestData.PathAndQuery;
 
+			Tuple<TransportResponse, IReadOnlyCollection<Node>> result;
+
 			try
 			{
-				var (response, nodes) = _productRegistration.Sniff(_transportClient, _nodePool.UsingSsl, requestData);
+				if (isAsync)
+					result = await _productRegistration
+						.SniffAsync(_transportClient, _nodePool.UsingSsl, requestData, cancellationToken)
+						.ConfigureAwait(false);
+				else
+					result = _productRegistration
+						.Sniff(_transportClient, _nodePool.UsingSsl, requestData);
 
-				ThrowBadAuthPipelineExceptionWhenNeeded(response.ApiCallDetails);
+				ThrowBadAuthPipelineExceptionWhenNeeded(result.Item1.ApiCallDetails);
 
 				//sniff should not silently accept bad but valid http responses
-				if (!response.ApiCallDetails.HasSuccessfulStatusCodeAndExpectedContentType)
-					throw new PipelineException(requestData.OnFailurePipelineFailure, response.ApiCallDetails.OriginalException) { Response = response };
+				if (!result.Item1.ApiCallDetails.HasSuccessfulStatusCodeAndExpectedContentType)
+					throw new PipelineException(requestData.OnFailurePipelineFailure, result.Item1.ApiCallDetails.OriginalException) { Response = result.Item1 };
 
-				_nodePool.Reseed(nodes);
+				_nodePool.Reseed(result.Item2);
 				Refresh = true;
+
 				return;
 			}
 			catch (Exception e)
@@ -567,55 +485,9 @@ public class DefaultRequestPipeline<TConfiguration> : RequestPipeline
 				}
 				exceptions.Add(e);
 			}
+
+			throw new PipelineException(PipelineFailure.SniffFailure, exceptions.AsAggregateOrFirst());
 		}
-
-		throw new PipelineException(PipelineFailure.SniffFailure, exceptions.AsAggregateOrFirst());
-	}
-
-	public override async Task SniffAsync(CancellationToken cancellationToken)
-	{
-		if (!_productRegistration.SupportsSniff) return;
-
-		var exceptions = new List<Exception>();
-
-		foreach (var node in SniffNodes)
-		{
-			var requestData =
-				_productRegistration.CreateSniffRequestData(node, PingAndSniffRequestConfiguration, _settings, _memoryStreamFactory);
-
-			using var audit = Audit(SniffSuccess, node);
-
-			if (audit is not null)
-				audit.PathAndQuery = requestData.PathAndQuery;
-
-			try
-			{
-				var (response, nodes) = await _productRegistration
-					.SniffAsync(_transportClient, _nodePool.UsingSsl, requestData, cancellationToken)
-					.ConfigureAwait(false);
-
-				ThrowBadAuthPipelineExceptionWhenNeeded(response.ApiCallDetails);
-
-				//sniff should not silently accept bad but valid http responses
-				if (!response.ApiCallDetails.HasSuccessfulStatusCodeAndExpectedContentType)
-					throw new PipelineException(requestData.OnFailurePipelineFailure, response.ApiCallDetails.OriginalException) { Response = response };
-
-				_nodePool.Reseed(nodes);
-				Refresh = true;
-				return;
-			}
-			catch (Exception e)
-			{
-				if (audit is not null)
-				{
-					audit.Event = SniffFailure;
-					audit.Exception = e;
-				}
-				exceptions.Add(e);
-			}
-		}
-
-		throw new PipelineException(PipelineFailure.SniffFailure, exceptions.AsAggregateOrFirst());
 	}
 
 	public override void SniffOnConnectionFailure()

--- a/src/Elastic.Transport/Components/Pipeline/DefaultRequestPipeline.cs
+++ b/src/Elastic.Transport/Components/Pipeline/DefaultRequestPipeline.cs
@@ -97,7 +97,7 @@ public class DefaultRequestPipeline<TConfiguration> : RequestPipeline
 			var timeout = _settings.MaxRetryTimeout.GetValueOrDefault(RequestTimeout);
 			var now = _dateTimeProvider.Now();
 
-			//we apply a soft margin so that if a request timesout at 59 seconds when the maximum is 60 we also abort.
+			//we apply a soft margin so that if a request times out at 59 seconds when the maximum is 60 we also abort.
 			var margin = timeout.TotalMilliseconds / 100.0 * 98;
 			var marginTimeSpan = TimeSpan.FromMilliseconds(margin);
 			var timespanCall = now - StartedOn;

--- a/src/Elastic.Transport/Components/Pipeline/RequestData.cs
+++ b/src/Elastic.Transport/Components/Pipeline/RequestData.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Security.Cryptography.X509Certificates;
+using Elastic.Transport.Diagnostics;
 using Elastic.Transport.Diagnostics.Auditing;
 using Elastic.Transport.Extensions;
 
@@ -35,11 +36,13 @@ public sealed class RequestData
 		PostData data,
 		ITransportConfiguration global,
 		RequestParameters local,
-		MemoryStreamFactory memoryStreamFactory
+		MemoryStreamFactory memoryStreamFactory,
+		OpenTelemetryData openTelemetryData
 	)
 		: this(method, data, global, local?.RequestConfiguration, memoryStreamFactory)
 	{
 		_path = path;
+		OpenTelemetryData = openTelemetryData;
 		CustomResponseBuilder = local?.CustomResponseBuilder;
 		PathAndQuery = CreatePathWithQueryStrings(path, ConnectionSettings, local);
 	}
@@ -191,6 +194,7 @@ public sealed class RequestData
 	public IReadOnlyDictionary<string, string> RequestMetaData { get; }
 
 	public bool IsAsync { get; internal set; }
+	internal OpenTelemetryData OpenTelemetryData { get; }
 
 	public override string ToString() => $"{Method.GetStringValue()} {_path}";
 

--- a/src/Elastic.Transport/Components/TransportClient/HttpMethod.cs
+++ b/src/Elastic.Transport/Components/TransportClient/HttpMethod.cs
@@ -2,6 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using System;
 using System.Runtime.Serialization;
 
 // ReSharper disable InconsistentNaming
@@ -28,4 +29,24 @@ public enum HttpMethod
 	[EnumMember(Value = "HEAD")]
 	HEAD
 #pragma warning restore 1591
+}
+
+/// <summary>
+/// Defines extension methods for <see cref="HttpMethod"/>.
+/// </summary>
+public static class HttpMethodExtensions
+{
+	/// <summary>
+	/// Returns the string value for a given <see cref="HttpMethod"/>.
+	/// </summary>
+	public static string GetStringValue(this HttpMethod httpMethod) =>
+		httpMethod switch
+		{
+			HttpMethod.GET => "GET",
+			HttpMethod.POST => "POST",
+			HttpMethod.PUT => "PUT",
+			HttpMethod.DELETE => "DELETE",
+			HttpMethod.HEAD => "HEAD",
+			_ => throw new InvalidOperationException("Unknown enum value.")
+		};
 }

--- a/src/Elastic.Transport/Components/TransportClient/HttpTransportClient.cs
+++ b/src/Elastic.Transport/Components/TransportClient/HttpTransportClient.cs
@@ -156,9 +156,13 @@ public class HttpTransportClient : TransportClient
 			if (OpenTelemetry.CurrentSpanIsElasticTransportOwnedAndHasListeners && (Activity.Current?.IsAllDataRequested ?? false))
 			{
 				var attributes = requestData.ConnectionSettings.ProductRegistration.ParseOpenTelemetryAttributesFromApiCallDetails(response.ApiCallDetails);
-				foreach (var attribute in attributes)
+
+				if (attributes is not null)
 				{
-					Activity.Current?.SetTag(attribute.Key, attribute.Value);
+					foreach (var attribute in attributes)
+					{
+						Activity.Current?.SetTag(attribute.Key, attribute.Value);
+					}
 				}
 			}
 

--- a/src/Elastic.Transport/Configuration/RequestConfiguration.cs
+++ b/src/Elastic.Transport/Configuration/RequestConfiguration.cs
@@ -11,7 +11,7 @@ using Elastic.Transport.Extensions;
 namespace Elastic.Transport;
 
 /// <summary>
-/// Allows you to inject per <see cref="HttpTransport.Request{TResponse}"/> overrides to the current <see cref="ITransportConfiguration"/>.
+/// Allows you to inject per request overrides to the current <see cref="ITransportConfiguration"/>.
 /// </summary>
 public interface IRequestConfiguration
 {

--- a/src/Elastic.Transport/Configuration/Security/BasicAuthenticationCredentials.cs
+++ b/src/Elastic.Transport/Configuration/Security/BasicAuthenticationCredentials.cs
@@ -18,11 +18,15 @@ public sealed class BasicAuthentication : AuthorizationHeader
 	public static string BasicAuthenticationScheme { get; } = "Basic";
 
 	/// <inheritdoc cref="BasicAuthentication"/>
-	public BasicAuthentication(string username, string password) =>
+	public BasicAuthentication(string username, string password)
+	{
 		_base64String = GetBase64String($"{username}:{password}");
+		Username = username;
+	}
 
 	/// <inheritdoc cref="AuthorizationHeader.AuthScheme"/>
 	public override string AuthScheme { get; } = BasicAuthenticationScheme;
+	internal string Username { get; }
 
 	/// <inheritdoc cref="AuthorizationHeader.TryGetAuthorizationParameters(out string)"/>
 	public override bool TryGetAuthorizationParameters(out string value)

--- a/src/Elastic.Transport/Configuration/UserAgent.cs
+++ b/src/Elastic.Transport/Configuration/UserAgent.cs
@@ -31,7 +31,7 @@ public sealed class UserAgent
 
 	private UserAgent(string fullUserAgentString) => _toString = fullUserAgentString;
 
-	/// <summary> Create a user agent that adhers to the minimum information needed to be elastic standard compliant </summary>
+	/// <summary> Create a user agent that adheres to the minimum information needed to be elastic standard compliant </summary>
 	/// <param name="reposName">The repos name uniquely identifies the origin of the client</param>
 	/// <param name="typeVersionLookup">
 	/// Use <see cref="Type"/>'s assembly <see cref="AssemblyInformationalVersionAttribute"/>
@@ -45,7 +45,7 @@ public sealed class UserAgent
 	/// <summary> Create a user string that does not confirm to elastic client standards </summary>
 	public static UserAgent Create(string fullUserAgentString) => new UserAgent(fullUserAgentString);
 
-	/// <summary> The precalculated string representation of this <see cref="UserAgent"/> instance </summary>
+	/// <summary> The pre=calculated string representation of this <see cref="UserAgent"/> instance </summary>
 	/// <returns></returns>
 	public override string ToString() => _toString;
 }

--- a/src/Elastic.Transport/DefaultHttpTransport.cs
+++ b/src/Elastic.Transport/DefaultHttpTransport.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Elastic.Transport.Diagnostics;
 using Elastic.Transport.Extensions;
 using Elastic.Transport.Products;
 
@@ -117,7 +118,7 @@ public class DefaultHttpTransport<TConfiguration> : HttpTransport<TConfiguration
 		_productRegistration = configurationValues.ProductRegistration;
 		Settings = configurationValues;
 		PipelineProvider = pipelineProvider ?? new DefaultRequestPipelineFactory<TConfiguration>();
-		DateTimeProvider = dateTimeProvider ?? Elastic.Transport.DefaultDateTimeProvider.Default;
+		DateTimeProvider = dateTimeProvider ?? DefaultDateTimeProvider.Default;
 		MemoryStreamFactory = memoryStreamFactory ?? configurationValues.MemoryStreamFactory;
 	}
 
@@ -130,16 +131,13 @@ public class DefaultHttpTransport<TConfiguration> : HttpTransport<TConfiguration
 	/// </summary>
 	public override TConfiguration Settings { get; }
 
-	/// <summary>
-	///
-	/// </summary>
-	/// <typeparam name="TResponse"></typeparam>
-	/// <param name="method"></param>
-	/// <param name="path"></param>
-	/// <param name="data"></param>
-	/// <param name="requestParameters"></param>
-	/// <returns></returns>
-	public override TResponse Request<TResponse>(HttpMethod method, string path, PostData? data = null, RequestParameters? requestParameters = null)
+	/// <inheritdoc cref="HttpTransport.Request{TResponse}(HttpMethod, string, PostData?, RequestParameters?, OpenTelemetryData)"/>
+	public override TResponse Request<TResponse>(
+		HttpMethod method,
+		string path,
+		PostData? data,
+		RequestParameters? requestParameters,
+		OpenTelemetryData openTelemetryData)
 	{
 		using var pipeline =
 			PipelineProvider.Create(Settings, DateTimeProvider, MemoryStreamFactory, requestParameters);
@@ -214,19 +212,13 @@ public class DefaultHttpTransport<TConfiguration> : HttpTransport<TConfiguration
 		return FinalizeResponse(requestData, pipeline, seenExceptions, response);
 	}
 
-	/// <summary>
-	///
-	/// </summary>
-	/// <typeparam name="TResponse"></typeparam>
-	/// <param name="method"></param>
-	/// <param name="path"></param>
-	/// <param name="data"></param>
-	/// <param name="requestParameters"></param>
-	/// <param name="cancellationToken"></param>
-	/// <returns></returns>
-	/// <exception cref="UnexpectedTransportException"></exception>
-	public override async Task<TResponse> RequestAsync<TResponse>(HttpMethod method, string path,
-		PostData? data = null, RequestParameters? requestParameters = null,
+	/// <inheritdoc cref="HttpTransport.RequestAsync{TResponse}(HttpMethod, string, PostData?, RequestParameters?, OpenTelemetryData, CancellationToken)"/>
+	public override async Task<TResponse> RequestAsync<TResponse>(
+		HttpMethod method,
+		string path,
+		PostData? data,
+		RequestParameters? requestParameters,
+		OpenTelemetryData openTelemetryData,
 		CancellationToken cancellationToken = default)
 	{
 		using var pipeline =
@@ -318,6 +310,7 @@ public class DefaultHttpTransport<TConfiguration> : HttpTransport<TConfiguration
 
 		return FinalizeResponse(requestData, pipeline, seenExceptions, response);
 	}
+
 	private static void ThrowUnexpectedTransportException<TResponse>(Exception killerException,
 		List<PipelineException> seenExceptions,
 		RequestData requestData,

--- a/src/Elastic.Transport/DefaultHttpTransport.cs
+++ b/src/Elastic.Transport/DefaultHttpTransport.cs
@@ -168,7 +168,7 @@ public class DefaultHttpTransport<TConfiguration> : HttpTransport<TConfiguration
 		else
 			pipeline.FirstPoolUsage(Settings.BootstrapLock);
 
-		var requestData = new RequestData(method, path, data, Settings, requestParameters, MemoryStreamFactory);
+		var requestData = new RequestData(method, path, data, Settings, requestParameters, MemoryStreamFactory, openTelemetryData);
 		Settings.OnRequestDataCreated?.Invoke(requestData);
 		TResponse response = null;
 

--- a/src/Elastic.Transport/Diagnostics/Auditing/AuditEvent.cs
+++ b/src/Elastic.Transport/Diagnostics/Auditing/AuditEvent.cs
@@ -6,8 +6,7 @@ namespace Elastic.Transport.Diagnostics.Auditing;
 
 /// <summary>
 /// Enumeration of different auditable events that can occur in the execution of
-/// <see cref="HttpTransport.RequestAsync{TResponse}"/> as modeled by
-/// <see cref="RequestPipeline"/>.
+/// requests as modelled by <see cref="RequestPipeline"/>.
 /// </summary>
 public enum AuditEvent
 {
@@ -52,14 +51,14 @@ public enum AuditEvent
 	HealthyResponse,
 
 	/// <summary>
-	/// The call into <see cref="HttpTransport.Request{TResponse}"/> took too long.
-	/// This could mean the call was retried but retrying was to slow and cumulative this exceeded
+	/// The request took too long.
+	/// This could mean the call was retried but retrying was to slow and cumulatively this exceeded
 	/// <see cref="ITransportConfiguration.MaxRetryTimeout"/>
 	/// </summary>
 	MaxTimeoutReached,
 
 	/// <summary>
-	/// The call into <see cref="HttpTransport.Request{TResponse}"/> was not able to complete
+	/// The request was not able to complete
 	/// successfully and exceeded the available retries as configured on
 	/// <see cref="ITransportConfiguration.MaxRetries"/>.
 	/// </summary>

--- a/src/Elastic.Transport/Diagnostics/OpenTelemetry/OpenTelemetry.cs
+++ b/src/Elastic.Transport/Diagnostics/OpenTelemetry/OpenTelemetry.cs
@@ -1,3 +1,7 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
 using System;
 using System.Diagnostics;
 

--- a/src/Elastic.Transport/Diagnostics/OpenTelemetry/OpenTelemetry.cs
+++ b/src/Elastic.Transport/Diagnostics/OpenTelemetry/OpenTelemetry.cs
@@ -63,6 +63,6 @@ public static class OpenTelemetry
 
 		// We add the client schema version only when it differs from the product schema version
 		if (!productSchemaVersion.Equals(OpenTelemetrySchemaVersion, StringComparison.Ordinal))
-			activity?.SetTag(OpenTelemetryAttributes.OpenTelemetrySchemaVersion, OpenTelemetrySchemaVersion);
+			activity?.SetTag(OpenTelemetryAttributes.ElasticTransportSchemaVersion, OpenTelemetrySchemaVersion);
 	}
 }

--- a/src/Elastic.Transport/Diagnostics/OpenTelemetry/OpenTelemetry.cs
+++ b/src/Elastic.Transport/Diagnostics/OpenTelemetry/OpenTelemetry.cs
@@ -1,0 +1,22 @@
+using System.Diagnostics;
+
+namespace Elastic.Transport.Diagnostics;
+
+/// <summary>
+/// Activity information for OpenTelemetry instrumentation.
+/// </summary>
+public static class OpenTelemetry
+{
+	/// <summary>
+	/// The name of the primary <see cref="ActivitySource"/> for the transport. 
+	/// </summary>
+	public const string ElasticTransportActivitySourceName = "Elastic.Transport";
+
+	internal static ActivitySource ElasticTransportActivitySource = new(ElasticTransportActivitySourceName, "1.0.0");
+
+	/// <summary>
+	/// Check if the "Elastic.Transport" <see cref="ActivitySource"/> has listeners.
+	/// Allows derived clients to avoid overhead to collect attributes when there are no listeners.
+	/// </summary>
+	public static bool ElasticTransportActivitySourceHasListeners => ElasticTransportActivitySource.HasListeners();
+}

--- a/src/Elastic.Transport/Diagnostics/OpenTelemetry/OpenTelemetryAttributes.cs
+++ b/src/Elastic.Transport/Diagnostics/OpenTelemetry/OpenTelemetryAttributes.cs
@@ -1,3 +1,7 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
 namespace Elastic.Transport.Diagnostics;
 
 /// <summary>

--- a/src/Elastic.Transport/Diagnostics/OpenTelemetry/OpenTelemetryAttributes.cs
+++ b/src/Elastic.Transport/Diagnostics/OpenTelemetry/OpenTelemetryAttributes.cs
@@ -1,0 +1,47 @@
+namespace Elastic.Transport.Diagnostics;
+
+/// <summary>
+/// Defines custom, attribute names, but defined under OpenTelemetry semantic conventions.
+/// </summary>
+internal static class OpenTelemetryAttributes
+{
+	/// <summary>
+	/// The name of the product library consuming the Elastic.Transport library.
+	/// </summary>
+	public const string ElasticTransportProductName = "elastic.transport.product.name";
+
+	/// <summary>
+	/// The informational version of the product library consuming the Elastic.Transport library.
+	/// </summary>
+	public const string ElasticTransportProductVersion = "elastic.transport.product.version";
+
+	/// <summary>
+	/// The informational version of the Elastic.Transport library.
+	/// </summary>
+	public const string ElasticTransportVersion = "elastic.transport.version";
+
+	/// <summary>
+	/// The URL for the implemented OpenTelemetry schema version for attributes added by the transport layer.
+	/// </summary>
+	public const string OpenTelemetrySchemaVersion = "elastic.transport.schema_url";
+
+	/// <summary>
+	/// May be included by the Elasticsearch client to communicate the schema version it conforms to.
+	/// </summary>
+	public const string DbElasticsearchSchemaUrl = "db.elasticsearch.schema_url";
+
+	/// <summary>
+	/// The number of nodes attempted during a logical operation to Elasticsearch.
+	/// </summary>
+	public const string ElasticTransportAttemptedNodes = "elastic.transport.attempted_nodes";
+
+	/// <summary>
+	/// The measured milliseconds taken to prepare the HTTP request before sending it to the server.
+	/// </summary>
+	public const string ElasticTransportPrepareRequestMs = "elastic.transport.prepare_request_ms";
+
+	/// <summary>
+	/// The measured milliseconds taken to deserialize an HTTP response from the server.
+	/// </summary>
+	public const string ElasticTransportDeserializeResponseMs = "elastic.transport.deserialize_response_ms";
+}

--- a/src/Elastic.Transport/Diagnostics/OpenTelemetry/OpenTelemetryAttributes.cs
+++ b/src/Elastic.Transport/Diagnostics/OpenTelemetry/OpenTelemetryAttributes.cs
@@ -23,7 +23,7 @@ internal static class OpenTelemetryAttributes
 	/// <summary>
 	/// The URL for the implemented OpenTelemetry schema version for attributes added by the transport layer.
 	/// </summary>
-	public const string OpenTelemetrySchemaVersion = "elastic.transport.schema_url";
+	public const string ElasticTransportSchemaVersion = "elastic.transport.schema_url";
 
 	/// <summary>
 	/// May be included by the Elasticsearch client to communicate the schema version it conforms to.
@@ -44,4 +44,14 @@ internal static class OpenTelemetryAttributes
 	/// The measured milliseconds taken to deserialize an HTTP response from the server.
 	/// </summary>
 	public const string ElasticTransportDeserializeResponseMs = "elastic.transport.deserialize_response_ms";
+
+	/// <summary>
+	/// The human-readable identifier for the cluster, usually retrieved from response headers.
+	/// </summary>
+	public const string DbElasticsearchClusterName = "db.elasticsearch.cluster.name";
+
+	/// <summary>
+	/// The identifier of the node/insatnce which handled a request, usually retrieved from response headers.
+	/// </summary>
+	public const string DbElasticsearchNodeName = "db.elasticsearch.node.name";
 }

--- a/src/Elastic.Transport/Diagnostics/OpenTelemetry/OpenTelemetryData.cs
+++ b/src/Elastic.Transport/Diagnostics/OpenTelemetry/OpenTelemetryData.cs
@@ -10,10 +10,10 @@ public readonly struct OpenTelemetryData
 	/// <summary>
 	/// The name to use for spans relating to a request.
 	/// </summary>
-	public string? SpanName { get; init; }
+	public readonly string? SpanName { get; init; }
 
 	/// <summary>
 	/// Additional span attributes for transport spans relating to a request.
 	/// </summary>
-	public Dictionary<string, object>? SpanAttributes { get; init; }
+	public readonly Dictionary<string, object>? SpanAttributes { get; init; }
 }

--- a/src/Elastic.Transport/Diagnostics/OpenTelemetry/OpenTelemetryData.cs
+++ b/src/Elastic.Transport/Diagnostics/OpenTelemetry/OpenTelemetryData.cs
@@ -1,3 +1,7 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
 using System.Collections.Generic;
 
 namespace Elastic.Transport.Diagnostics;

--- a/src/Elastic.Transport/Diagnostics/OpenTelemetry/OpenTelemetryData.cs
+++ b/src/Elastic.Transport/Diagnostics/OpenTelemetry/OpenTelemetryData.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+
+namespace Elastic.Transport.Diagnostics;
+
+/// <summary>
+/// Allows consumers to pass specific values for OpenTelemetry instrumentation for each request.
+/// </summary>
+public readonly struct OpenTelemetryData
+{
+	/// <summary>
+	/// The name to use for spans relating to a request.
+	/// </summary>
+	public string? SpanName { get; init; }
+
+	/// <summary>
+	/// Additional span attributes for transport spans relating to a request.
+	/// </summary>
+	public Dictionary<string, object>? SpanAttributes { get; init; }
+}

--- a/src/Elastic.Transport/Diagnostics/OpenTelemetry/SemanticConventions.cs
+++ b/src/Elastic.Transport/Diagnostics/OpenTelemetry/SemanticConventions.cs
@@ -1,3 +1,7 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
 namespace Elastic.Transport.Diagnostics;
 
 /// <summary>

--- a/src/Elastic.Transport/Diagnostics/OpenTelemetry/SemanticConventions.cs
+++ b/src/Elastic.Transport/Diagnostics/OpenTelemetry/SemanticConventions.cs
@@ -1,0 +1,6 @@
+﻿namespace Elastic.Transport.Diagnostics;
+
+internal static class SemanticConventions
+{
+
+}

--- a/src/Elastic.Transport/Diagnostics/OpenTelemetry/SemanticConventions.cs
+++ b/src/Elastic.Transport/Diagnostics/OpenTelemetry/SemanticConventions.cs
@@ -1,6 +1,25 @@
-﻿namespace Elastic.Transport.Diagnostics;
+namespace Elastic.Transport.Diagnostics;
 
+/// <summary>
+/// Constants for OpenTelemetrySemanticConventions
+/// </summary>
 internal static class SemanticConventions
 {
+	// DATABASE
+	public const string DbSystem = "db.system";
+	public const string DbUser = "db.user";
 
+	// HTTP
+	public const string HttpResponseStatusCode = "http.response.status_code";
+	public const string HttpRequestMethod = "http.request.method";
+
+	// SERVER
+	public const string ServerAddress = "server.address";
+	public const string ServerPort = "server.port";
+
+	// URL
+	public const string UrlFull = "url.full";
+
+	// URL
+	public const string UserAgentOriginal = "user_agent.original";
 }

--- a/src/Elastic.Transport/Elastic.Transport.csproj
+++ b/src/Elastic.Transport/Elastic.Transport.csproj
@@ -32,4 +32,9 @@
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.1" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
   </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="Microsoft.NETFramework.ReferenceAssemblies.net461" Version="1.0.3" />
+    <PackageReference Update="Microsoft.SourceLink.GitHub" Version="1.1.1" />
+  </ItemGroup>
 </Project>

--- a/src/Elastic.Transport/Exceptions/TransportException.cs
+++ b/src/Elastic.Transport/Exceptions/TransportException.cs
@@ -13,9 +13,7 @@ using static Elastic.Transport.Diagnostics.ResponseStatics;
 namespace Elastic.Transport;
 
 /// <summary>
-/// Exceptions that occur <see cref="HttpTransport.Request{TResponse}"/> are wrapped inside
-/// this exception. This is done to not lose valuable diagnostic information.
-///
+/// Exceptions that occur are wrapped inside this exception. This is done to not lose valuable diagnostic information.
 /// <para>
 /// When <see cref="ITransportConfiguration.ThrowExceptions"/> is set these exceptions are rethrown and need
 /// to be caught
@@ -41,7 +39,7 @@ public class TransportException : Exception
 
 	/// <summary>
 	/// The audit trail keeping track of what happened during the invocation of
-	/// <see cref="HttpTransport.Request{TResponse}"/> up until the moment of this exception.
+	/// a request, up until the moment of this exception.
 	/// </summary>
 	public IEnumerable<Audit> AuditTrail { get; internal set; }
 

--- a/src/Elastic.Transport/Extensions/TaskExtensions.cs
+++ b/src/Elastic.Transport/Extensions/TaskExtensions.cs
@@ -1,0 +1,41 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+// Adapted from https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/core/Azure.Core/src/Shared/TaskExtensions.cs
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Diagnostics;
+using System.Threading.Tasks;
+
+namespace Elastic.Transport;
+
+internal static class TaskExtensions
+{
+	[Conditional("DEBUG")]
+	private static void VerifyTaskCompleted(bool isCompleted)
+	{
+		if (!isCompleted)
+		{
+			if (Debugger.IsAttached)
+			{
+				Debugger.Break();
+			}
+			// Throw an InvalidOperationException instead of using
+			// Debug.Assert because that brings down xUnit immediately
+			throw new InvalidOperationException("Task is not completed");
+		}
+	}
+
+	public static T EnsureCompleted<T>(this ValueTask<T> task)
+	{
+#if DEBUG
+		VerifyTaskCompleted(task.IsCompleted);
+#endif
+#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
+		return task.GetAwaiter().GetResult();
+#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
+	}
+}

--- a/src/Elastic.Transport/Extensions/TaskExtensions.cs
+++ b/src/Elastic.Transport/Extensions/TaskExtensions.cs
@@ -38,4 +38,14 @@ internal static class TaskExtensions
 		return task.GetAwaiter().GetResult();
 #pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
 	}
+
+	public static void EnsureCompleted(this ValueTask task)
+	{
+#if DEBUG
+		VerifyTaskCompleted(task.IsCompleted);
+#endif
+#pragma warning disable VSTHRD002 // Avoid problematic synchronous waits
+		task.GetAwaiter().GetResult();
+#pragma warning restore VSTHRD002 // Avoid problematic synchronous waits
+	}
 }

--- a/src/Elastic.Transport/HttpTransport.cs
+++ b/src/Elastic.Transport/HttpTransport.cs
@@ -54,7 +54,7 @@ public abstract class HttpTransport
 		string path,
 		PostData? postData,
 		RequestParameters? requestParameters,
-		OpenTelemetryData openTelemetryData)
+		in OpenTelemetryData openTelemetryData)
 		where TResponse : TransportResponse, new();
 #pragma warning restore 1573
 
@@ -102,7 +102,7 @@ public abstract class HttpTransport
 		string path,
 		PostData? postData,
 		RequestParameters? requestParameters,
-		OpenTelemetryData openTelemetryData,
+		in OpenTelemetryData openTelemetryData,
 		CancellationToken cancellationToken = default)
 		where TResponse : TransportResponse, new();
 #pragma warning restore 1573

--- a/src/Elastic.Transport/HttpTransport.cs
+++ b/src/Elastic.Transport/HttpTransport.cs
@@ -4,6 +4,7 @@
 
 using System.Threading;
 using System.Threading.Tasks;
+using Elastic.Transport.Diagnostics;
 
 namespace Elastic.Transport;
 
@@ -13,23 +14,98 @@ namespace Elastic.Transport;
 public abstract class HttpTransport
 {
 	/// <summary>
-	/// Perform a request into the products cluster using <see cref="RequestPipeline" />'s workflow.
+	/// Orchestrate a request synchronously into a <see cref="NodePool"/> using the workflow defined in the <see cref="RequestPipeline"/>.
 	/// </summary>
+	/// <remarks>NOTE: It is highly recommended to prefer the asynchronous version of this method instead of this synchronous API.</remarks>
+	/// <typeparam name="TResponse">The type to deserialize the response body into.</typeparam>
+	/// <param name="method">The <see cref="HttpMethod"/> for the HTTP request.</param>
+	/// <param name="path">The path of the request.</param>
+	/// <returns>The deserialized <typeparamref name="TResponse"/>.</returns>
+	public TResponse Request<TResponse>(
+		HttpMethod method,
+		string path)
+		where TResponse : TransportResponse, new()
+			=> Request<TResponse>(method, path, null, null, default);
+
+#pragma warning disable 1573
+	/// <inheritdoc cref="Request{TResponse}(HttpMethod, string)"/>
+	/// <param name="postData">The data to be included as the body of the HTTP request.</param>
+	public TResponse Request<TResponse>(
+		HttpMethod method,
+		string path,
+		PostData? postData)
+		where TResponse : TransportResponse, new()
+			=> Request<TResponse>(method, path, postData, null, default);
+
+	/// <inheritdoc cref="Request{TResponse}(HttpMethod, string, PostData?)"/>
+	/// <param name="requestParameters">The parameters for the request.</param>
+	public TResponse Request<TResponse>(
+		HttpMethod method,
+		string path,
+		PostData? postData,
+		RequestParameters? requestParameters)
+		where TResponse : TransportResponse, new()
+			=> Request<TResponse>(method, path, postData, requestParameters, default);
+
+	/// <inheritdoc cref="Request{TResponse}(HttpMethod, string, PostData?, RequestParameters?)"/>
+	/// <param name="openTelemetryData">Data to be used to control the OpenTelemetry instrumentation.</param>
 	public abstract TResponse Request<TResponse>(
 		HttpMethod method,
 		string path,
-		PostData? data = null,
-		RequestParameters? requestParameters = null)
+		PostData? postData,
+		RequestParameters? requestParameters,
+		OpenTelemetryData openTelemetryData)
 		where TResponse : TransportResponse, new();
+#pragma warning restore 1573
 
-	/// <inheritdoc cref="Request{TResponse}" />
+	/// <summary>
+	/// Orchestrate a request asynchronously into a <see cref="NodePool"/> using the workflow defined in the <see cref="RequestPipeline"/>.
+	/// </summary>
+	/// <typeparam name="TResponse">The type to deserialize the response body into.</typeparam>
+	/// <param name="method">The <see cref="HttpMethod"/> for the HTTP request.</param>
+	/// <param name="path">The path of the request.</param>
+	/// <param name="cancellationToken">The cancellation token to use.</param>
+	/// <returns>The deserialized <typeparamref name="TResponse"/>.</returns>
+	public Task<TResponse> RequestAsync<TResponse>(
+		HttpMethod method,
+		string path,
+		CancellationToken cancellationToken = default)
+		where TResponse : TransportResponse, new()
+			=> RequestAsync<TResponse>(method, path, null, null, default, cancellationToken);
+
+#pragma warning disable 1573
+	/// <inheritdoc cref="RequestAsync{TResponse}(HttpMethod, string, CancellationToken)"/>
+	/// <param name="postData">The data to be included as the body of the HTTP request.</param>
+	public Task<TResponse> RequestAsync<TResponse>(
+		HttpMethod method,
+		string path,
+		PostData? postData,
+		CancellationToken cancellationToken = default)
+		where TResponse : TransportResponse, new()
+			=> RequestAsync<TResponse>(method, path, postData, null, default, cancellationToken);
+
+	/// <inheritdoc cref="RequestAsync{TResponse}(HttpMethod, string, PostData?, CancellationToken)"/>
+	/// <param name="requestParameters">The parameters for the request.</param>
+	public Task<TResponse> RequestAsync<TResponse>(
+		HttpMethod method,
+		string path,
+		PostData? postData,
+		RequestParameters? requestParameters,
+		CancellationToken cancellationToken = default)
+		where TResponse : TransportResponse, new()
+			=> RequestAsync<TResponse>(method, path, postData, requestParameters, default, cancellationToken);
+
+	/// <inheritdoc cref="RequestAsync{TResponse}(HttpMethod, string, PostData?, RequestParameters?, CancellationToken)"/>
+	/// <param name="openTelemetryData">Data to be used to control the OpenTelemetry instrumentation.</param>
 	public abstract Task<TResponse> RequestAsync<TResponse>(
 		HttpMethod method,
 		string path,
-		PostData? data = null,
-		RequestParameters? requestParameters = null,
+		PostData? postData,
+		RequestParameters? requestParameters,
+		OpenTelemetryData openTelemetryData,
 		CancellationToken cancellationToken = default)
 		where TResponse : TransportResponse, new();
+#pragma warning restore 1573
 }
 
 /// <summary>

--- a/src/Elastic.Transport/Products/DefaultProductRegistration.cs
+++ b/src/Elastic.Transport/Products/DefaultProductRegistration.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -22,7 +23,14 @@ public sealed class DefaultProductRegistration : ProductRegistration
 	/// <summary>
 	/// 
 	/// </summary>
-	public DefaultProductRegistration() => _metaHeaderProvider = new DefaultMetaHeaderProvider(typeof(HttpTransport), ServiceIdentifier);
+	public DefaultProductRegistration()
+	{
+		_metaHeaderProvider = new DefaultMetaHeaderProvider(typeof(HttpTransport), ServiceIdentifier);
+
+		ProductAssemblyVersion = typeof(ProductRegistration).Assembly
+			.GetCustomAttribute<AssemblyInformationalVersionAttribute>()
+			.InformationalVersion;
+	}
 
 	/// <summary> A static instance of <see cref="DefaultProductRegistration"/> to promote reuse </summary>
 	public static DefaultProductRegistration Default { get; } = new DefaultProductRegistration();
@@ -56,6 +64,12 @@ public sealed class DefaultProductRegistration : ProductRegistration
 
 	/// <inheritdoc cref="ProductRegistration.DefaultMimeType"/>
 	public override string DefaultMimeType => null;
+
+	/// <inheritdoc cref="ProductRegistration.ProductAssemblyVersion"/>
+	public override string ProductAssemblyVersion { get; }
+
+	/// <inheritdoc cref="ProductRegistration.DefaultOpenTelemetryAttributes"/>
+	public override IReadOnlyDictionary<string, object>? DefaultOpenTelemetryAttributes { get; }
 
 	/// <inheritdoc cref="ProductRegistration.HttpStatusCodeClassifier"/>
 	public override bool HttpStatusCodeClassifier(HttpMethod method, int statusCode) =>
@@ -91,4 +105,10 @@ public sealed class DefaultProductRegistration : ProductRegistration
 	/// <inheritdoc cref="ProductRegistration.Ping"/>
 	public override TransportResponse Ping(TransportClient connection, RequestData pingData) =>
 		throw new NotImplementedException();
+
+	/// <inheritdoc/>
+	public override IReadOnlyCollection<string> DefaultHeadersToParse() => Array.Empty<string>();
+
+	/// <inheritdoc/>
+	public override Dictionary<string, object>? ParseOpenTelemetryAttributesFromApiCallDetails(ApiCallDetails callDetails) => null;
 }

--- a/src/Elastic.Transport/Products/DefaultProductRegistration.cs
+++ b/src/Elastic.Transport/Products/DefaultProductRegistration.cs
@@ -22,13 +22,16 @@ public sealed class DefaultProductRegistration : ProductRegistration
 	/// <summary>
 	/// 
 	/// </summary>
-	public DefaultProductRegistration() => _metaHeaderProvider = new DefaultMetaHeaderProvider(typeof(HttpTransport), "et");
+	public DefaultProductRegistration() => _metaHeaderProvider = new DefaultMetaHeaderProvider(typeof(HttpTransport), ServiceIdentifier);
 
 	/// <summary> A static instance of <see cref="DefaultProductRegistration"/> to promote reuse </summary>
 	public static DefaultProductRegistration Default { get; } = new DefaultProductRegistration();
 
 	/// <inheritdoc cref="ProductRegistration.Name"/>
 	public override string Name { get; } = "elastic-transport-net";
+
+	/// <inheritdoc cref="ProductRegistration.ServiceIdentifier"/>
+	public override string? ServiceIdentifier => "et";
 
 	/// <inheritdoc cref="ProductRegistration.SupportsPing"/>
 	public override bool SupportsPing { get; } = false;

--- a/src/Elastic.Transport/Products/Elasticsearch/ElasticsearchProductRegistration.cs
+++ b/src/Elastic.Transport/Products/Elasticsearch/ElasticsearchProductRegistration.cs
@@ -34,10 +34,13 @@ public class ElasticsearchProductRegistration : ProductRegistration
 	public ElasticsearchProductRegistration(Type markerType) : this()
 	{
 		var clientVersionInfo = ReflectionVersionInfo.Create(markerType);
-		_metaHeaderProvider = new DefaultMetaHeaderProvider(clientVersionInfo, "es");
+
+		var identifier = ServiceIdentifier;
+		if (!string.IsNullOrEmpty(identifier))
+			_metaHeaderProvider = new DefaultMetaHeaderProvider(clientVersionInfo, identifier);
 
 		// Only set this if we have a version.
-		// If we don't have a version we won't apply the vendor-based REST API compatibilty Accept header.
+		// If we don't have a version we won't apply the vendor-based REST API compatibility Accept header.
 		if (clientVersionInfo.Version.Major > 0)
 			_clientMajorVersion = clientVersionInfo.Version.Major;
 	}
@@ -47,6 +50,9 @@ public class ElasticsearchProductRegistration : ProductRegistration
 
 	/// <inheritdoc cref="ProductRegistration.Name"/>
 	public override string Name { get; } = "elasticsearch-net";
+
+	/// <inheritdoc cref="ProductRegistration.ServiceIdentifier"/>
+	public override string? ServiceIdentifier => "es";
 
 	/// <inheritdoc cref="ProductRegistration.SupportsPing"/>
 	public override bool SupportsPing { get; } = true;

--- a/src/Elastic.Transport/Products/Elasticsearch/ElasticsearchProductRegistration.cs
+++ b/src/Elastic.Transport/Products/Elasticsearch/ElasticsearchProductRegistration.cs
@@ -115,7 +115,7 @@ public class ElasticsearchProductRegistration : ProductRegistration
 		{
 			QueryString = {{"timeout", requestConfiguration.PingTimeout}, {"flat_settings", true},}
 		};
-		return new RequestData(HttpMethod.GET, SniffPath, null, settings, requestParameters, memoryStreamFactory)
+		return new RequestData(HttpMethod.GET, SniffPath, null, settings, requestParameters, memoryStreamFactory, default)
 		{
 			Node = node
 		};
@@ -153,8 +153,11 @@ public class ElasticsearchProductRegistration : ProductRegistration
 			RequestConfiguration = requestConfiguration
 		};
 
-		var data = new RequestData(HttpMethod.HEAD, string.Empty, null, global, requestParameters,
-			memoryStreamFactory) {Node = node};
+		var data = new RequestData(HttpMethod.HEAD, string.Empty, null, global, requestParameters, memoryStreamFactory, default)
+		{
+			Node = node
+		};
+
 		return data;
 	}
 

--- a/src/Elastic.Transport/Products/Elasticsearch/ElasticsearchProductRegistration.cs
+++ b/src/Elastic.Transport/Products/Elasticsearch/ElasticsearchProductRegistration.cs
@@ -21,18 +21,21 @@ namespace Elastic.Transport.Products.Elasticsearch;
 /// </summary>
 public class ElasticsearchProductRegistration : ProductRegistration
 {
+	internal const string XFoundHandlingClusterHeader = "X-Found-Handling-Cluster";
+	internal const string XFoundHandlingInstanceHeader = "X-Found-Handling-Instance";
+
 	private readonly HeadersList _headers;
 	private readonly MetaHeaderProvider _metaHeaderProvider;
 	private readonly int? _clientMajorVersion;
 
 	private static string _clusterName;
-	private static readonly string[] _all = new[] { "X-Found-Handling-Cluster", "X-Found-Handling-Instance" };
-	private static readonly string[] _instanceHeader = new[] { "X-Found-Handling-Instance" };
+	private static readonly string[] _all = new[] { XFoundHandlingClusterHeader, XFoundHandlingInstanceHeader };
+	private static readonly string[] _instanceHeader = new[] { XFoundHandlingInstanceHeader };
 
 	/// <summary>
 	/// Create a new instance of the Elasticsearch product registration.
 	/// </summary>
-	public ElasticsearchProductRegistration() => _headers = new HeadersList("warning");
+	internal ElasticsearchProductRegistration() => _headers = new HeadersList("warning");
 
 	/// <summary>
 	/// 
@@ -206,7 +209,7 @@ public class ElasticsearchProductRegistration : ProductRegistration
 	{
 		Dictionary<string, object>? attributes = null;
 
-		if (string.IsNullOrEmpty(_clusterName) && callDetails.TryGetHeader("X-Found-Handling-Cluster", out var clusterValues))
+		if (string.IsNullOrEmpty(_clusterName) && callDetails.TryGetHeader(XFoundHandlingClusterHeader, out var clusterValues))
 		{
 			_clusterName = clusterValues.FirstOrDefault();
 		}
@@ -214,16 +217,16 @@ public class ElasticsearchProductRegistration : ProductRegistration
 		if (!string.IsNullOrEmpty(_clusterName))
 		{
 			attributes ??= new Dictionary<string, object>();
-			attributes.Add("db.elasticsearch.cluster.name", _clusterName);
+			attributes.Add(OpenTelemetryAttributes.DbElasticsearchClusterName, _clusterName);
 		}
 
-		if (callDetails.TryGetHeader("X-Found-Handling-Instance", out var instanceValues))
+		if (callDetails.TryGetHeader(XFoundHandlingInstanceHeader, out var instanceValues))
 		{
 			var instance = instanceValues.FirstOrDefault();
 			if (!string.IsNullOrEmpty(instance))
 			{
 				attributes ??= new Dictionary<string, object>();
-				attributes.Add("db.elasticsearch.node.name", instance);
+				attributes.Add(OpenTelemetryAttributes.DbElasticsearchNodeName, instance);
 			}
 		}
 

--- a/src/Elastic.Transport/Products/ProductRegistration.cs
+++ b/src/Elastic.Transport/Products/ProductRegistration.cs
@@ -10,7 +10,7 @@ using System.Threading.Tasks;
 namespace Elastic.Transport.Products;
 
 /// <summary>
-/// When <see cref="HttpTransport.Request{TResponse}"/> interfaces with a product some parts are
+/// When a request interfaces with a product, some parts are
 /// bespoke for each product. This interface defines the contract products will have to implement in order to fill
 /// in these bespoke parts.
 /// <para>The expectation is that unless you instantiate <see cref="DefaultHttpTransport{TConnectionSettings}"/>

--- a/src/Elastic.Transport/Products/ProductRegistration.cs
+++ b/src/Elastic.Transport/Products/ProductRegistration.cs
@@ -106,16 +106,40 @@ public abstract class ProductRegistration
 	/// </summary>
 	public abstract bool HttpStatusCodeClassifier(HttpMethod method, int statusCode);
 
-	/// <summary> Try to obtain a server error from the response, this is used for debugging and exception messages </summary>
+	/// <summary>
+	/// Try to obtain a server error from the response, this is used for debugging and exception messages
+	/// </summary>
 	public abstract bool TryGetServerErrorReason<TResponse>(TResponse response, out string reason) where TResponse : TransportResponse;
 
 	/// <summary>
-	/// TODO
+	/// A <see cref="MetaHeaderProvider"/> which produces the client meta header for a request.
 	/// </summary>
 	public abstract MetaHeaderProvider MetaHeaderProvider { get; }
 
 	/// <summary>
-	/// TODO
+	/// A <see cref="ResponseBuilder"/> used to produce product responses from an HTTP response.
 	/// </summary>
 	public abstract ResponseBuilder ResponseBuilder { get; }
+
+	/// <summary>
+	/// The assembly informational version of the product.
+	/// </summary>
+	public abstract string ProductAssemblyVersion { get; }
+
+	/// <summary>
+	/// A set of common OpenTelemetry attributes for this product which are added to the logical operation span created
+	/// by Elastic.Transport.
+	/// </summary>
+	public abstract IReadOnlyDictionary<string, object>? DefaultOpenTelemetryAttributes { get; }
+
+	/// <summary>
+	/// Returns a collection of header names to be parsed from the HTTP response.
+	/// </summary>
+	public abstract IReadOnlyCollection<string> DefaultHeadersToParse();
+
+	/// <summary>
+	/// May return a dictionary containing OpenTelemetry attributes parsed from the <see cref="ApiCallDetails"/> which are
+	/// added to the logical operation span created by Elastic.Transport.
+	/// </summary>
+	public abstract Dictionary<string, object>? ParseOpenTelemetryAttributesFromApiCallDetails(ApiCallDetails callDetails);
 }

--- a/src/Elastic.Transport/Products/ProductRegistration.cs
+++ b/src/Elastic.Transport/Products/ProductRegistration.cs
@@ -35,6 +35,11 @@ public abstract class ProductRegistration
 	public abstract string Name { get; }
 
 	/// <summary>
+	/// An optional service-identifier string that is used in metadata headers.
+	/// </summary>
+	public abstract string? ServiceIdentifier { get; }
+
+	/// <summary>
 	/// Whether the product <see cref="HttpTransport{TConnectionSettings}"/> will call out to supports ping endpoints
 	/// </summary>
 	public abstract bool SupportsPing { get; }

--- a/src/Elastic.Transport/Requests/MetaData/ReflectionVersionInfo.cs
+++ b/src/Elastic.Transport/Requests/MetaData/ReflectionVersionInfo.cs
@@ -58,7 +58,7 @@ internal sealed class ReflectionVersionInfo : VersionInfo
 
 		try
 		{
-			// This fallback may not include the minor version numbers
+			// This fall back may not include the minor version numbers
 			if (productVersion == EmptyVersion)
 				productVersion = type.Assembly.GetName()?.Version?.ToString() ?? EmptyVersion;
 		}

--- a/src/Elastic.Transport/Responses/CustomResponseBuilder.cs
+++ b/src/Elastic.Transport/Responses/CustomResponseBuilder.cs
@@ -9,8 +9,7 @@ using System.Threading.Tasks;
 namespace Elastic.Transport;
 
 /// <summary>
-/// Allows callers of <see cref="HttpTransport.Request{TResponse}"/> to override completely
-/// how `TResponse` should be deserialized to a `TResponse` that implements <see cref="TransportResponse"/> instance.
+/// Allows callers to override completely how `TResponse` should be deserialized to a `TResponse` that implements <see cref="TransportResponse"/> instance.
 /// <para>Expert setting only</para>
 /// </summary>
 public abstract class CustomResponseBuilder

--- a/src/Elastic.Transport/Responses/ResponseStatics.cs
+++ b/src/Elastic.Transport/Responses/ResponseStatics.cs
@@ -13,7 +13,7 @@ namespace Elastic.Transport.Diagnostics;
 
 /// <summary>
 /// Creates human readable debug strings based on <see cref="ApiCallDetails"/> so that
-/// its clear what exactly transpired during a call into <see cref="HttpTransport.Request{TResponse}"/>
+/// its clear what exactly transpired during a request.
 /// </summary>
 internal static class ResponseStatics
 {

--- a/tests/Elastic.Elasticsearch.IntegrationTests/Elastic - Backup.Elasticsearch.IntegrationTests.csproj
+++ b/tests/Elastic.Elasticsearch.IntegrationTests/Elastic - Backup.Elasticsearch.IntegrationTests.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net6.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Elastic.Elasticsearch.Xunit" Version="0.4.3" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+        <PackageReference Include="xunit" Version="2.5.0" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="coverlet.collector" Version="3.1.2">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+      <PackageReference Include="FluentAssertions" Version="5.10.3" />
+      <PackageReference Include="Nullean.VsTest.Pretty.TestLogger" Version="0.3.0" />
+      <PackageReference Include="JunitXml.TestLogger" Version="3.0.134" />
+    </ItemGroup>
+
+    <ItemGroup>
+      <ProjectReference Include="..\..\src\Elastic.Transport\Elastic.Transport.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/tests/Elastic.Elasticsearch.IntegrationTests/Elastic.Elasticsearch.IntegrationTests.csproj
+++ b/tests/Elastic.Elasticsearch.IntegrationTests/Elastic.Elasticsearch.IntegrationTests.csproj
@@ -1,32 +1,31 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
 
-        <IsPackable>false</IsPackable>
-    </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Elastic.Elasticsearch.Xunit" Version="0.4.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="Nullean.VsTest.Pretty.TestLogger" Version="0.3.0" />
+    <PackageReference Include="JunitXml.TestLogger" Version="3.0.134" />
+  </ItemGroup>
 
-    <ItemGroup>
-        <PackageReference Include="Elastic.Elasticsearch.Xunit" Version="0.4.3" />
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.1.0" />
-        <PackageReference Include="xunit" Version="2.4.1" />
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.1.2">
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-            <PrivateAssets>all</PrivateAssets>
-        </PackageReference>
-      <PackageReference Include="FluentAssertions" Version="5.10.3" />
-      <PackageReference Include="Nullean.VsTest.Pretty.TestLogger" Version="0.3.0" />
-      <PackageReference Include="JunitXml.TestLogger" Version="2.1.81" />
-    </ItemGroup>
-
-    <ItemGroup>
-      <ProjectReference Include="..\..\src\Elastic.Transport\Elastic.Transport.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Elastic.Transport\Elastic.Transport.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/tests/Elastic.Transport.IntegrationTests/Elastic.Transport.IntegrationTests.csproj
+++ b/tests/Elastic.Transport.IntegrationTests/Elastic.Transport.IntegrationTests.csproj
@@ -8,19 +8,26 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.1.1" />
+    <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.9.2" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="5.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
-    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="xunit" Version="2.5.0" />
     <PackageReference Include="Xunit.Extensions.Ordering" Version="1.4.5" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
-    <PackageReference Include="coverlet.collector" Version="1.3.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Nullean.VsTest.Pretty.TestLogger" Version="0.3.0" />
-    <PackageReference Include="JunitXml.TestLogger" Version="2.1.81" />
+    <PackageReference Include="JunitXml.TestLogger" Version="3.0.134" />
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Elastic.Transport.VirtualizedCluster\Elastic.Transport.VirtualizedCluster.csproj" />
   </ItemGroup>
+  
 </Project>

--- a/tests/Elastic.Transport.IntegrationTests/OpenTelemetry/OpenTelemetryTests.cs
+++ b/tests/Elastic.Transport.IntegrationTests/OpenTelemetry/OpenTelemetryTests.cs
@@ -18,6 +18,8 @@ using Xunit;
 
 namespace Elastic.Transport.IntegrationTests.OpenTelemetry;
 
+// We cannot allow these tests to run in parallel with other tests as the listener may pick up other activities.
+[Collection(nameof(NonParallelCollection))]
 public class OpenTelemetryTests : AssemblyServerTestsBase
 {
 	internal const string Cluster = "e9106fc68e3044f0b1475b04bf4ffd5f";
@@ -75,7 +77,7 @@ public class OpenTelemetryTests : AssemblyServerTestsBase
 
 			activity.TagObjects.Should().Contain(t => t.Key == OpenTelemetryAttributes.ElasticTransportProductName)
 				.Subject.Value.Should().BeOfType<string>()
-				.Subject.Should().Be("elastic-net");
+				.Subject.Should().Be("elasticsearch-net");
 
 			activity.TagObjects.Should().Contain(t => t.Key == OpenTelemetryAttributes.ElasticTransportProductVersion)
 				.Subject.Value.Should().BeOfType<string>()
@@ -96,3 +98,6 @@ public class OpenTelemetryController : ControllerBase
 		return Task.CompletedTask;
 	}
 }
+
+[CollectionDefinition(nameof(NonParallelCollection), DisableParallelization = true)]
+public class NonParallelCollection { }

--- a/tests/Elastic.Transport.IntegrationTests/OpenTelemetry/OpenTelemetryTests.cs
+++ b/tests/Elastic.Transport.IntegrationTests/OpenTelemetry/OpenTelemetryTests.cs
@@ -1,0 +1,98 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Elastic.Transport.Diagnostics;
+using Elastic.Transport.IntegrationTests.Plumbing;
+using Elastic.Transport.IntegrationTests.Plumbing.Stubs;
+using Elastic.Transport.Products.Elasticsearch;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Xunit;
+
+namespace Elastic.Transport.IntegrationTests.OpenTelemetry;
+
+public class OpenTelemetryTests : AssemblyServerTestsBase
+{
+	internal const string Cluster = "e9106fc68e3044f0b1475b04bf4ffd5f";
+	internal const string Instance = "instance-0000000001";
+
+	public OpenTelemetryTests(TransportTestServer instance) : base(instance) { }
+
+	[Fact]
+	public async Task ElasticsearchTagsShouldBeSet_WhenUsingTheElasticsearchRegistration()
+	{
+		var connection = new TestableHttpConnection();
+		var connectionPool = new SingleNodePool(Server.Uri);
+		var config = new TransportConfiguration(connectionPool, connection, productRegistration: new ElasticsearchProductRegistration(typeof(Clients.Elasticsearch.ElasticsearchClient)));
+		var transport = new DefaultHttpTransport(config);
+
+		var mre = new ManualResetEvent(false);
+
+		var callCounter = 0;
+		using var listener = new ActivityListener()
+		{
+			ActivityStarted = _ => { },
+			ActivityStopped = activity =>
+			{
+				callCounter++;
+
+				if (callCounter > 1)
+					Assert.Fail("Expected one activity, but received multiple stop events.");
+
+				Assertions(activity);
+				mre.Set();
+			},
+			ShouldListenTo = activitySource => activitySource.Name == Diagnostics.OpenTelemetry.ElasticTransportActivitySourceName,
+			Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData
+		};
+		ActivitySource.AddActivityListener(listener);
+
+		_ = await transport.GetAsync<VoidResponse>("/opentelemetry");
+
+		mre.WaitOne(TimeSpan.FromSeconds(1)).Should().BeTrue();
+
+		static void Assertions(Activity activity)
+		{
+			var informationalVersion = (typeof(Clients.Elasticsearch.ElasticsearchClient)
+				.Assembly
+				.GetCustomAttributes(typeof(AssemblyInformationalVersionAttribute), false)
+				as AssemblyInformationalVersionAttribute[]).FirstOrDefault()?.InformationalVersion;
+
+			activity.TagObjects.Should().Contain(t => t.Key == OpenTelemetryAttributes.DbElasticsearchClusterName)
+				.Subject.Value.Should().BeOfType<string>()
+				.Subject.Should().Be(Cluster);
+
+			activity.TagObjects.Should().Contain(t => t.Key == OpenTelemetryAttributes.DbElasticsearchNodeName)
+				.Subject.Value.Should().BeOfType<string>()
+				.Subject.Should().Be(Instance);
+
+			activity.TagObjects.Should().Contain(t => t.Key == OpenTelemetryAttributes.ElasticTransportProductName)
+				.Subject.Value.Should().BeOfType<string>()
+				.Subject.Should().Be("elastic-net");
+
+			activity.TagObjects.Should().Contain(t => t.Key == OpenTelemetryAttributes.ElasticTransportProductVersion)
+				.Subject.Value.Should().BeOfType<string>()
+				.Subject.Should().Be(informationalVersion);
+		}
+	}
+}
+
+[ApiController, Route("[controller]")]
+public class OpenTelemetryController : ControllerBase
+{
+	[HttpGet()]
+	public Task Get()
+	{
+		Response.Headers.Add(ElasticsearchProductRegistration.XFoundHandlingClusterHeader, OpenTelemetryTests.Cluster);
+		Response.Headers.Add(ElasticsearchProductRegistration.XFoundHandlingInstanceHeader, OpenTelemetryTests.Instance);
+
+		return Task.CompletedTask;
+	}
+}

--- a/tests/Elastic.Transport.Tests/ActivityTest.cs
+++ b/tests/Elastic.Transport.Tests/ActivityTest.cs
@@ -2,23 +2,83 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using System;
 using System.Diagnostics;
+using System.Threading;
 using System.Threading.Tasks;
+using Elastic.Transport.Diagnostics;
 using Elastic.Transport.Tests.Plumbing;
 using FluentAssertions;
 using Xunit;
 
 namespace Elastic.Transport.Tests;
 
-// We cannot allow this test to run in parellel with other tests as the listener may pick up other activities
+// We cannot allow these tests to run in parellel with other tests as the listener may pick up other activities.
 [Collection(nameof(NonParallelCollection))]
-public class ActivityTest
+public class ActivityTests
 {
 	[Fact]
 	public async Task BasicOpenTelemetryTest()
 	{
+		await ExecuteTestAsync(Assertions);
+
+		static void Assertions(Activity activity)
+		{
+			activity.Should().NotBeNull();
+			activity.Kind.Should().Be(ActivityKind.Client);
+			activity.DisplayName.Should().Be("GET");
+			activity.OperationName.Should().Be("GET");
+			activity.TagObjects.Should().Contain(t => t.Key == SemanticConventions.UrlFull && (string)t.Value == "http://localhost:9200/");
+			activity.TagObjects.Should().Contain(n => n.Key == SemanticConventions.ServerAddress && (string)n.Value == "localhost");
+#if !NETFRAMEWORK
+			activity.Status.Should().Be(ActivityStatusCode.Ok);
+#endif
+
+			// TODO - Other assertions
+		}
+	}
+
+	[Fact]
+	public async Task PreferSpanNameFromOpenTelemetryData()
+	{
+		const string spanName = "Overridden span name";
+
+		await ExecuteTestAsync(new OpenTelemetryData { SpanName = spanName }, Assertions);
+
+		static void Assertions(Activity activity)
+		{
+			activity.DisplayName.Should().Be(spanName);
+		}
+	}
+
+	[Fact]
+	public async Task IncludeAttributesFromOpenTelemetryData()
+	{
+		const string attributeName = "test.attribute";
+		const string attributeValue = "test-value";
+
+		await ExecuteTestAsync(new OpenTelemetryData
+		{
+			SpanAttributes = new System.Collections.Generic.Dictionary<string, object>
+			{
+				[attributeName] = attributeValue
+			}
+		}, Assertions);
+
+		static void Assertions(Activity activity)
+		{
+			activity.TagObjects.Should().Contain(t => t.Key == attributeName && (string)t.Value == attributeValue);
+		}
+	}
+
+	private Task ExecuteTestAsync(Action<Activity> assertion) => ExecuteTestAsync(default, assertion);
+
+	private async Task ExecuteTestAsync(OpenTelemetryData openTelemetryData, Action<Activity> assertions)
+	{
+		var mre = new ManualResetEvent(false);
+
 		var callCounter = 0;
-		var listener = new ActivityListener
+		using var listener = new ActivityListener()
 		{
 			ActivityStarted = _ => { },
 			ActivityStopped = activity =>
@@ -28,24 +88,18 @@ public class ActivityTest
 				if (callCounter > 1)
 					Assert.Fail("Expected one activity, but received multiple stop events.");
 
-				activity.Should().NotBeNull();
-				activity.Kind.Should().Be(ActivityKind.Client);
-				activity.DisplayName.Should().Be("Elastic.Transport: HTTP GET");
-				activity.OperationName.Should().Be("Elastic.Transport: HTTP GET");
-				activity.Tags.Should().Contain(n => n.Key == "http.url" && n.Value == "http://localhost:9200/");
-				activity.Tags.Should().Contain(n => n.Key == "net.peer.name" && n.Value == "localhost");
-#if !NETFRAMEWORK
-				activity.Status.Should().Be(ActivityStatusCode.Ok);
-#endif
+				assertions(activity);
+				mre.Set();
 			},
-			ShouldListenTo = activitySource => activitySource.Name == "Elastic.Transport.RequestPipeline",
+			ShouldListenTo = activitySource => activitySource.Name == OpenTelemetry.ElasticTransportActivitySourceName,
 			Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData
 		};
 		ActivitySource.AddActivityListener(listener);
 
 		var transport = new DefaultHttpTransport(InMemoryConnectionFactory.Create());
+		_ = await transport.RequestAsync<VoidResponse>(HttpMethod.GET, "/", null, null, openTelemetryData);
 
-		_ = await transport.RequestAsync<VoidResponse>(HttpMethod.GET, "/");
+		mre.WaitOne(TimeSpan.FromSeconds(1)).Should().BeTrue();
 	}
 }
 

--- a/tests/Elastic.Transport.Tests/Elastic.Transport.Tests.csproj
+++ b/tests/Elastic.Transport.Tests/Elastic.Transport.Tests.csproj
@@ -7,17 +7,27 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5" />
-    <PackageReference Include="coverlet.collector" Version="1.3.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="xunit" Version="2.5.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="Nullean.VsTest.Pretty.TestLogger" Version="0.3.0" />
-    <PackageReference Include="JunitXml.TestLogger" Version="2.1.81" />
+    <PackageReference Include="JunitXml.TestLogger" Version="3.0.134" />
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Elastic.Transport.VirtualizedCluster\Elastic.Transport.VirtualizedCluster.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="Microsoft.NETFramework.ReferenceAssemblies.net461" Version="1.0.3" />
   </ItemGroup>
 
 </Project>

--- a/tests/Elastic.Transport.Tests/OpenTelemetryTests.cs
+++ b/tests/Elastic.Transport.Tests/OpenTelemetryTests.cs
@@ -16,7 +16,7 @@ using Xunit;
 
 namespace Elastic.Transport.Tests;
 
-// We cannot allow these tests to run in parellel with other tests as the listener may pick up other activities.
+// We cannot allow these tests to run in parallel with other tests as the listener may pick up other activities.
 [Collection(nameof(NonParallelCollection))]
 public class OpenTelemetryTests
 {

--- a/tests/Elastic.Transport.Tests/ResponseBuilderDisposeTests.cs
+++ b/tests/Elastic.Transport.Tests/ResponseBuilderDisposeTests.cs
@@ -33,7 +33,7 @@ namespace Elastic.Transport.Tests
 		{
 			var settings = disableDirectStreaming ? _settingsDisableDirectStream : _settings;
 			var memoryStreamFactory = new TrackMemoryStreamFactory();
-			var requestData = new RequestData(HttpMethod.GET, "/", null, settings, null, memoryStreamFactory)
+			var requestData = new RequestData(HttpMethod.GET, "/", null, settings, null, memoryStreamFactory, default)
 			{
 				Node = new Node(new Uri("http://localhost:9200"))
 			};
@@ -80,7 +80,7 @@ namespace Elastic.Transport.Tests
 			var settings = disableDirectStreaming ? _settingsDisableDirectStream : _settings;
 			var memoryStreamFactory = new TrackMemoryStreamFactory();
 
-			var requestData = new RequestData(HttpMethod.GET, "/", null, settings, null, memoryStreamFactory)
+			var requestData = new RequestData(HttpMethod.GET, "/", null, settings, null, memoryStreamFactory, default)
 			{
 				Node = new Node(new Uri("http://localhost:9200"))
 			};


### PR DESCRIPTION
Refactors the OTel instrumentation such that products using `Transport` no longer need to start their own `Activity` and pass basic abstracted OTel information used by `Transport` to create Activity and assign attributes.

This also refactors several of our more complex sync and async methods to use a single, more maintainable implementation.