### PR TITLE
Enhance StreamResponse handling and update dependencies

### DIFF
--- a/src/Elastic.Transport/Components/Pipeline/DefaultResponseBuilder.cs
+++ b/src/Elastic.Transport/Components/Pipeline/DefaultResponseBuilder.cs
@@ -230,10 +230,7 @@ internal class DefaultResponseBuilder<TError> : ResponseBuilder where TError : E
 		if (details.HttpStatusCode.HasValue &&
 			requestData.SkipDeserializationForStatusCodes.Contains(details.HttpStatusCode.Value))
 		{
-			// In this scenario, we always dispose as we've explicitly skipped reading the response
-			if (ownsStream)
-				responseStream.Dispose();
-
+			ConditionalDisposal(responseStream, ownsStream, response);
 			return null;
 		}
 
@@ -296,7 +293,6 @@ internal class DefaultResponseBuilder<TError> : ResponseBuilder where TError : E
 		{
 			// Note the exception this handles is ONLY thrown after a check if the stream length is zero.
 			// When the length is zero, `default` is returned by Deserialize(Async) instead.
-
 			ConditionalDisposal(responseStream, ownsStream, response);
 			return default;
 		}

--- a/src/Elastic.Transport/Components/Pipeline/DefaultResponseBuilder.cs
+++ b/src/Elastic.Transport/Components/Pipeline/DefaultResponseBuilder.cs
@@ -26,7 +26,7 @@ internal static class ResponseBuilderDefaults
 
 	public static readonly Type[] SpecialTypes =
 	{
-		typeof(StringResponse), typeof(BytesResponse), typeof(VoidResponse), typeof(DynamicResponse)
+		typeof(StringResponse), typeof(BytesResponse), typeof(VoidResponse), typeof(DynamicResponse), typeof(StreamResponse)
 	};
 }
 
@@ -224,68 +224,65 @@ internal class DefaultResponseBuilder<TError> : ResponseBuilder where TError : E
 			details.ResponseBodyInBytes = bytes;
 		}
 
-		using (responseStream)
+		if (SetSpecialTypes<TResponse>(mimeType, bytes, responseStream, requestData.MemoryStreamFactory, out var r)) return r;
+
+		if (details.HttpStatusCode.HasValue &&
+			requestData.SkipDeserializationForStatusCodes.Contains(details.HttpStatusCode.Value))
+			return null;
+
+		var serializer = requestData.ConnectionSettings.RequestResponseSerializer;
+
+		TResponse response;
+		if (requestData.CustomResponseBuilder != null)
 		{
-			if (SetSpecialTypes<TResponse>(mimeType, bytes, responseStream, requestData.MemoryStreamFactory, out var r)) return r;
+			var beforeTicks = Stopwatch.GetTimestamp();
 
-			if (details.HttpStatusCode.HasValue &&
-				requestData.SkipDeserializationForStatusCodes.Contains(details.HttpStatusCode.Value))
-				return null;
+			if (isAsync)
+				response = await requestData.CustomResponseBuilder
+					.DeserializeResponseAsync(serializer, details, responseStream, cancellationToken)
+					.ConfigureAwait(false) as TResponse;
+			else
+				response = requestData.CustomResponseBuilder
+					.DeserializeResponse(serializer, details, responseStream) as TResponse;
 
-			var serializer = requestData.ConnectionSettings.RequestResponseSerializer;
+			var deserializeResponseMs = (Stopwatch.GetTimestamp() - beforeTicks) / (Stopwatch.Frequency / 1000);
+			if (deserializeResponseMs > OpenTelemetry.MinimumMillisecondsToEmitTimingSpanAttribute && OpenTelemetry.CurrentSpanIsElasticTransportOwnedHasListenersAndAllDataRequested)
+				Activity.Current?.SetTag(OpenTelemetryAttributes.ElasticTransportDeserializeResponseMs, deserializeResponseMs);
 
-			TResponse response;
-			if (requestData.CustomResponseBuilder != null)
+			return response;
+		}
+
+		// TODO: Handle empty data in a nicer way as throwing exceptions has a cost we'd like to avoid!
+		// ie. check content-length (add to ApiCallDetails)? Content-length cannot be retrieved from a GZip content stream which is annoying.
+		try
+		{
+			if (requiresErrorDeserialization && TryGetError(details, requestData, responseStream, out var error) && error.HasError())
 			{
-				var beforeTicks = Stopwatch.GetTimestamp();
-
-				if (isAsync)
-					response = await requestData.CustomResponseBuilder
-						.DeserializeResponseAsync(serializer, details, responseStream, cancellationToken)
-						.ConfigureAwait(false) as TResponse;
-				else
-					response = requestData.CustomResponseBuilder
-						.DeserializeResponse(serializer, details, responseStream) as TResponse;
-
-				var deserializeResponseMs = (Stopwatch.GetTimestamp() - beforeTicks) / (Stopwatch.Frequency / 1000);
-				if (deserializeResponseMs > OpenTelemetry.MinimumMillisecondsToEmitTimingSpanAttribute && OpenTelemetry.CurrentSpanIsElasticTransportOwnedHasListenersAndAllDataRequested)
-					Activity.Current?.SetTag(OpenTelemetryAttributes.ElasticTransportDeserializeResponseMs, deserializeResponseMs);
-
+				response = new TResponse();
+				SetErrorOnResponse(response, error);
 				return response;
 			}
 
-			// TODO: Handle empty data in a nicer way as throwing exceptions has a cost we'd like to avoid!
-			// ie. check content-length (add to ApiCallDetails)? Content-length cannot be retrieved from a GZip content stream which is annoying.
-			try
-			{
-				if (requiresErrorDeserialization && TryGetError(details, requestData, responseStream, out var error) && error.HasError())
-				{
-					response = new TResponse();
-					SetErrorOnResponse(response, error);
-					return response;
-				}
-
-				if (!requestData.ValidateResponseContentType(mimeType))
-					return default;
-
-				var beforeTicks = Stopwatch.GetTimestamp();
-
-				if (isAsync)
-					response = await serializer.DeserializeAsync<TResponse>(responseStream, cancellationToken).ConfigureAwait(false);
-				else
-					response = serializer.Deserialize<TResponse>(responseStream);
-
-				var deserializeResponseMs = (Stopwatch.GetTimestamp() - beforeTicks) / (Stopwatch.Frequency / 1000);
-
-				if (deserializeResponseMs > OpenTelemetry.MinimumMillisecondsToEmitTimingSpanAttribute && OpenTelemetry.CurrentSpanIsElasticTransportOwnedHasListenersAndAllDataRequested)
-					Activity.Current?.SetTag(OpenTelemetryAttributes.ElasticTransportDeserializeResponseMs, deserializeResponseMs);
-
-				return response;
-			}
-			catch (JsonException ex) when (ex.Message.Contains("The input does not contain any JSON tokens"))
-			{
+			if (!requestData.ValidateResponseContentType(mimeType))
 				return default;
-			}
+
+			var beforeTicks = Stopwatch.GetTimestamp();
+
+			if (isAsync)
+				response = await serializer.DeserializeAsync<TResponse>(responseStream, cancellationToken).ConfigureAwait(false);
+			else
+				response = serializer.Deserialize<TResponse>(responseStream);
+
+			var deserializeResponseMs = (Stopwatch.GetTimestamp() - beforeTicks) / (Stopwatch.Frequency / 1000);
+
+			if (deserializeResponseMs > OpenTelemetry.MinimumMillisecondsToEmitTimingSpanAttribute && OpenTelemetry.CurrentSpanIsElasticTransportOwnedHasListenersAndAllDataRequested)
+				Activity.Current?.SetTag(OpenTelemetryAttributes.ElasticTransportDeserializeResponseMs, deserializeResponseMs);
+
+			return response;
+		}
+		catch (JsonException ex) when (ex.Message.Contains("The input does not contain any JSON tokens"))
+		{
+			return default;
 		}
 	}
 

