### PR TITLE
Add per request configuration and response builder support

### DIFF
--- a/src/Elastic.Transport.VirtualizedCluster/Components/ExposingPipelineFactory.cs
+++ b/src/Elastic.Transport.VirtualizedCluster/Components/ExposingPipelineFactory.cs
@@ -2,6 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+#nullable enable
 namespace Elastic.Transport.VirtualizedCluster.Components;
 
 /// <summary>
@@ -14,7 +15,7 @@ public sealed class ExposingPipelineFactory<TConfiguration> : RequestPipelineFac
 		DateTimeProvider = dateTimeProvider;
 		MemoryStreamFactory = TransportConfiguration.DefaultMemoryStreamFactory;
 		Configuration = configuration;
-		Pipeline = Create(Configuration, DateTimeProvider, MemoryStreamFactory, new DefaultRequestParameters());
+		Pipeline = Create(Configuration, DateTimeProvider, MemoryStreamFactory, null);
 		RequestHandler = new DistributedTransport<TConfiguration>(Configuration, this, DateTimeProvider, MemoryStreamFactory);
 	}
 
@@ -26,6 +27,6 @@ public sealed class ExposingPipelineFactory<TConfiguration> : RequestPipelineFac
 	public ITransport<TConfiguration> RequestHandler { get; }
 
 	public override RequestPipeline Create(TConfiguration configurationValues, DateTimeProvider dateTimeProvider,
-		MemoryStreamFactory memoryStreamFactory, RequestParameters requestParameters) =>
-			new DefaultRequestPipeline<TConfiguration>(Configuration, DateTimeProvider, MemoryStreamFactory, requestParameters ?? new DefaultRequestParameters());
+		MemoryStreamFactory memoryStreamFactory, IRequestConfiguration? requestConfiguration) =>
+			new DefaultRequestPipeline<TConfiguration>(Configuration, DateTimeProvider, MemoryStreamFactory, requestConfiguration);
 }

--- a/src/Elastic.Transport.VirtualizedCluster/Components/VirtualizedCluster.cs
+++ b/src/Elastic.Transport.VirtualizedCluster/Components/VirtualizedCluster.cs
@@ -27,24 +27,28 @@ public class VirtualizedCluster
 		_exposingRequestPipeline = new ExposingPipelineFactory<ITransportConfiguration>(settings, _dateTimeProvider);
 
 		_syncCall = (t, r) => t.Request<VirtualResponse>(
-			HttpMethod.GET, "/",
-			PostData.Serializable(new {}), new DefaultRequestParameters()
-		{
-				RequestConfiguration = r?.Invoke(new RequestConfigurationDescriptor(null))
-		});
+			method: HttpMethod.GET,
+			path: "/",
+			postData: PostData.Serializable(new { }),
+			requestParameters: new DefaultRequestParameters(),
+			openTelemetryData: default,
+			localConfiguration: r?.Invoke(new RequestConfigurationDescriptor(null)),
+			responseBuilder: null
+		);
 		_asyncCall = async (t, r) =>
 		{
 			var res = await t.RequestAsync<VirtualResponse>
 			(
-				HttpMethod.GET, "/",
-				PostData.Serializable(new { }),
-				new DefaultRequestParameters()
-				{
-					RequestConfiguration = r?.Invoke(new RequestConfigurationDescriptor(null))
-				},
+				method: HttpMethod.GET,
+				path: "/",
+				postData: PostData.Serializable(new { }),
+				requestParameters: new DefaultRequestParameters(),
+				openTelemetryData: default,
+				localConfiguration: r?.Invoke(new RequestConfigurationDescriptor(null)),
+				responseBuilder: null,
 				CancellationToken.None
 			).ConfigureAwait(false);
-			return (TransportResponse)res;
+			return res;
 		};
 	}
 

