### PR TITLE
Add parameterless constructor to `StreamResponse`

### DIFF
--- a/src/Elastic.Transport/Responses/Special/StreamResponse.cs
+++ b/src/Elastic.Transport/Responses/Special/StreamResponse.cs
@@ -25,6 +25,13 @@ public sealed class StreamResponse :
 	public string MimeType { get; }
 
 	/// <inheritdoc cref="StreamResponse"/>
+	public StreamResponse()
+	{
+		Body = Stream.Null;
+		MimeType = string.Empty;
+	}
+
+	/// <inheritdoc cref="StreamResponse"/>
 	public StreamResponse(Stream body, string? mimeType)
 	{
 		Body = body;


### PR DESCRIPTION
This is required to fulfill the `new()` constraint on e.g. `ResponseBuilder.ToResponse()`.