--- a/src/Elastic.Transport/Components/TransportClient/HttpRequestInvoker.cs
+++ b/src/Elastic.Transport/Components/TransportClient/HttpRequestInvoker.cs
@@ -157,7 +157,6 @@ public class HttpRequestInvoker : IRequestInvoker
 		var isStreamResponse = typeof(TResponse) == typeof(StreamResponse);
 
 		using (isStreamResponse ? DiagnosticSources.SingletonDisposable : receive)
-		using (isStreamResponse ? Stream.Null : responseStream ??= Stream.Null)
 		{
 			TResponse response;
 

--- a/src/Elastic.Transport/Components/TransportClient/HttpRequestInvoker.cs
+++ b/src/Elastic.Transport/Components/TransportClient/HttpRequestInvoker.cs
@@ -166,9 +166,17 @@ public class HttpRequestInvoker : IRequestInvoker
 				response = requestData.ConnectionSettings.ProductRegistration.ResponseBuilder.ToResponse<TResponse>
 						(requestData, ex, statusCode, responseHeaders, responseStream, mimeType, contentLength, threadPoolStats, tcpStats);
 
-			// Defer disposal of the response message
-			if (response is StreamResponse sr)
-				sr.Finalizer = () => receivedResponse.Dispose();
+			// Unless indicated otherwise by the TransportResponse, we've now handled the response stream, so we can dispose of the HttpResponseMessage
+			// to release the connection. In cases, where the derived response works directly on the stream, it can be left open and additional IDisposable
+			// resources can be linked such that their disposal is deferred.
+			if (response.LeaveOpen)
+			{
+				response.LinkedDisposables = [receivedResponse];
+			}
+			else
+			{
+				receivedResponse.Dispose();
+			}
 
 			if (!OpenTelemetry.CurrentSpanIsElasticTransportOwnedAndHasListeners || (!(Activity.Current?.IsAllDataRequested ?? false)))
 				return response;
@@ -179,11 +187,6 @@ public class HttpRequestInvoker : IRequestInvoker
 
 			foreach (var attribute in attributes)
 				Activity.Current?.SetTag(attribute.Key, attribute.Value);
-
-			// Unless indicated otherwise by the TransportResponse, we've now handled the response stream, so we can dispose of the HttpResponseMessage
-			// to release the connection.
-			if (!response.LeaveOpen)
-				receivedResponse.Dispose();
 
 			return response;
 		}

--- a/src/Elastic.Transport/Components/TransportClient/HttpRequestInvoker.cs
+++ b/src/Elastic.Transport/Components/TransportClient/HttpRequestInvoker.cs
@@ -171,10 +171,11 @@ public class HttpRequestInvoker : IRequestInvoker
 			// resources can be linked such that their disposal is deferred.
 			if (response.LeaveOpen)
 			{
-				response.LinkedDisposables = [receivedResponse];
+				response.LinkedDisposables = [receivedResponse, responseStream];
 			}
 			else
 			{
+				responseStream.Dispose();
 				receivedResponse.Dispose();
 			}
 
@@ -192,7 +193,9 @@ public class HttpRequestInvoker : IRequestInvoker
 		}
 		catch
 		{
-			receivedResponse.Dispose(); // if there's an exception, ensure we always release the response so that the connection is freed.
+			// if there's an exception, ensure we always release the stream and response so that the connection is freed.
+			responseStream.Dispose();
+			receivedResponse.Dispose(); 
 			throw;
 		}
 	}

--- a/src/Elastic.Transport/Components/TransportClient/HttpWebRequestInvoker.cs
+++ b/src/Elastic.Transport/Components/TransportClient/HttpWebRequestInvoker.cs
@@ -182,10 +182,11 @@ public class HttpWebRequestInvoker : IRequestInvoker
 			// resources can be linked such that their disposal is deferred.
 			if (response.LeaveOpen)
 			{
-				response.LinkedDisposables = [receivedResponse];
+				response.LinkedDisposables = [receivedResponse, responseStream];
 			}
 			else
 			{
+				responseStream.Dispose();
 				receivedResponse.Dispose();
 			}
 
@@ -202,7 +203,9 @@ public class HttpWebRequestInvoker : IRequestInvoker
 		}
 		catch
 		{
-			receivedResponse.Dispose(); // ensure we always release the response so the connection is freed.
+			// if there's an exception, ensure we always release the stream and response so that the connection is freed.
+			responseStream.Dispose();
+			receivedResponse.Dispose();
 			throw;
 		}
 	}

--- a/src/Elastic.Transport/Components/TransportClient/HttpWebRequestInvoker.cs
+++ b/src/Elastic.Transport/Components/TransportClient/HttpWebRequestInvoker.cs
@@ -190,6 +190,9 @@ public class HttpWebRequestInvoker : IRequestInvoker
 				}
 			}
 
+			if (!response.LeaveOpen)
+				receivedResponse.Dispose();
+
 			return response;
 		}
 		catch

--- a/src/Elastic.Transport/Components/TransportClient/InMemoryRequestInvoker.cs
+++ b/src/Elastic.Transport/Components/TransportClient/InMemoryRequestInvoker.cs
@@ -85,13 +85,8 @@ public class InMemoryRequestInvoker : IRequestInvoker
 		var sc = statusCode ?? _statusCode;
 		Stream responseStream = body != null ? requestData.MemoryStreamFactory.Create(body) : requestData.MemoryStreamFactory.Create(EmptyBody);
 