--- a/src/Elastic.Transport/Components/Pipeline/DefaultRequestPipeline.cs
+++ b/src/Elastic.Transport/Components/Pipeline/DefaultRequestPipeline.cs
@@ -36,7 +36,7 @@ public class DefaultRequestPipeline<TConfiguration> : RequestPipeline
 		TConfiguration configurationValues,
 		DateTimeProvider dateTimeProvider,
 		MemoryStreamFactory memoryStreamFactory,
-		RequestParameters requestParameters
+		IRequestConfiguration? requestConfiguration
 	)
 	{
 		_settings = configurationValues;
@@ -47,7 +47,7 @@ public class DefaultRequestPipeline<TConfiguration> : RequestPipeline
 		_productRegistration = configurationValues.ProductRegistration;
 		_responseBuilder = _productRegistration.ResponseBuilder;
 		_nodePredicate = _settings.NodePredicate ?? _productRegistration.NodePredicate;
-		RequestConfiguration = requestParameters?.RequestConfiguration;
+		RequestConfiguration = requestConfiguration;
 		StartedOn = dateTimeProvider.Now();
 	}
 

--- a/src/Elastic.Transport/Components/Providers/DefaultRequestPipelineFactory.cs
+++ b/src/Elastic.Transport/Components/Providers/DefaultRequestPipelineFactory.cs
@@ -14,6 +14,6 @@ internal sealed class DefaultRequestPipelineFactory<TConfiguration> : RequestPip
 	/// returns instances of <see cref="DefaultRequestPipeline{TConfiguration}"/>
 	/// </summary>
 	public override RequestPipeline Create(TConfiguration configurationValues, DateTimeProvider dateTimeProvider,
-		MemoryStreamFactory memoryStreamFactory, RequestParameters requestParameters) =>
-			new DefaultRequestPipeline<TConfiguration>(configurationValues, dateTimeProvider, memoryStreamFactory, requestParameters);
+		MemoryStreamFactory memoryStreamFactory, IRequestConfiguration? requestConfiguration) =>
+			new DefaultRequestPipeline<TConfiguration>(configurationValues, dateTimeProvider, memoryStreamFactory, requestConfiguration);
 }

--- a/src/Elastic.Transport/Components/Providers/RequestPipelineFactory.cs
+++ b/src/Elastic.Transport/Components/Providers/RequestPipelineFactory.cs
@@ -12,5 +12,5 @@ public abstract class RequestPipelineFactory<TConfiguration>
 
 	/// <summary> Create an instance of <see cref="RequestPipeline"/> </summary>
 	public abstract RequestPipeline Create(TConfiguration configuration, DateTimeProvider dateTimeProvider,
-		MemoryStreamFactory memoryStreamFactory, RequestParameters requestParameters);
+		MemoryStreamFactory memoryStreamFactory, IRequestConfiguration? requestParameters);
 }

--- a/src/Elastic.Transport/Configuration/ITransportConfiguration.cs
+++ b/src/Elastic.Transport/Configuration/ITransportConfiguration.cs
@@ -93,7 +93,7 @@ public interface ITransportConfiguration : IDisposable
 	/// <summary>
 	/// Try to send these headers for every request
 	/// </summary>
-	NameValueCollection Headers { get; }
+	NameValueCollection? Headers { get; }
 
 	/// <summary>
 	/// Whether HTTP pipelining is enabled. The default is <c>true</c>
@@ -143,18 +143,18 @@ public interface ITransportConfiguration : IDisposable
 	/// When using static or single node connection pooling it is assumed the list of node you instantiate the client with should be taken
 	/// verbatim.
 	/// </summary>
-	Func<Node, bool> NodePredicate { get; }
+	Func<Node, bool>? NodePredicate { get; }
 
 	/// <summary>
 	/// Allows you to register a callback every time a an API call is returned
 	/// </summary>
-	Action<ApiCallDetails> OnRequestCompleted { get; }
+	Action<ApiCallDetails>? OnRequestCompleted { get; }
 
 	/// <summary>
 	/// An action to run when the <see cref="RequestData" /> for a request has been
 	/// created.
 	/// </summary>
