### PR TITLE
Change `CustomResponseBuilder` property setter to `public`

### DIFF
--- a/src/Elastic.Transport/Requests/RequestParameters.cs
+++ b/src/Elastic.Transport/Requests/RequestParameters.cs
@@ -36,7 +36,7 @@ public abstract class RequestParameters
 	/// <summary>
 	/// 
 	/// </summary>
-	public CustomResponseBuilder CustomResponseBuilder { get; internal set; }
+	public CustomResponseBuilder CustomResponseBuilder { get; set; }
 
 	/// <summary>
 	/// 

--- a/src/Elastic.Transport/Responses/HttpDetails/ApiCallDetails.cs
+++ b/src/Elastic.Transport/Responses/HttpDetails/ApiCallDetails.cs
@@ -82,7 +82,7 @@ public sealed class ApiCallDetails
 	/// <summary>
 	///
 	/// </summary>
-	internal string ResponseMimeType { get; set; }
+	public string ResponseMimeType { get; set; }
 
 	/// <summary>
 	///


### PR DESCRIPTION
The ESQL search endpoint returns a response with `byte[]` body and we need a way to create an `ElasticsearchResponse` from a non-JSON body.

This PR changes the setter of `CustomResponseBuilder` property setter to `public` and as well exposes the `ApiCallDetails.ResponseMimeType` property to - in a later phase - be able to deserialize the body based on the actual MIME-type (e.g. `json`, `csv`, `arrow`, ...).