-		var isStreamResponse = typeof(TResponse) == typeof(StreamResponse);
-
-		using (isStreamResponse ? Stream.Null : responseStream ??= Stream.Null)
-		{
-			return requestData.ConnectionSettings.ProductRegistration.ResponseBuilder
-				.ToResponse<TResponse>(requestData, _exception, sc, _headers, responseStream, contentType ?? _contentType ?? RequestData.DefaultMimeType, body?.Length ?? 0, null, null);
-		}
+		return requestData.ConnectionSettings.ProductRegistration.ResponseBuilder
+			.ToResponse<TResponse>(requestData, _exception, sc, _headers, responseStream, contentType ?? _contentType ?? RequestData.DefaultMimeType, body?.Length ?? 0, null, null);
 	}
 
 	/// <inheritdoc cref="BuildResponse{TResponse}"/>>
@@ -122,13 +117,8 @@ public class InMemoryRequestInvoker : IRequestInvoker
 
 		Stream responseStream = body != null ? requestData.MemoryStreamFactory.Create(body) : requestData.MemoryStreamFactory.Create(EmptyBody);
 
-		var isStreamResponse = typeof(TResponse) == typeof(StreamResponse);
-
-		using (isStreamResponse ? Stream.Null : responseStream ??= Stream.Null)
-		{
-			return await requestData.ConnectionSettings.ProductRegistration.ResponseBuilder
-				.ToResponseAsync<TResponse>(requestData, _exception, sc, _headers, responseStream, contentType ?? _contentType, body?.Length ?? 0, null, null, cancellationToken)
-				.ConfigureAwait(false);
-		}
+		return await requestData.ConnectionSettings.ProductRegistration.ResponseBuilder
+			.ToResponseAsync<TResponse>(requestData, _exception, sc, _headers, responseStream, contentType ?? _contentType, body?.Length ?? 0, null, null, cancellationToken)
+			.ConfigureAwait(false);
 	}
 }

--- a/src/Elastic.Transport/Components/TransportClient/InMemoryRequestInvoker.cs
+++ b/src/Elastic.Transport/Components/TransportClient/InMemoryRequestInvoker.cs
@@ -109,10 +109,16 @@ public class InMemoryRequestInvoker : IRequestInvoker
 		requestData.MadeItToResponse = true;
 
 		var sc = statusCode ?? _statusCode;
-		Stream s = body != null ? requestData.MemoryStreamFactory.Create(body) : requestData.MemoryStreamFactory.Create(EmptyBody);
-		return await requestData.ConnectionSettings.ProductRegistration.ResponseBuilder
-			.ToResponseAsync<TResponse>(requestData, _exception, sc, _headers, s, contentType ?? _contentType, body?.Length ?? 0, null, null, cancellationToken)
-			.ConfigureAwait(false);
-	}
 
+		Stream responseStream = body != null ? requestData.MemoryStreamFactory.Create(body) : requestData.MemoryStreamFactory.Create(EmptyBody);
+
+		var isStreamResponse = typeof(TResponse) == typeof(StreamResponse);
+
+		using (isStreamResponse ? Stream.Null : responseStream ??= Stream.Null)
+		{
+			return await requestData.ConnectionSettings.ProductRegistration.ResponseBuilder
+			.ToResponseAsync<TResponse>(requestData, _exception, sc, _headers, responseStream, contentType ?? _contentType, body?.Length ?? 0, null, null, cancellationToken)
+			.ConfigureAwait(false);
+		}
+	}
 }

--- a/src/Elastic.Transport/Requests/Body/PostData.cs
+++ b/src/Elastic.Transport/Requests/Body/PostData.cs
@@ -111,6 +111,7 @@ public abstract partial class PostData
 		buffer.Position = 0;
 		buffer.CopyTo(writableStream, BufferSize);
 		WrittenBytes ??= buffer.ToArray();
+		buffer.Dispose();
 	}
 
 	/// <summary>
@@ -132,5 +133,10 @@ public abstract partial class PostData
 		buffer.Position = 0;
 		await buffer.CopyToAsync(writableStream, BufferSize, ctx).ConfigureAwait(false);
 		WrittenBytes ??= buffer.ToArray();
+#if NET
+		await buffer.DisposeAsync().ConfigureAwait(false);
+#else
+		buffer.Dispose();
+#endif
 	}
 }

--- a/src/Elastic.Transport/Responses/Special/StreamResponse.cs
+++ b/src/Elastic.Transport/Responses/Special/StreamResponse.cs
@@ -13,13 +13,9 @@ namespace Elastic.Transport;
 /// <strong>MUST</strong> be disposed after use to ensure the HTTP connection is freed for reuse.
 /// </para>
 /// </summary>
-public class StreamResponse :
-	TransportResponse<Stream>,
-	IDisposable
+public class StreamResponse : TransportResponse<Stream>, IDisposable
 {
 	private bool _disposed;
-
-	internal Action? Finalizer { get; set; }
 
 	/// <summary>
 	/// The MIME type of the response, if present.
@@ -53,7 +49,12 @@ public class StreamResponse :
 			if (disposing)
 			{
 				Body.Dispose();
-				Finalizer?.Invoke();
+
+				if (LinkedDisposables is not null)
+				{
+					foreach (var disposable in LinkedDisposables)
+						disposable.Dispose();
+				}
 			}
 
 			_disposed = true;

--- a/src/Elastic.Transport/Responses/Special/StreamResponse.cs
+++ b/src/Elastic.Transport/Responses/Special/StreamResponse.cs
@@ -40,6 +40,8 @@ public class StreamResponse :
 		MimeType = mimeType ?? string.Empty;
 	}
 
+	internal override bool LeaveOpen => true;
+
 	/// <summary>
 	/// Disposes the underlying stream.
 	/// </summary>

--- a/src/Elastic.Transport/Responses/TransportResponse.cs
+++ b/src/Elastic.Transport/Responses/TransportResponse.cs
@@ -8,7 +8,7 @@ namespace Elastic.Transport;
 
 /// <summary>
 /// A response from an Elastic product including details about the request/response life cycle. Base class for the built in low level response
-/// types, <see cref="StringResponse"/>, <see cref="BytesResponse"/>, <see cref="DynamicResponse"/> and <see cref="VoidResponse"/>
+/// types, <see cref="StringResponse"/>, <see cref="BytesResponse"/>, <see cref="DynamicResponse"/>, <see cref="StreamResponse"/> and <see cref="VoidResponse"/>
 /// </summary>
 public abstract class TransportResponse<T> : TransportResponse
 {
@@ -34,5 +34,7 @@ public abstract class TransportResponse
 	public override string ToString() => ApiCallDetails?.DebugInformation
 		// ReSharper disable once ConstantNullCoalescingCondition
 		?? $"{nameof(ApiCallDetails)} not set, likely a bug, reverting to default ToString(): {base.ToString()}";
+
+	internal virtual bool LeaveOpen { get; } = false;
 }
 

--- a/src/Elastic.Transport/Responses/TransportResponse.cs
+++ b/src/Elastic.Transport/Responses/TransportResponse.cs
@@ -2,6 +2,8 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using System;
+using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
 namespace Elastic.Transport;