-	Action<RequestData> OnRequestDataCreated { get; }
+	Action<RequestData>? OnRequestDataCreated { get; }
 
 	/// <summary>
 	/// When enabled, all headers from the HTTP response will be included in the <see cref="ApiCallDetails"/>.
@@ -184,7 +184,7 @@ public interface ITransportConfiguration : IDisposable
 	/// <summary>
 	/// Append these query string parameters automatically to every request
 	/// </summary>
-	NameValueCollection QueryStringParameters { get; }
+	NameValueCollection? QueryStringParameters { get; }
 
 	/// <summary>The serializer to use to serialize requests and deserialize responses</summary>
 	Serializer RequestResponseSerializer { get; }

--- a/src/Elastic.Transport/Configuration/RequestConfiguration.cs
+++ b/src/Elastic.Transport/Configuration/RequestConfiguration.cs
@@ -131,7 +131,7 @@ public interface IRequestConfiguration
 	/// <summary>
 	/// Holds additional meta data about the request.
 	/// </summary>
-	RequestMetaData RequestMetaData { get; set; }
+	RequestMetaData? RequestMetaData { get; set; }
 }
 
 /// <inheritdoc cref="IRequestConfiguration"/>
@@ -192,7 +192,7 @@ public class RequestConfiguration : IRequestConfiguration
 public class RequestConfigurationDescriptor : IRequestConfiguration
 {
 	/// <inheritdoc cref="IRequestConfiguration"/>
-	public RequestConfigurationDescriptor(IRequestConfiguration config)
+	public RequestConfigurationDescriptor(IRequestConfiguration? config)
 	{
 		Self.RequestTimeout = config?.RequestTimeout;
 		Self.PingTimeout = config?.PingTimeout;

--- a/src/Elastic.Transport/Diagnostics/OpenTelemetry/OpenTelemetryData.cs
+++ b/src/Elastic.Transport/Diagnostics/OpenTelemetry/OpenTelemetryData.cs
@@ -14,10 +14,10 @@ public readonly struct OpenTelemetryData
 	/// <summary>
 	/// The name to use for spans relating to a request.
 	/// </summary>
-	public readonly string? SpanName { get; init; }
+	public string? SpanName { get; init; }
 
 	/// <summary>
 	/// Additional span attributes for transport spans relating to a request.
 	/// </summary>
-	public readonly Dictionary<string, object>? SpanAttributes { get; init; }
+	public Dictionary<string, object>? SpanAttributes { get; init; }
 }

--- a/src/Elastic.Transport/ITransport.cs
+++ b/src/Elastic.Transport/ITransport.cs
@@ -23,13 +23,21 @@ public interface ITransport
 	/// <param name="postData">The data to be included as the body of the HTTP request.</param>
 	/// <param name="requestParameters">The parameters for the request.</param>
 	/// <param name="openTelemetryData">Data to be used to control the OpenTelemetry instrumentation.</param>
+	/// <param name="localConfiguration">Per request configuration</param>
+	/// <param name="responseBuilder">
+	/// Allows callers to override completely how `TResponse` should be deserialized to a `TResponse` that implements <see cref="TransportResponse"/> instance.
+	/// <para>Expert setting only</para>
+	/// </param>
 	/// <returns>The deserialized <typeparamref name="TResponse"/>.</returns>
 	public TResponse Request<TResponse>(
 		HttpMethod method,
 		string path,
 		PostData? postData,
 		RequestParameters? requestParameters,
-		in OpenTelemetryData openTelemetryData)
+		in OpenTelemetryData openTelemetryData,
+		IRequestConfiguration? localConfiguration,
+		CustomResponseBuilder? responseBuilder
+	)
 		where TResponse : TransportResponse, new();
 
 
