### PR TITLE
Improve `UrlFormatter`

### DIFF
--- a/src/Elastic.Transport/Extensions/Extensions.cs
+++ b/src/Elastic.Transport/Extensions/Extensions.cs
@@ -38,7 +38,7 @@ internal static class Extensions
 			throw new ArgumentNullException(name);
 	}
 
-	internal static bool IsNullOrEmpty(this string value) => string.IsNullOrEmpty(value);
+	internal static bool IsNullOrEmpty(this string? value) => string.IsNullOrEmpty(value);
 
 	internal static string Utf8String(this byte[] bytes) => bytes == null ? null : Encoding.UTF8.GetString(bytes, 0, bytes.Length);
 


### PR DESCRIPTION
Improvements to `CreateString`:

1. The `IEnumerable<object>` was never matching (except for exact this type). I changed the code to check for `IEnumerable` instead
2. To support arrays with non-zero lower bounds, I kept the `Array` special case
3. For performance reasons (saving one iterator instance and being able to use `for` instead of `foreach`) I special cased `IList`

Besides that, I fixed some nullability annotations.