@@ -35,6 +37,10 @@ public abstract class TransportResponse
 		// ReSharper disable once ConstantNullCoalescingCondition
 		?? $"{nameof(ApiCallDetails)} not set, likely a bug, reverting to default ToString(): {base.ToString()}";
 
+	[JsonIgnore]
+	internal IEnumerable<IDisposable>? LinkedDisposables { get; set; }
+
+	[JsonIgnore]
 	internal virtual bool LeaveOpen { get; } = false;
 }
 

--- a/src/Elastic.Transport/Responses/TransportResponse.cs
+++ b/src/Elastic.Transport/Responses/TransportResponse.cs
@@ -40,9 +40,20 @@ public abstract class TransportResponse
 	/// <summary>
 	/// Allows other disposable resources to to be disposed along with the response.
 	/// </summary>
+	/// <remarks>
+	/// While it's slightly confusing to have this on the base type which is NOT IDisposable, it avoids
+	/// specialised type checking in the request invoker and response builder code. Currently, only used by
+	/// StreamResponse and kept internal. If we later make this public, we might need to refine this.
+	/// </remarks>
 	[JsonIgnore]
 	internal IEnumerable<IDisposable>? LinkedDisposables { get; set; }
 
+	/// <summary>
+	/// Allows the response to identify that the response stream should NOT be automatically disposed.
+	/// </summary>
+	/// <remarks>
+	/// Currently only used by StreamResponse and therefore internal.
+	/// </remarks>
 	[JsonIgnore]
 	internal virtual bool LeaveOpen { get; } = false;
 }

--- a/src/Elastic.Transport/Responses/TransportResponse.cs
+++ b/src/Elastic.Transport/Responses/TransportResponse.cs
@@ -37,6 +37,9 @@ public abstract class TransportResponse
 		// ReSharper disable once ConstantNullCoalescingCondition
 		?? $"{nameof(ApiCallDetails)} not set, likely a bug, reverting to default ToString(): {base.ToString()}";
 
+	/// <summary>
+	/// Allows other disposable resources to to be disposed along with the response.
+	/// </summary>
 	[JsonIgnore]
 	internal IEnumerable<IDisposable>? LinkedDisposables { get; set; }
 

--- a/tests/Elastic.Transport.IntegrationTests/Http/StreamResponseTests.cs
+++ b/tests/Elastic.Transport.IntegrationTests/Http/StreamResponseTests.cs
@@ -33,6 +33,23 @@ public class StreamResponseTests(TransportTestServer instance) : AssemblyServerT
 		_ = sr.ReadToEndAsync();
 	}
 
+	//[Fact]
+	//public async Task StreamResponse_MemoryStreamShouldNotBeDisposed()
+	//{
+	//	var nodePool = new SingleNodePool(Server.Uri);
+	//	var memoryStreamFactory = new TrackMemoryStreamFactory();
+	//	var config = new TransportConfiguration(nodePool, productRegistration: new ElasticsearchProductRegistration(typeof(Clients.Elasticsearch.ElasticsearchClient)))
+	//		.MemoryStreamFactory(memoryStreamFactory);
+
+	//	var transport = new DistributedTransport(config);
+
+	//	_ = await transport.PostAsync<StreamResponse>(Path, PostData.String("{}"));
+
+	//	var memoryStream = memoryStreamFactory.Created.Last();
+
+	//	memoryStream.IsDisposed.Should().BeFalse();
+	//}
+
 	[Fact]
 	public async Task StreamResponse_MemoryStreamShouldNotBeDisposed()
 	{
@@ -52,13 +69,12 @@ public class StreamResponseTests(TransportTestServer instance) : AssemblyServerT
 	}
 
 	[Fact]
-	public async Task  StringResponse_MemoryStreamShouldBeDisposed()
+	public async Task StringResponse_MemoryStreamShouldBeDisposed()
 	{
 		var nodePool = new SingleNodePool(Server.Uri);
 		var memoryStreamFactory = new TrackMemoryStreamFactory();
 		var config = new TransportConfiguration(nodePool, productRegistration: new ElasticsearchProductRegistration(typeof(Clients.Elasticsearch.ElasticsearchClient)))
-			.MemoryStreamFactory(memoryStreamFactory)
-			.DisableDirectStreaming(true);
+			.MemoryStreamFactory(memoryStreamFactory);
 
 		var transport = new DistributedTransport(config);
 
@@ -67,6 +83,27 @@ public class StreamResponseTests(TransportTestServer instance) : AssemblyServerT
 		var memoryStream = memoryStreamFactory.Created.Last();
 
 		memoryStream.IsDisposed.Should().BeTrue();
+	}
+
+	[Fact]
+	public async Task Response_MemoryStreamShouldBeDisposed()
+	{
+		var nodePool = new SingleNodePool(Server.Uri);
+		var memoryStreamFactory = new TrackMemoryStreamFactory();
+		var config = new TransportConfiguration(nodePool, productRegistration: new ElasticsearchProductRegistration(typeof(Clients.Elasticsearch.ElasticsearchClient)))
+			.MemoryStreamFactory(memoryStreamFactory);
+
+		var transport = new DistributedTransport(config);
+
+		_ = await transport.PostAsync<TestResponse>(Path, PostData.String("{}"));
+
+		var memoryStream = memoryStreamFactory.Created.Last();
+
+		memoryStream.IsDisposed.Should().BeTrue();
+	}
+
+	private class TestResponse : TransportResponse
+	{
 	}
 
 	private class TrackDisposeStream : MemoryStream

--- a/tests/Elastic.Transport.IntegrationTests/Http/StreamResponseTests.cs
+++ b/tests/Elastic.Transport.IntegrationTests/Http/StreamResponseTests.cs
@@ -1,0 +1,38 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.IO;
+using System.Text.Json;
+using System.Threading.Tasks;
+using Elastic.Transport.IntegrationTests.Plumbing;
+using Elastic.Transport.Products.Elasticsearch;
+using Microsoft.AspNetCore.Mvc;
+using Xunit;
+
+namespace Elastic.Transport.IntegrationTests.Http;
+
+public class StreamResponseTests(TransportTestServer instance) : AssemblyServerTestsBase(instance)
+{
+	private const string Path = "/streamresponse";
+
+	[Fact]
+	public async Task StreamResponse_ShouldNotBeDisposed()
+	{
+		var nodePool = new SingleNodePool(Server.Uri);
+		var config = new TransportConfiguration(nodePool, productRegistration: new ElasticsearchProductRegistration(typeof(Clients.Elasticsearch.ElasticsearchClient)));
+		var transport = new DistributedTransport(config);
+
+		var response = await transport.PostAsync<StreamResponse>(Path, PostData.String("{}"));
+
+		var sr = new StreamReader(response.Body);
+		var responseString = sr.ReadToEndAsync();
+	}
+}
+
+[ApiController, Route("[controller]")]
+public class StreamResponseController : ControllerBase
+{
+	[HttpPost]
+	public Task<JsonElement> Post([FromBody] JsonElement body) => Task.FromResult(body);
+}