@@ -43,6 +51,11 @@ public interface ITransport
 	/// <param name="requestParameters">The parameters for the request.</param>
 	/// <param name="cancellationToken">The cancellation token to use.</param>
 	/// <param name="openTelemetryData">Data to be used to control the OpenTelemetry instrumentation.</param>
+	/// <param name="localConfiguration">Per request configuration</param>
+	/// <param name="responseBuilder">
+	/// Allows callers to override completely how `TResponse` should be deserialized to a `TResponse` that implements <see cref="TransportResponse"/> instance.
+	/// <para>Expert setting only</para>
+	/// </param>
 	/// <returns>The deserialized <typeparamref name="TResponse"/>.</returns>
 	public Task<TResponse> RequestAsync<TResponse>(
 		HttpMethod method,
@@ -50,7 +63,10 @@ public interface ITransport
 		PostData? postData,
 		RequestParameters? requestParameters,
 		in OpenTelemetryData openTelemetryData,
-		CancellationToken cancellationToken = default)
+		IRequestConfiguration? localConfiguration,
+		CustomResponseBuilder? responseBuilder,
+		CancellationToken cancellationToken = default
+	)
 		where TResponse : TransportResponse, new();
 }
 
@@ -79,7 +95,7 @@ public static class TransportExtensions
 		HttpMethod method,
 		string path)
 		where TResponse : TransportResponse, new()
-			=> transport.Request<TResponse>(method, path, null, null, default);
+			=> transport.Request<TResponse>(method, path, null, null, default, null, null);
 
 	/// <inheritdoc cref="ITransport.Request{TResponse}"/>>
 	public static TResponse Request<TResponse>(
@@ -88,7 +104,7 @@ public static class TransportExtensions
 		string path,
 		PostData? postData)
 		where TResponse : TransportResponse, new()
-			=> transport.Request<TResponse>(method, path, postData, null, default);
+			=> transport.Request<TResponse>(method, path, postData, null, default, null, null);
 
 	/// <inheritdoc cref="ITransport.Request{TResponse}"/>>
 	public static TResponse Request<TResponse>(
@@ -98,8 +114,18 @@ public static class TransportExtensions
 		PostData? postData,
 		RequestParameters? requestParameters)
 		where TResponse : TransportResponse, new()
-			=> transport.Request<TResponse>(method, path, postData, requestParameters, default);
+			=> transport.Request<TResponse>(method, path, postData, requestParameters, default, null, null);
 
+	/// <inheritdoc cref="ITransport.Request{TResponse}"/>>
+	public static TResponse Request<TResponse>(
+		this ITransport transport,
+		HttpMethod method,
+		string path,
+		PostData? postData,
+		RequestParameters? requestParameters,
+		IRequestConfiguration localConfiguration)
+		where TResponse : TransportResponse, new()
+			=> transport.Request<TResponse>(method, path, postData, requestParameters, default, localConfiguration, null);
 
 	/// <inheritdoc cref="ITransport.RequestAsync{TResponse}"/>>
 	public static Task<TResponse> RequestAsync<TResponse>(
@@ -108,7 +134,7 @@ public static class TransportExtensions
 		string path,
 		CancellationToken cancellationToken = default)
 		where TResponse : TransportResponse, new()
-			=> transport.RequestAsync<TResponse>(method, path, null, null, default, cancellationToken);
+			=> transport.RequestAsync<TResponse>(method, path, null, null, default, null, null, cancellationToken);
 
 	/// <inheritdoc cref="ITransport.RequestAsync{TResponse}"/>>
 	public static Task<TResponse> RequestAsync<TResponse>(
@@ -118,7 +144,7 @@ public static class TransportExtensions
 		PostData? postData,
 		CancellationToken cancellationToken = default)
 		where TResponse : TransportResponse, new()