--- a/tests/Elastic.Transport.IntegrationTests/Http/StreamResponseTests.cs
+++ b/tests/Elastic.Transport.IntegrationTests/Http/StreamResponseTests.cs
@@ -2,11 +2,14 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
 using Elastic.Transport.IntegrationTests.Plumbing;
 using Elastic.Transport.Products.Elasticsearch;
+using FluentAssertions;
 using Microsoft.AspNetCore.Mvc;
 using Xunit;
 
@@ -25,8 +28,88 @@ public class StreamResponseTests(TransportTestServer instance) : AssemblyServerT
 
 		var response = await transport.PostAsync<StreamResponse>(Path, PostData.String("{}"));
 
-		var sr = new StreamReader(response.Body);
-		var responseString = sr.ReadToEndAsync();
+		// Ensure the stream is readable
+		using var sr = new StreamReader(response.Body);
+		_ = sr.ReadToEndAsync();
+	}
+
+	[Fact]
+	public async Task StreamResponse_MemoryStreamShouldNotBeDisposed()
+	{
+		var nodePool = new SingleNodePool(Server.Uri);
+		var memoryStreamFactory = new TrackMemoryStreamFactory();
+		var config = new TransportConfiguration(nodePool, productRegistration: new ElasticsearchProductRegistration(typeof(Clients.Elasticsearch.ElasticsearchClient)))
+			.MemoryStreamFactory(memoryStreamFactory)
+			.DisableDirectStreaming(true);
+
+		var transport = new DistributedTransport(config);
+
+		_ = await transport.PostAsync<StreamResponse>(Path, PostData.String("{}"));
+
+		var memoryStream = memoryStreamFactory.Created.Last();
+
+		memoryStream.IsDisposed.Should().BeFalse();
+	}
+
+	[Fact]
+	public async Task  StringResponse_MemoryStreamShouldBeDisposed()
+	{
+		var nodePool = new SingleNodePool(Server.Uri);
+		var memoryStreamFactory = new TrackMemoryStreamFactory();
+		var config = new TransportConfiguration(nodePool, productRegistration: new ElasticsearchProductRegistration(typeof(Clients.Elasticsearch.ElasticsearchClient)))
+			.MemoryStreamFactory(memoryStreamFactory)
+			.DisableDirectStreaming(true);
+
+		var transport = new DistributedTransport(config);
+
+		_ = await transport.PostAsync<StringResponse>(Path, PostData.String("{}"));
+
+		var memoryStream = memoryStreamFactory.Created.Last();
+
+		memoryStream.IsDisposed.Should().BeTrue();
+	}
+
+	private class TrackDisposeStream : MemoryStream
+	{
+		public TrackDisposeStream() { }
+
+		public TrackDisposeStream(byte[] bytes) : base(bytes) { }
+
+		public TrackDisposeStream(byte[] bytes, int index, int count) : base(bytes, index, count) { }
+
+		public bool IsDisposed { get; private set; }
+
+		protected override void Dispose(bool disposing)
+		{
+			IsDisposed = true;
+			base.Dispose(disposing);
+		}
+	}
+
+	private class TrackMemoryStreamFactory : MemoryStreamFactory
+	{
+		public IList<TrackDisposeStream> Created { get; } = [];
+
+		public override MemoryStream Create()
+		{
+			var stream = new TrackDisposeStream();
+			Created.Add(stream);
+			return stream;
+		}
+
+		public override MemoryStream Create(byte[] bytes)
+		{
+			var stream = new TrackDisposeStream(bytes);
+			Created.Add(stream);
+			return stream;
+		}
+
+		public override MemoryStream Create(byte[] bytes, int index, int count)
+		{
+			var stream = new TrackDisposeStream(bytes, index, count);
+			Created.Add(stream);
+			return stream;
+		}
 	}
 }
 

--- a/tests/Elastic.Transport.Tests/Plumbing/InMemoryConnectionFactory.cs
+++ b/tests/Elastic.Transport.Tests/Plumbing/InMemoryConnectionFactory.cs
@@ -3,16 +3,17 @@
 // See the LICENSE file in the project root for more information
 
 using System;