-			=> transport.RequestAsync<TResponse>(method, path, postData, null, default, cancellationToken);
+			=> transport.RequestAsync<TResponse>(method, path, postData, null, default, null, null, cancellationToken);
 
 	/// <inheritdoc cref="ITransport.RequestAsync{TResponse}"/>>
 	public static Task<TResponse> RequestAsync<TResponse>(
@@ -129,5 +155,17 @@ public static class TransportExtensions
 		RequestParameters? requestParameters,
 		CancellationToken cancellationToken = default)
 		where TResponse : TransportResponse, new()
-			=> transport.RequestAsync<TResponse>(method, path, postData, requestParameters, default, cancellationToken);
+			=> transport.RequestAsync<TResponse>(method, path, postData, requestParameters, default, null, null, cancellationToken);
+
+	/// <inheritdoc cref="ITransport.RequestAsync{TResponse}"/>>
+	public static Task<TResponse> RequestAsync<TResponse>(
+		this ITransport transport,
+		HttpMethod method,
+		string path,
+		PostData? postData,
+		RequestParameters? requestParameters,
+		IRequestConfiguration localConfiguration,
+		CancellationToken cancellationToken = default)
+		where TResponse : TransportResponse, new()
+			=> transport.RequestAsync<TResponse>(method, path, postData, requestParameters, default, localConfiguration, null, cancellationToken);
 }

--- a/src/Elastic.Transport/Products/Elasticsearch/ElasticsearchProductRegistration.cs
+++ b/src/Elastic.Transport/Products/Elasticsearch/ElasticsearchProductRegistration.cs
@@ -127,9 +127,10 @@ public class ElasticsearchProductRegistration : ProductRegistration
 	{
 		var requestParameters = new DefaultRequestParameters
 		{
-			QueryString = { { "timeout", requestConfiguration.PingTimeout }, { "flat_settings", true }, }
+			QueryString = { { "timeout", requestConfiguration.PingTimeout }, { "flat_settings", true } }
 		};
-		return new RequestData(HttpMethod.GET, SniffPath, null, settings, requestParameters, memoryStreamFactory, default)
+		var sniffPath = requestParameters.CreatePathWithQueryStrings(SniffPath, settings);
+		return new RequestData(HttpMethod.GET, sniffPath, null, settings, requestConfiguration, null, memoryStreamFactory, default)
 		{
 			Node = node
 		};
@@ -162,12 +163,7 @@ public class ElasticsearchProductRegistration : ProductRegistration
 		MemoryStreamFactory memoryStreamFactory
 	)
 	{
-		var requestParameters = new DefaultRequestParameters
-		{
-			RequestConfiguration = requestConfiguration
-		};
-
-		var data = new RequestData(HttpMethod.HEAD, string.Empty, null, global, requestParameters, memoryStreamFactory, default)
+		var data = new RequestData(HttpMethod.HEAD, string.Empty, null, global, requestConfiguration, null, memoryStreamFactory, default)
 		{
 			Node = node
 		};

--- a/src/Elastic.Transport/Requests/Body/PostData.Serializable.cs
+++ b/src/Elastic.Transport/Requests/Body/PostData.Serializable.cs
@@ -42,8 +42,7 @@ public abstract partial class PostData
 			FinishStream(writableStream, buffer, settings);
 		}
 
-		public override async Task WriteAsync(Stream writableStream, ITransportConfiguration settings,
-			CancellationToken cancellationToken)
+		public override async Task WriteAsync(Stream writableStream, ITransportConfiguration settings, CancellationToken cancellationToken)
 		{
 			MemoryStream buffer = null;
 			var stream = writableStream;

--- a/tests/Elastic.Elasticsearch.IntegrationTests/SecurityClusterTests.cs
+++ b/tests/Elastic.Elasticsearch.IntegrationTests/SecurityClusterTests.cs
@@ -33,13 +33,13 @@ public class SecurityClusterTests : IntegrationTestBase<SecurityCluster>
 	[Fact]
 	public void SyncRequestDoesNotThrowOnBadAuth()
 	{
-		var response = RequestHandler.Request<StringResponse>(GET, "/", null, new DefaultRequestParameters
-		{
-			RequestConfiguration = new RequestConfiguration
+		var response = RequestHandler.Request<StringResponse>(GET, "/", null,
+			new DefaultRequestParameters(),
+			new RequestConfiguration
 			{
 				AuthenticationHeader = new BasicAuthentication("unknown-user", "bad-password")
 			}
-		});
+		);
 		response.ApiCallDetails.Should().NotBeNull();
 		response.ApiCallDetails.HasSuccessfulStatusCode.Should().BeFalse();
 	}

--- a/tests/Elastic.Transport.Tests/OpenTelemetryTests.cs
+++ b/tests/Elastic.Transport.Tests/OpenTelemetryTests.cs
@@ -129,7 +129,7 @@ public class OpenTelemetryTests
 		var mre = new ManualResetEvent(false);
 
 		var callCounter = 0;
-		using var listener = new ActivityListener()
+		using var listener = new ActivityListener
 		{
 			ActivityStarted = _ => { },
 			ActivityStopped = activity =>
@@ -149,7 +149,7 @@ public class OpenTelemetryTests
 
 		transport ??= new DistributedTransport(InMemoryConnectionFactory.Create());
 
-		_ = await transport.RequestAsync<VoidResponse>(HttpMethod.GET, "/", null, null, openTelemetryData);
+		_ = await transport.RequestAsync<VoidResponse>(HttpMethod.GET, "/", null, null, openTelemetryData, null, null, default);
 
 		mre.WaitOne(TimeSpan.FromSeconds(1)).Should().BeTrue();
 	}

--- a/tests/Elastic.Transport.Tests/ResponseBuilderDisposeTests.cs
+++ b/tests/Elastic.Transport.Tests/ResponseBuilderDisposeTests.cs
@@ -33,7 +33,7 @@ namespace Elastic.Transport.Tests
 		{
 			var settings = disableDirectStreaming ? _settingsDisableDirectStream : _settings;
 			var memoryStreamFactory = new TrackMemoryStreamFactory();
-			var requestData = new RequestData(HttpMethod.GET, "/", null, settings, null, memoryStreamFactory, default)
+			var requestData = new RequestData(HttpMethod.GET, "/", null, settings, null, null, memoryStreamFactory, default)
 			{
 				Node = new Node(new Uri("http://localhost:9200"))
 			};
@@ -80,7 +80,7 @@ namespace Elastic.Transport.Tests
 			var settings = disableDirectStreaming ? _settingsDisableDirectStream : _settings;
 			var memoryStreamFactory = new TrackMemoryStreamFactory();
 
-			var requestData = new RequestData(HttpMethod.GET, "/", null, settings, null, memoryStreamFactory, default)
+			var requestData = new RequestData(HttpMethod.GET, "/", null, settings, null, null, memoryStreamFactory, default)
 			{
 				Node = new Node(new Uri("http://localhost:9200"))
 			};

--- a/tests/Elastic.Transport.Tests/Test.cs
+++ b/tests/Elastic.Transport.Tests/Test.cs
@@ -74,16 +74,6 @@ namespace Elastic.Transport.Tests
 			public MyClientConfiguration NewSettings(string value) => Assign(value, (c, v) => _setting = v);
 		}
 
-		public class MyClientRequestPipeline : DefaultRequestPipeline<MyClientConfiguration>
-		{
-			public MyClientRequestPipeline(MyClientConfiguration configurationValues,
-				DateTimeProvider dateTimeProvider, MemoryStreamFactory memoryStreamFactory,
-					RequestParameters requestParameters)
-						: base(configurationValues, dateTimeProvider, memoryStreamFactory, requestParameters)
-			{
-			}
-		}
-
 		public void ExtendingConfiguration()
 		{
 			var clientConfiguration = new MyClientConfiguration()


### PR DESCRIPTION
Added parameters for local request configuration and custom response builders to the `ITransport` interface methods. Also enhanced nullable references and improved type safety in various classes and methods to accommodate these changes.