+using Elastic.Transport.Products;
 
 namespace Elastic.Transport.Tests.Plumbing
 {
 	public static class InMemoryConnectionFactory
 	{
-		public static TransportConfiguration Create()
+		public static TransportConfiguration Create(ProductRegistration productRegistration = null)
 		{
 			var invoker = new InMemoryRequestInvoker();
 			var pool = new SingleNodePool(new Uri("http://localhost:9200"));
-			var settings = new TransportConfiguration(pool, invoker);
+			var settings = new TransportConfiguration(pool, invoker, productRegistration: productRegistration);
 			return settings;
 		}
 	}

--- a/tests/Elastic.Transport.Tests/ResponseBuilderDisposeTests.cs
+++ b/tests/Elastic.Transport.Tests/ResponseBuilderDisposeTests.cs
@@ -5,8 +5,10 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Elastic.Transport.Products;
 using Elastic.Transport.Tests.Plumbing;
 using FluentAssertions;
 using Xunit;
@@ -19,52 +21,114 @@ public class ResponseBuilderDisposeTests
 	private readonly ITransportConfiguration _settingsDisableDirectStream = InMemoryConnectionFactory.Create().DisableDirectStreaming();
 
 	[Fact]
-	public async Task StreamResponseWithPotentialBody_StreamIsNotDisposed() => await AssertResponse<StreamResponse>(false, expectedDisposed: false);
+	public async Task StreamResponseWithPotentialBody_StreamIsNotDisposed() =>
+		await AssertResponse<StreamResponse>(false, expectedDisposed: false);
 
 	[Fact]
-	public async Task StreamResponseWithPotentialBodyAndDisableDirectStreaming_MemoryStreamIsNotDisposed() => await AssertResponse<StreamResponse>(true, expectedDisposed: false);
+	public async Task StreamResponseWithPotentialBodyAndDisableDirectStreaming_MemoryStreamIsNotDisposed() =>
+		await AssertResponse<StreamResponse>(true, expectedDisposed: false);
 
 	[Fact]
-	public async Task StreamResponseWith204StatusCode_StreamIsDisposed() => await AssertResponse<StreamResponse>(false, 204);
+	public async Task StreamResponseWith204StatusCode_StreamIsDisposed() =>
+		await AssertResponse<StreamResponse>(false, 204);
 
 	[Fact]
-	public async Task StreamResponseForHeadRequest_StreamIsDisposed() => await AssertResponse<StreamResponse>(false, httpMethod: HttpMethod.HEAD);
+	public async Task StreamResponseForHeadRequest_StreamIsDisposed() =>
+		await AssertResponse<StreamResponse>(false, httpMethod: HttpMethod.HEAD);
 
 	[Fact]
-	public async Task StreamResponseWithZeroContentLength_StreamIsDisposed() => await AssertResponse<StreamResponse>(false, contentLength: 0);
+	public async Task StreamResponseWithZeroContentLength_StreamIsDisposed() =>
+		await AssertResponse<StreamResponse>(false, contentLength: 0);
 
 	[Fact]
-	public async Task ResponseWithPotentialBody_StreamIsDisposed() => await AssertResponse<TestResponse>(false, expectedDisposed: true);
+	public async Task ResponseWithPotentialBody_StreamIsDisposed() =>
+		await AssertResponse<TestResponse>(false, expectedDisposed: true);
 
 	[Fact]
-	public async Task ResponseWithPotentialBodyAndDisableDirectStreaming_MemoryStreamIsDisposed() => await AssertResponse<TestResponse>(true, expectedDisposed: true);
+	public async Task ResponseWithPotentialBodyButInvalidMimeType_StreamIsDisposed() =>
+		await AssertResponse<TestResponse>(false, mimeType: "application/not-valid", expectedDisposed: true);
 
 	[Fact]
-	public async Task ResponseWith204StatusCode_StreamIsDisposed() => await AssertResponse<TestResponse>(false, 204);
+	public async Task ResponseWithPotentialBodyButSkippedStatusCode_StreamIsDisposed() =>
+		await AssertResponse<TestResponse>(false, skipStatusCode: 200, expectedDisposed: true);
 
 	[Fact]
-	public async Task ResponseForHeadRequest_StreamIsDisposed() => await AssertResponse<TestResponse>(false, httpMethod: HttpMethod.HEAD);
+	public async Task ResponseWithPotentialBodyButEmptyJson_StreamIsDisposed() =>
+		await AssertResponse<TestResponse>(false, responseJson: "  ", expectedDisposed: true);
 
 	[Fact]
-	public async Task ResponseWithZeroContentLength_StreamIsDisposed() => await AssertResponse<TestResponse>(false, contentLength: 0);
+	// NOTE: The empty string here hits a fast path in STJ which returns default if the stream length is zero.
+	public async Task ResponseWithPotentialBodyButNullResponseDuringDeserialization_StreamIsDisposed() =>
+		await AssertResponse<TestResponse>(false, responseJson: "", expectedDisposed: true);
 
 	[Fact]
-	public async Task StringResponseWithPotentialBodyAndDisableDirectStreaming_MemoryStreamIsDisposed() => await AssertResponse<StringResponse>(true, expectedDisposed: true, memoryStreamCreateExpected: 1);
+	public async Task ResponseWithPotentialBodyAndCustomResponseBuilder_StreamIsDisposed() =>
+		await AssertResponse<TestResponse>(false, customResponseBuilder: new TestCustomResponseBuilder(), expectedDisposed: true);
 
-	private async Task AssertResponse<T>(bool disableDirectStreaming, int statusCode = 200, HttpMethod httpMethod = HttpMethod.GET, int contentLength = 10, bool expectedDisposed = true, int memoryStreamCreateExpected = -1)
-		 where T : TransportResponse, new()
+	[Fact]
+	// NOTE: We expect one memory stream factory creation when handling error responses
+	public async Task ResponseWithPotentialBodyAndErrorResponse_StreamIsDisposed() =>
+		await AssertResponse<TestResponse>(false, productRegistration: new TestProductRegistration(), expectedDisposed: true, memoryStreamCreateExpected: 1);
+
+	[Fact]
+	public async Task ResponseWithPotentialBodyAndDisableDirectStreaming_MemoryStreamIsDisposed() =>
+		await AssertResponse<TestResponse>(true, expectedDisposed: true);
+
+	[Fact]
+	public async Task ResponseWith204StatusCode_StreamIsDisposed() =>
+		await AssertResponse<TestResponse>(false, 204);
+
+	[Fact]
+	public async Task ResponseForHeadRequest_StreamIsDisposed() =>
+		await AssertResponse<TestResponse>(false, httpMethod: HttpMethod.HEAD);
+
+	[Fact]
+	public async Task ResponseWithZeroContentLength_StreamIsDisposed() =>
+		await AssertResponse<TestResponse>(false, contentLength: 0);
+
+	[Fact]
+	public async Task StringResponseWithPotentialBodyAndDisableDirectStreaming_MemoryStreamIsDisposed() =>
+		await AssertResponse<StringResponse>(true, expectedDisposed: true, memoryStreamCreateExpected: 1);
+
+	private async Task AssertResponse<T>(bool disableDirectStreaming, int statusCode = 200, HttpMethod httpMethod = HttpMethod.GET, int contentLength = 10,
+		bool expectedDisposed = true, string mimeType = "application/json", string responseJson = "{}", int skipStatusCode = -1,
+		CustomResponseBuilder customResponseBuilder = null, ProductRegistration productRegistration = null, int memoryStreamCreateExpected = -1)
+			where T : TransportResponse, new()
 	{
-		var settings = disableDirectStreaming ? _settingsDisableDirectStream : _settings;
-		var memoryStreamFactory = new TrackMemoryStreamFactory();
+		ITransportConfiguration config;
 
-		var requestData = new RequestData(httpMethod, "/", null, settings, null, null, memoryStreamFactory, default)
+		if (skipStatusCode > -1 )
+		{
+			config = InMemoryConnectionFactory.Create(productRegistration)
+				.DisableDirectStreaming(disableDirectStreaming)
+				.SkipDeserializationForStatusCodes(skipStatusCode);
+		}
+		else if (productRegistration is not null)
+		{
+			config = InMemoryConnectionFactory.Create(productRegistration)
+				.DisableDirectStreaming(disableDirectStreaming);
+		}
+		else
+		{
+			config = disableDirectStreaming ? _settingsDisableDirectStream : _settings;
+		}
+
+		var memoryStreamFactory = new TrackMemoryStreamFactory();
+		
+		var requestData = new RequestData(httpMethod, "/", null, config, null, customResponseBuilder, memoryStreamFactory, default)
 		{
 			Node = new Node(new Uri("http://localhost:9200"))
 		};
 
 		var stream = new TrackDisposeStream();
 
-		var response = _settings.ProductRegistration.ResponseBuilder.ToResponse<T>(requestData, null, statusCode, null, stream, null, contentLength, null, null);
+		if (!string.IsNullOrEmpty(responseJson))
+		{
+			stream.Write(Encoding.UTF8.GetBytes(responseJson), 0, responseJson.Length);
+			stream.Position = 0;
+		}
+
+		var response = config.ProductRegistration.ResponseBuilder.ToResponse<T>(requestData, null, statusCode, null, stream, mimeType, contentLength, null, null);
 
 		response.Should().NotBeNull();
 
@@ -83,12 +147,12 @@ public class ResponseBuilderDisposeTests
 		stream = new TrackDisposeStream();
 		var ct = new CancellationToken();
 
-		response = await _settings.ProductRegistration.ResponseBuilder.ToResponseAsync<T>(requestData, null, statusCode, null, stream, null, contentLength, null, null,
+		response = await config.ProductRegistration.ResponseBuilder.ToResponseAsync<T>(requestData, null, statusCode, null, stream, null, contentLength, null, null,
 			cancellationToken: ct);
 
 		response.Should().NotBeNull();
 
-		memoryStreamFactory.Created.Count.Should().Be(memoryStreamCreateExpected > -1 ? memoryStreamCreateExpected + 1: disableDirectStreaming ? 2 : 0);
+		memoryStreamFactory.Created.Count.Should().Be(memoryStreamCreateExpected > -1 ? memoryStreamCreateExpected + 1 : disableDirectStreaming ? 2 : 0);
 		if (disableDirectStreaming)
 		{
 			var memoryStream = memoryStreamFactory.Created[0];
@@ -100,6 +164,66 @@ public class ResponseBuilderDisposeTests
 			stream.IsDisposed.Should().Be(expectedDisposed);
 		}
 	}
+
+	private class TestProductRegistration : ProductRegistration
+	{
+		public override string DefaultMimeType => "application/json";
+		public override string Name => "name";
+		public override string ServiceIdentifier => "id";
+		public override bool SupportsPing => false;
+		public override bool SupportsSniff => false;
+		public override HeadersList ResponseHeadersToParse => [];
+		public override MetaHeaderProvider MetaHeaderProvider => null;
+		public override string ProductAssemblyVersion => "0.0.0";
+		public override IReadOnlyDictionary<string, object> DefaultOpenTelemetryAttributes => new Dictionary<string, object>();
+		public override RequestData CreatePingRequestData(Node node, RequestConfiguration requestConfiguration, ITransportConfiguration global, MemoryStreamFactory memoryStreamFactory) => throw new NotImplementedException();
+		public override RequestData CreateSniffRequestData(Node node, IRequestConfiguration requestConfiguration, ITransportConfiguration settings, MemoryStreamFactory memoryStreamFactory) => throw new NotImplementedException();
+		public override IReadOnlyCollection<string> DefaultHeadersToParse() => [];
+		public override bool HttpStatusCodeClassifier(HttpMethod method, int statusCode) => true;
+		public override bool NodePredicate(Node node) => throw new NotImplementedException();
+		public override Dictionary<string, object> ParseOpenTelemetryAttributesFromApiCallDetails(ApiCallDetails callDetails) => throw new NotImplementedException();
+		public override TransportResponse Ping(IRequestInvoker requestInvoker, RequestData pingData) => throw new NotImplementedException();
+		public override Task<TransportResponse> PingAsync(IRequestInvoker requestInvoker, RequestData pingData, CancellationToken cancellationToken) => throw new NotImplementedException();
+		public override Tuple<TransportResponse, IReadOnlyCollection<Node>> Sniff(IRequestInvoker requestInvoker, bool forceSsl, RequestData requestData) => throw new NotImplementedException();
+		public override Task<Tuple<TransportResponse, IReadOnlyCollection<Node>>> SniffAsync(IRequestInvoker requestInvoker, bool forceSsl, RequestData requestData, CancellationToken cancellationToken) => throw new NotImplementedException();
+		public override int SniffOrder(Node node) => throw new NotImplementedException();
+		public override bool TryGetServerErrorReason<TResponse>(TResponse response, out string reason) => throw new NotImplementedException();
+		public override ResponseBuilder ResponseBuilder => new TestErrorResponseBuilder();
+	}
+
+	private class TestError : ErrorResponse
+	{
+		public string MyError { get; set; }
+
+		public override bool HasError() => true;
+	}
+
+	private class TestErrorResponseBuilder : DefaultResponseBuilder<TestError>
+	{
+		protected override void SetErrorOnResponse<TResponse>(TResponse response, TestError error)
+		{
+			// nothing to do in this scenario
+		}
+
+		protected override bool TryGetError(ApiCallDetails apiCallDetails, RequestData requestData, Stream responseStream, out TestError error)
+		{
+			error = new TestError();
+			return true;
+		}
+
+		protected override bool RequiresErrorDeserialization(ApiCallDetails details, RequestData requestData) => true;
+	}
+
+	private class TestCustomResponseBuilder : CustomResponseBuilder
+	{
+		public override object DeserializeResponse(Serializer serializer, ApiCallDetails response, Stream stream) =>
+			new TestResponse { ApiCallDetails = response };
+
+		public override Task<object> DeserializeResponseAsync(Serializer serializer, ApiCallDetails response, Stream stream, CancellationToken ctx = default) =>
+			Task.FromResult<object>(new TestResponse { ApiCallDetails = response });
+	}
+
+	private class TestRequestParameters : RequestParameters { }
 
 	private class TrackDisposeStream : MemoryStream
 	{

--- a/tests/Elastic.Transport.Tests/ResponseBuilderDisposeTests.cs
+++ b/tests/Elastic.Transport.Tests/ResponseBuilderDisposeTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -15,42 +16,89 @@ namespace Elastic.Transport.Tests;
 public class ResponseBuilderDisposeTests
 {
 	private readonly ITransportConfiguration _settings = InMemoryConnectionFactory.Create().DisableDirectStreaming(false);
+	private readonly ITransportConfiguration _settingsDisableDirectStream = InMemoryConnectionFactory.Create().DisableDirectStreaming();
 
 	[Fact]
-	public async Task ResponseWithPotentialBody_StreamIsNotDisposed() => await AssertResponse(expectedDisposed: false);
+	public async Task StreamResponseWithPotentialBody_StreamIsNotDisposed() => await AssertResponse<StreamResponse>(false, expectedDisposed: false);
 
 	[Fact]
-	public async Task ResponseWith204StatusCode_StreamIsDisposed() => await AssertResponse(204);
+	public async Task StreamResponseWithPotentialBodyAndDisableDirectStreaming_MemoryStreamIsNotDisposed() => await AssertResponse<StreamResponse>(true, expectedDisposed: false);
 
 	[Fact]
-	public async Task ResponseForHeadRequest_StreamIsDisposed() => await AssertResponse(httpMethod: HttpMethod.HEAD);
+	public async Task StreamResponseWith204StatusCode_StreamIsDisposed() => await AssertResponse<StreamResponse>(false, 204);
 
 	[Fact]
-	public async Task ResponseWithZeroContentLength_StreamIsDisposed() => await AssertResponse(contentLength: 0);
+	public async Task StreamResponseForHeadRequest_StreamIsDisposed() => await AssertResponse<StreamResponse>(false, httpMethod: HttpMethod.HEAD);
 
-	private async Task AssertResponse(int statusCode = 200, HttpMethod httpMethod = HttpMethod.GET, int contentLength = 10, bool expectedDisposed = true)
+	[Fact]
+	public async Task StreamResponseWithZeroContentLength_StreamIsDisposed() => await AssertResponse<StreamResponse>(false, contentLength: 0);
+
+	[Fact]
+	public async Task ResponseWithPotentialBody_StreamIsDisposed() => await AssertResponse<TestResponse>(false, expectedDisposed: true);
+
+	[Fact]
+	public async Task ResponseWithPotentialBodyAndDisableDirectStreaming_MemoryStreamIsDisposed() => await AssertResponse<TestResponse>(true, expectedDisposed: true);
+
+	[Fact]
+	public async Task ResponseWith204StatusCode_StreamIsDisposed() => await AssertResponse<TestResponse>(false, 204);
+
+	[Fact]
+	public async Task ResponseForHeadRequest_StreamIsDisposed() => await AssertResponse<TestResponse>(false, httpMethod: HttpMethod.HEAD);
+
+	[Fact]
+	public async Task ResponseWithZeroContentLength_StreamIsDisposed() => await AssertResponse<TestResponse>(false, contentLength: 0);
+
+	[Fact]
+	public async Task StringResponseWithPotentialBodyAndDisableDirectStreaming_MemoryStreamIsDisposed() => await AssertResponse<StringResponse>(true, expectedDisposed: true, memoryStreamCreateExpected: 1);
+
+	private async Task AssertResponse<T>(bool disableDirectStreaming, int statusCode = 200, HttpMethod httpMethod = HttpMethod.GET, int contentLength = 10, bool expectedDisposed = true, int memoryStreamCreateExpected = -1)
+		 where T : TransportResponse, new()
 	{
-		var settings = _settings;
-		var requestData = new RequestData(httpMethod, "/", null, settings, null, null, null, default)
+		var settings = disableDirectStreaming ? _settingsDisableDirectStream : _settings;
+		var memoryStreamFactory = new TrackMemoryStreamFactory();
+
+		var requestData = new RequestData(httpMethod, "/", null, settings, null, null, memoryStreamFactory, default)
 		{
 			Node = new Node(new Uri("http://localhost:9200"))
 		};
 
 		var stream = new TrackDisposeStream();
 
-		var response = _settings.ProductRegistration.ResponseBuilder.ToResponse<TestResponse>(requestData, null, statusCode, null, stream, null, contentLength, null, null);
+		var response = _settings.ProductRegistration.ResponseBuilder.ToResponse<T>(requestData, null, statusCode, null, stream, null, contentLength, null, null);
 
 		response.Should().NotBeNull();
-		stream.IsDisposed.Should().Be(expectedDisposed);
+
+		memoryStreamFactory.Created.Count.Should().Be(memoryStreamCreateExpected > -1 ? memoryStreamCreateExpected : disableDirectStreaming ? 1 : 0);
+		if (disableDirectStreaming)
+		{
+			var memoryStream = memoryStreamFactory.Created[0];
+			stream.IsDisposed.Should().BeTrue();
+			memoryStream.IsDisposed.Should().Be(expectedDisposed);
+		}
+		else
+		{
+			stream.IsDisposed.Should().Be(expectedDisposed);
+		}
 
 		stream = new TrackDisposeStream();
 		var ct = new CancellationToken();
 
-		response = await _settings.ProductRegistration.ResponseBuilder.ToResponseAsync<TestResponse>(requestData, null, statusCode, null, stream, null, contentLength, null, null,
+		response = await _settings.ProductRegistration.ResponseBuilder.ToResponseAsync<T>(requestData, null, statusCode, null, stream, null, contentLength, null, null,
 			cancellationToken: ct);
 
 		response.Should().NotBeNull();
-		stream.IsDisposed.Should().Be(expectedDisposed);
+
+		memoryStreamFactory.Created.Count.Should().Be(memoryStreamCreateExpected > -1 ? memoryStreamCreateExpected + 1: disableDirectStreaming ? 2 : 0);
+		if (disableDirectStreaming)
+		{
+			var memoryStream = memoryStreamFactory.Created[0];
+			stream.IsDisposed.Should().BeTrue();
+			memoryStream.IsDisposed.Should().Be(expectedDisposed);
+		}
+		else
+		{
+			stream.IsDisposed.Should().Be(expectedDisposed);
+		}
 	}
 
 	private class TrackDisposeStream : MemoryStream
@@ -67,6 +115,32 @@ public class ResponseBuilderDisposeTests
 		{
 			IsDisposed = true;
 			base.Dispose(disposing);
+		}
+	}
+
+	private class TrackMemoryStreamFactory : MemoryStreamFactory
+	{
+		public IList<TrackDisposeStream> Created { get; } = [];
+
+		public override MemoryStream Create()
+		{
+			var stream = new TrackDisposeStream();
+			Created.Add(stream);
+			return stream;
+		}
+
+		public override MemoryStream Create(byte[] bytes)
+		{
+			var stream = new TrackDisposeStream(bytes);
+			Created.Add(stream);
+			return stream;
+		}
+
+		public override MemoryStream Create(byte[] bytes, int index, int count)
+		{
+			var stream = new TrackDisposeStream(bytes, index, count);
+			Created.Add(stream);
+			return stream;
 		}
 	}
 }

--- a/tests/Elastic.Transport.Tests/ResponseBuilderDisposeTests.cs
+++ b/tests/Elastic.Transport.Tests/ResponseBuilderDisposeTests.cs
@@ -29,8 +29,8 @@ public class ResponseBuilderDisposeTests
 		await AssertResponse<StreamResponse>(true, expectedDisposed: false);
 
 	[Fact]
-	public async Task StreamResponseWith204StatusCode_StreamIsDisposed() =>
-		await AssertResponse<StreamResponse>(false, 204);
+	public async Task StreamResponseWith204StatusCode_MemoryStreamIsDisposed() =>
+		await AssertResponse<StreamResponse>(true, 204);
 
 	[Fact]
 	public async Task StreamResponseForHeadRequest_StreamIsDisposed() =>
@@ -222,8 +222,6 @@ public class ResponseBuilderDisposeTests
 		public override Task<object> DeserializeResponseAsync(Serializer serializer, ApiCallDetails response, Stream stream, CancellationToken ctx = default) =>
 			Task.FromResult<object>(new TestResponse { ApiCallDetails = response });
 	}
-
-	private class TestRequestParameters : RequestParameters { }
 
 	private class TrackDisposeStream : MemoryStream
 	{


### PR DESCRIPTION
Updated `ResponseBuilderDefaults` to include `StreamResponse` in `SpecialTypes`. Refactored `SetBodyCoreAsync` in `DefaultResponseBuilder.cs` for readability and removed unnecessary `using` statements. Modified `RequestCoreAsync` in `HttpWebRequestInvoker.cs` and `BuildResponseAsync` in `InMemoryRequestInvoker.cs` to handle `StreamResponse` types with proper disposal. Updated `Elastic.Transport.csproj` to reference `System.Text.Json` version `8.0.5`.