### PR TITLE
Refactor RequestData

### DIFF
--- a/Elastic.Transport.sln.DotSettings
+++ b/Elastic.Transport.sln.DotSettings
@@ -104,7 +104,7 @@ See the LICENSE file in the project root for more information</s:String>
       &lt;/Entry.Match&gt;&#xD;
       &lt;Entry.SortBy&gt;&#xD;
         &lt;Kind Is="Member" /&gt;&#xD;
-        &lt;Name Is="Enter Pattern Here" /&gt;&#xD;
+        &lt;Name  /&gt;&#xD;
       &lt;/Entry.SortBy&gt;&#xD;
     &lt;/Entry&gt;&#xD;
     &lt;Entry DisplayName="Fields"&gt;&#xD;
@@ -119,7 +119,7 @@ See the LICENSE file in the project root for more information</s:String>
       &lt;Entry.SortBy&gt;&#xD;
         &lt;Access /&gt;&#xD;
         &lt;Readonly /&gt;&#xD;
-        &lt;Name Is="Enter Pattern Here" /&gt;&#xD;
+        &lt;Name  /&gt;&#xD;
       &lt;/Entry.SortBy&gt;&#xD;
     &lt;/Entry&gt;&#xD;
     &lt;Entry DisplayName="Constructors"&gt;&#xD;
@@ -139,7 +139,7 @@ See the LICENSE file in the project root for more information</s:String>
       &lt;/Entry.Match&gt;&#xD;
       &lt;Entry.SortBy&gt;&#xD;
         &lt;Access /&gt;&#xD;
-        &lt;Name Is="Enter Pattern Here" /&gt;&#xD;
+        &lt;Name  /&gt;&#xD;
       &lt;/Entry.SortBy&gt;&#xD;
     &lt;/Entry&gt;&#xD;
     &lt;Entry DisplayName="Setup/Teardown Methods" Priority="100"&gt;&#xD;
@@ -203,7 +203,7 @@ See the LICENSE file in the project root for more information</s:String>
       &lt;/Entry.Match&gt;&#xD;
       &lt;Entry.SortBy&gt;&#xD;
         &lt;Kind Is="Member" /&gt;&#xD;
-        &lt;Name Is="Enter Pattern Here" /&gt;&#xD;
+        &lt;Name  /&gt;&#xD;
       &lt;/Entry.SortBy&gt;&#xD;
     &lt;/Entry&gt;&#xD;
     &lt;Entry DisplayName="Fields"&gt;&#xD;
@@ -218,7 +218,7 @@ See the LICENSE file in the project root for more information</s:String>
       &lt;Entry.SortBy&gt;&#xD;
         &lt;Access /&gt;&#xD;
         &lt;Readonly /&gt;&#xD;
-        &lt;Name Is="Enter Pattern Here" /&gt;&#xD;
+        &lt;Name  /&gt;&#xD;
       &lt;/Entry.SortBy&gt;&#xD;
     &lt;/Entry&gt;&#xD;
     &lt;Entry DisplayName="Constructors"&gt;&#xD;
@@ -238,7 +238,7 @@ See the LICENSE file in the project root for more information</s:String>
       &lt;/Entry.Match&gt;&#xD;
       &lt;Entry.SortBy&gt;&#xD;
         &lt;Access /&gt;&#xD;
-        &lt;Name Is="Enter Pattern Here" /&gt;&#xD;
+        &lt;Name  /&gt;&#xD;
       &lt;/Entry.SortBy&gt;&#xD;
     &lt;/Entry&gt;&#xD;
     &lt;Entry DisplayName="Interface Implementations"&gt;&#xD;
@@ -251,7 +251,7 @@ See the LICENSE file in the project root for more information</s:String>
       &lt;Entry.SortBy&gt;&#xD;
         &lt;ImplementsInterface Name="IDisposable" /&gt;&#xD;
         &lt;Access /&gt;&#xD;
-        &lt;Name Is="Enter Pattern Here" /&gt;&#xD;
+        &lt;Name  /&gt;&#xD;
       &lt;/Entry.SortBy&gt;&#xD;
     &lt;/Entry&gt;&#xD;
     &lt;Entry DisplayName="All other members" /&gt;&#xD;
@@ -505,6 +505,7 @@ See the LICENSE file in the project root for more information</s:String>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpKeepExistingMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpPlaceEmbeddedOnSameLineMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ECSharpUseContinuousIndentInsideBracesMigration/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002EMemberReordering_002EMigrations_002ECSharpFileLayoutPatternRemoveIsAttributeUpgrade/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EAlwaysTreatStructAsNotReorderableMigration/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/Environment/SettingsMigration/IsMigratorApplied/=JetBrains_002EReSharper_002EPsi_002ECSharp_002ECodeStyle_002ESettingsUpgrade_002EMigrateBlankLinesAroundFieldToBlankLinesAroundProperty/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/HighlightingManager/HighlightingEnabledByDefault/@EntryValue">False</s:Boolean>

--- a/src/Elastic.Transport.VirtualizedCluster/Components/VirtualClusterConnection.cs
+++ b/src/Elastic.Transport.VirtualizedCluster/Components/VirtualClusterConnection.cs
@@ -190,7 +190,6 @@ public class VirtualClusterRequestInvoker : IRequestInvoker
 		where TResponse : TransportResponse, new()
 		where TRule : IRule
 	{
-		requestData.MadeItToResponse = true;
 		if (rules.Count == 0)
 			throw new Exception($"No {origin} defined for the current VirtualCluster, so we do not know how to respond");
 

--- a/src/Elastic.Transport.VirtualizedCluster/Components/VirtualClusterConnection.cs
+++ b/src/Elastic.Transport.VirtualizedCluster/Components/VirtualClusterConnection.cs
@@ -110,9 +110,9 @@ public class VirtualClusterRequestInvoker : IRequestInvoker
 		}
 	}
 
-	private bool IsSniffRequest(RequestData requestData) => _productRegistration.IsSniffRequest(requestData);
+	private bool IsSniffRequest(Endpoint endpoint) => _productRegistration.IsSniffRequest(endpoint);
 
-	private bool IsPingRequest(RequestData requestData) => _productRegistration.IsPingRequest(requestData);
+	private bool IsPingRequest(Endpoint endpoint) => _productRegistration.IsPingRequest(endpoint);
 
 	/// <inheritdoc cref="IRequestInvoker.RequestAsync{TResponse}"/>>
 	public Task<TResponse> RequestAsync<TResponse>(Endpoint endpoint, RequestData requestData, CancellationToken cancellationToken)
@@ -129,7 +129,7 @@ public class VirtualClusterRequestInvoker : IRequestInvoker
 		try
 		{
 			var state = _calls[endpoint.Uri.Port];
-			if (IsSniffRequest(requestData))
+			if (IsSniffRequest(endpoint))
 			{
 				_ = Interlocked.Increment(ref state.Sniffed);
 				return HandleRules<TResponse, ISniffRule>(
@@ -142,7 +142,7 @@ public class VirtualClusterRequestInvoker : IRequestInvoker
 					(r) => _productRegistration.CreateSniffResponseBytes(_cluster.Nodes, _cluster.ElasticsearchVersion, _cluster.PublishAddressOverride, _cluster.SniffShouldReturnFqnd)
 				);
 			}
-			if (IsPingRequest(requestData))
+			if (IsPingRequest(endpoint))
 			{
 				_ = Interlocked.Increment(ref state.Pinged);
 				return HandleRules<TResponse, IRule>(

--- a/src/Elastic.Transport.VirtualizedCluster/Components/VirtualizedCluster.cs
+++ b/src/Elastic.Transport.VirtualizedCluster/Components/VirtualizedCluster.cs
@@ -32,7 +32,7 @@ public class VirtualizedCluster
 			postData: PostData.Serializable(new { }),
 			requestParameters: new DefaultRequestParameters(),
 			openTelemetryData: default,
-			localConfiguration: r?.Invoke(new RequestConfigurationDescriptor(null)),
+			localConfiguration: r?.Invoke(new RequestConfigurationDescriptor()),
 			responseBuilder: null
 		);
 		_asyncCall = async (t, r) =>
@@ -44,7 +44,7 @@ public class VirtualizedCluster
 				postData: PostData.Serializable(new { }),
 				requestParameters: new DefaultRequestParameters(),
 				openTelemetryData: default,
-				localConfiguration: r?.Invoke(new RequestConfigurationDescriptor(null)),
+				localConfiguration: r?.Invoke(new RequestConfigurationDescriptor()),
 				responseBuilder: null,
 				CancellationToken.None
 			).ConfigureAwait(false);

--- a/src/Elastic.Transport.VirtualizedCluster/Components/VirtualizedCluster.cs
+++ b/src/Elastic.Transport.VirtualizedCluster/Components/VirtualizedCluster.cs
@@ -18,7 +18,9 @@ public class VirtualizedCluster
 	private Func<ITransport<ITransportConfiguration>, Func<RequestConfigurationDescriptor, IRequestConfiguration>, Task<TransportResponse>> _asyncCall;
 	private Func<ITransport<ITransportConfiguration>, Func<RequestConfigurationDescriptor, IRequestConfiguration>, TransportResponse> _syncCall;
 
-	private class VirtualResponse : TransportResponse { }
+	private class VirtualResponse : TransportResponse;
+
+	private static readonly EndpointPath RootPath = new(HttpMethod.GET, "/");
 
 	internal VirtualizedCluster(TestableDateTimeProvider dateTimeProvider, TransportConfiguration settings)
 	{
@@ -27,10 +29,8 @@ public class VirtualizedCluster
 		_exposingRequestPipeline = new ExposingPipelineFactory<ITransportConfiguration>(settings, _dateTimeProvider);
 
 		_syncCall = (t, r) => t.Request<VirtualResponse>(
-			method: HttpMethod.GET,
-			path: "/",
+			path: RootPath,
 			postData: PostData.Serializable(new { }),
-			requestParameters: new DefaultRequestParameters(),
 			openTelemetryData: default,
 			localConfiguration: r?.Invoke(new RequestConfigurationDescriptor()),
 			responseBuilder: null
@@ -39,10 +39,8 @@ public class VirtualizedCluster
 		{
 			var res = await t.RequestAsync<VirtualResponse>
 			(
-				method: HttpMethod.GET,
-				path: "/",
+				path: RootPath,
 				postData: PostData.Serializable(new { }),
-				requestParameters: new DefaultRequestParameters(),
 				openTelemetryData: default,
 				localConfiguration: r?.Invoke(new RequestConfigurationDescriptor()),
 				responseBuilder: null,

--- a/src/Elastic.Transport.VirtualizedCluster/Products/Elasticsearch/ElasticsearchMockProductRegistration.cs
+++ b/src/Elastic.Transport.VirtualizedCluster/Products/Elasticsearch/ElasticsearchMockProductRegistration.cs
@@ -22,10 +22,9 @@ public sealed class ElasticsearchMockProductRegistration : MockProductRegistrati
 	public override byte[] CreateSniffResponseBytes(IReadOnlyList<Node> nodes, string stackVersion, string publishAddressOverride, bool returnFullyQualifiedDomainNames) =>
 		ElasticsearchSniffResponseFactory.Create(nodes, stackVersion, publishAddressOverride, returnFullyQualifiedDomainNames);
 
-	public override bool IsSniffRequest(RequestData requestData) =>
-		requestData.PathAndQuery.StartsWith(ElasticsearchProductRegistration.SniffPath, StringComparison.Ordinal);
+	public override bool IsSniffRequest(Endpoint endpoint) =>
+		endpoint.PathAndQuery.StartsWith(ElasticsearchProductRegistration.SniffPath, StringComparison.Ordinal);
 
-	public override bool IsPingRequest(RequestData requestData) =>
-		requestData.Method == HttpMethod.HEAD &&
-		(requestData.PathAndQuery == string.Empty || requestData.PathAndQuery.StartsWith("?"));
+	public override bool IsPingRequest(Endpoint endpoint) =>
+		endpoint.Method == HttpMethod.HEAD && (endpoint.PathAndQuery == string.Empty || endpoint.PathAndQuery.StartsWith("?"));
 }

--- a/src/Elastic.Transport.VirtualizedCluster/Products/MockProductRegistration.cs
+++ b/src/Elastic.Transport.VirtualizedCluster/Products/MockProductRegistration.cs
@@ -31,7 +31,7 @@ public abstract class MockProductRegistration
 	/// see <see cref="VirtualClusterRequestInvoker.Request{TResponse}"/> uses this to determine if the current request is a sniff request and should follow
 	/// the sniffing rules
 	/// </summary>
-	public abstract bool IsSniffRequest(RequestData requestData);
+	public abstract bool IsSniffRequest(Endpoint endpoint);
 
-	public abstract bool IsPingRequest(RequestData requestData);
+	public abstract bool IsPingRequest(Endpoint endpoint);
 }

--- a/src/Elastic.Transport/Components/Pipeline/DefaultRequestPipeline.cs
+++ b/src/Elastic.Transport/Components/Pipeline/DefaultRequestPipeline.cs
@@ -178,7 +178,7 @@ public class DefaultRequestPipeline<TConfiguration> : RequestPipeline
 		using var audit = Audit(HealthyResponse, endpoint.Node);
 
 		if (audit is not null)
-			audit.PathAndQuery = requestData.PathAndQuery;
+			audit.PathAndQuery = endpoint.PathAndQuery;
 
 		try
 		{
@@ -413,7 +413,7 @@ public class DefaultRequestPipeline<TConfiguration> : RequestPipeline
 		TransportResponse response;
 
 		//TODO remove
-		var requestData = new RequestData(pingEndpoint.Method, pingEndpoint.PathAndQuery, null, _settings, null, null, _memoryStreamFactory, default);
+		var requestData = new RequestData(null, _settings, null, null, _memoryStreamFactory, default);
 
 		try
 		{
@@ -455,7 +455,7 @@ public class DefaultRequestPipeline<TConfiguration> : RequestPipeline
 		{
 			var sniffEndpoint = _productRegistration.CreateSniffEndpoint(node, PingAndSniffRequestConfiguration, _settings);
 			//TODO remove
-			var requestData = new RequestData(sniffEndpoint.Method, sniffEndpoint.PathAndQuery, null, _settings, null, null, _memoryStreamFactory, default);
+			var requestData = new RequestData(null, _settings, null, null, _memoryStreamFactory, default);
 
 			using var audit = Audit(SniffSuccess, node);
 

--- a/src/Elastic.Transport/Components/Pipeline/DefaultRequestPipeline.cs
+++ b/src/Elastic.Transport/Components/Pipeline/DefaultRequestPipeline.cs
@@ -417,7 +417,7 @@ public class DefaultRequestPipeline<TConfiguration> : RequestPipeline
 		TransportResponse response;
 
 		//TODO remove
-		var requestData = new RequestData(_settings, null, null, _memoryStreamFactory, default);
+		var requestData = new RequestData(_settings, null, null, _memoryStreamFactory);
 
 		try
 		{
@@ -462,7 +462,7 @@ public class DefaultRequestPipeline<TConfiguration> : RequestPipeline
 		{
 			var sniffEndpoint = _productRegistration.CreateSniffEndpoint(node, PingAndSniffRequestConfiguration, _settings);
 			//TODO remove
-			var requestData = new RequestData(_settings, null, null, _memoryStreamFactory, default);
+			var requestData = new RequestData(_settings, null, null, _memoryStreamFactory);
 
 			using var audit = Audit(SniffSuccess, node);
 

--- a/src/Elastic.Transport/Components/Pipeline/DefaultRequestPipeline.cs
+++ b/src/Elastic.Transport/Components/Pipeline/DefaultRequestPipeline.cs
@@ -413,7 +413,7 @@ public class DefaultRequestPipeline<TConfiguration> : RequestPipeline
 		TransportResponse response;
 
 		//TODO remove
-		var requestData = new RequestData(null, _settings, null, null, _memoryStreamFactory, default);
+		var requestData = new RequestData(_settings, null, null, _memoryStreamFactory, default);
 
 		try
 		{
@@ -455,7 +455,7 @@ public class DefaultRequestPipeline<TConfiguration> : RequestPipeline
 		{
 			var sniffEndpoint = _productRegistration.CreateSniffEndpoint(node, PingAndSniffRequestConfiguration, _settings);
 			//TODO remove
-			var requestData = new RequestData(null, _settings, null, null, _memoryStreamFactory, default);
+			var requestData = new RequestData(_settings, null, null, _memoryStreamFactory, default);
 
 			using var audit = Audit(SniffSuccess, node);
 

--- a/src/Elastic.Transport/Components/Pipeline/DefaultResponseBuilder.cs
+++ b/src/Elastic.Transport/Components/Pipeline/DefaultResponseBuilder.cs
@@ -48,6 +48,7 @@ internal class DefaultResponseBuilder<TError> : ResponseBuilder where TError : E
 	public override TResponse ToResponse<TResponse>(
 		Endpoint endpoint,
 		RequestData requestData,
+		PostData postData,
 		Exception ex,
 		int? statusCode,
 		Dictionary<string, IEnumerable<string>> headers,
@@ -60,7 +61,7 @@ internal class DefaultResponseBuilder<TError> : ResponseBuilder where TError : E
 	{
 		responseStream.ThrowIfNull(nameof(responseStream));
 
-		var details = Initialize(endpoint, requestData, ex, statusCode, headers, mimeType, threadPoolStats, tcpStats, contentLength);
+		var details = Initialize(endpoint, requestData, postData, ex, statusCode, headers, mimeType, threadPoolStats, tcpStats, contentLength);
 
 		TResponse response = null;
 
@@ -79,6 +80,7 @@ internal class DefaultResponseBuilder<TError> : ResponseBuilder where TError : E
 	public override async Task<TResponse> ToResponseAsync<TResponse>(
 		Endpoint endpoint,
 		RequestData requestData,
+		PostData postData,
 		Exception ex,
 		int? statusCode,
 		Dictionary<string, IEnumerable<string>> headers,
@@ -92,7 +94,7 @@ internal class DefaultResponseBuilder<TError> : ResponseBuilder where TError : E
 	{
 		responseStream.ThrowIfNull(nameof(responseStream));
 
-		var details = Initialize(endpoint, requestData, ex, statusCode, headers, mimeType, threadPoolStats, tcpStats, contentLength);
+		var details = Initialize(endpoint, requestData, postData, ex, statusCode, headers, mimeType, threadPoolStats, tcpStats, contentLength);
 
 		TResponse response = null;
 

--- a/src/Elastic.Transport/Components/Pipeline/DefaultResponseBuilder.cs
+++ b/src/Elastic.Transport/Components/Pipeline/DefaultResponseBuilder.cs
@@ -33,7 +33,7 @@ internal static class ResponseBuilderDefaults
 /// <summary>
 ///     A helper class that deals with handling how a <see cref="Stream" /> is transformed to the requested
 ///     <see cref="TransportResponse" /> implementation. This includes handling optionally buffering based on
-///     <see cref="ITransportConfiguration.DisableDirectStreaming" />. And handling short circuiting special responses
+///     <see cref="IRequestConfiguration.DisableDirectStreaming" />. And handling short circuiting special responses
 ///     such as <see cref="StringResponse" />, <see cref="BytesResponse" /> and <see cref="VoidResponse" />
 /// </summary>
 internal class DefaultResponseBuilder<TError> : ResponseBuilder where TError : ErrorResponse, new()
@@ -202,7 +202,7 @@ internal class DefaultResponseBuilder<TError> : ResponseBuilder where TError : E
 		where TResponse : TransportResponse, new()
 	{
 		byte[] bytes = null;
-		var disableDirectStreaming = requestData.PostData?.DisableDirectStreaming ?? requestData.ConnectionSettings.DisableDirectStreaming;
+		var disableDirectStreaming = requestData.DisableDirectStreaming;
 		var requiresErrorDeserialization = RequiresErrorDeserialization(details, requestData);
 
 		var ownsStream = false;

--- a/src/Elastic.Transport/Components/Pipeline/DefaultResponseBuilder.cs
+++ b/src/Elastic.Transport/Components/Pipeline/DefaultResponseBuilder.cs
@@ -65,7 +65,7 @@ internal class DefaultResponseBuilder<TError> : ResponseBuilder where TError : E
 		TResponse response = null;
 
 		// Only attempt to set the body if the response may have content
-		if (MayHaveBody(statusCode, requestData.Method, contentLength))
+		if (MayHaveBody(statusCode, endpoint.Method, contentLength))
 			response = SetBody<TResponse>(details, requestData, responseStream, mimeType);
 
 		response ??= new TResponse();
@@ -97,7 +97,7 @@ internal class DefaultResponseBuilder<TError> : ResponseBuilder where TError : E
 		TResponse response = null;
 
 		// Only attempt to set the body if the response may have content
-		if (MayHaveBody(statusCode, requestData.Method, contentLength))
+		if (MayHaveBody(statusCode, endpoint.Method, contentLength))
 			response = await SetBodyAsync<TResponse>(details, requestData, responseStream, mimeType,
 				cancellationToken).ConfigureAwait(false);
 

--- a/src/Elastic.Transport/Components/Pipeline/PipelineException.cs
+++ b/src/Elastic.Transport/Components/Pipeline/PipelineException.cs
@@ -17,7 +17,7 @@ public class PipelineException : Exception
 		: base(GetMessage(failure)) => FailureReason = failure;
 
 	/// <inheritdoc cref="PipelineException"/>
-	public PipelineException(PipelineFailure failure, Exception innerException)
+	public PipelineException(PipelineFailure failure, Exception? innerException)
 		: base(GetMessage(failure), innerException) => FailureReason = failure;
 
 	/// <inheritdoc cref="PipelineFailure"/>

--- a/src/Elastic.Transport/Components/Pipeline/PipelineFailure.cs
+++ b/src/Elastic.Transport/Components/Pipeline/PipelineFailure.cs
@@ -33,12 +33,12 @@ public enum PipelineFailure
 	CouldNotStartSniffOnStartup,
 
 	/// <summary>
-	/// The overall timeout specified by <see cref="ITransportConfiguration.MaxRetryTimeout"/> was reached
+	/// The overall timeout specified by <see cref="IRequestConfiguration.MaxRetryTimeout"/> was reached
 	/// </summary>
 	MaxTimeoutReached,
 
 	/// <summary>
-	/// The overall max retries as specified by <see cref="ITransportConfiguration.MaxRetries"/> was reached
+	/// The overall max retries as specified by <see cref="IRequestConfiguration.MaxRetries"/> was reached
 	/// </summary>
 	MaxRetriesReached,
 

--- a/src/Elastic.Transport/Components/Pipeline/RequestData.cs
+++ b/src/Elastic.Transport/Components/Pipeline/RequestData.cs
@@ -153,13 +153,10 @@ public sealed class RequestData
 	public bool ParseAllHeaders { get; }
 	public bool DisableAutomaticProxyDetection { get; }
 	public bool HttpCompression { get; }
-	public bool MadeItToResponse { get; set; }
 	public int KeepAliveInterval { get; }
 	public int KeepAliveTime { get; }
 	public MemoryStreamFactory MemoryStreamFactory { get; }
 
-	public AuditEvent OnFailureAuditEvent => MadeItToResponse ? AuditEvent.BadResponse : AuditEvent.BadRequest;
-	public PipelineFailure OnFailurePipelineFailure => MadeItToResponse ? PipelineFailure.BadResponse : PipelineFailure.BadRequest;
 	public TimeSpan PingTimeout { get; }
 	public bool Pipelined { get; }
 	public string ProxyAddress { get; }

--- a/src/Elastic.Transport/Components/Pipeline/RequestData.cs
+++ b/src/Elastic.Transport/Components/Pipeline/RequestData.cs
@@ -74,7 +74,6 @@ public sealed class RequestData
 	public const string RunAsSecurityHeader = "es-security-runas-user";
 
 	public RequestData(
-		PostData? data,
 		ITransportConfiguration global,
 		IRequestConfiguration? local,
 		CustomResponseBuilder? customResponseBuilder,
@@ -86,7 +85,6 @@ public sealed class RequestData
 		CustomResponseBuilder = customResponseBuilder;
 		ConnectionSettings = global;
 		MemoryStreamFactory = memoryStreamFactory;
-		//PostData = data;
 
 		SkipDeserializationForStatusCodes = global.SkipDeserializationForStatusCodes;
 		DnsRefreshTimeout = global.DnsRefreshTimeout;
@@ -99,14 +97,12 @@ public sealed class RequestData
 		KeepAliveInterval = (int)(global.KeepAliveInterval?.TotalMilliseconds ?? 2000);
 		KeepAliveTime = (int)(global.KeepAliveTime?.TotalMilliseconds ?? 2000);
 
-		RunAs = local.RunAs ?? global.RunAs;
+		RunAs = local?.RunAs ?? global.RunAs;
 
 		DisableDirectStreaming = local?.DisableDirectStreaming ?? global.DisableDirectStreaming ?? false;
-		if (data != null)
-			data.DisableDirectStreaming = DisableDirectStreaming;
 
 		Pipelined = local?.HttpPipeliningEnabled ?? global.HttpPipeliningEnabled ?? true;
-		HttpCompression = global.EnableHttpCompression ?? local.EnableHttpCompression ?? true;
+		HttpCompression = global.EnableHttpCompression ?? local?.EnableHttpCompression ?? true;
 		ContentType = local?.ContentType ?? global.Accept ?? DefaultMimeType;
 		Accept = local?.Accept ?? global.Accept ?? DefaultMimeType;
 		ThrowExceptions = local?.ThrowExceptions ?? global.ThrowExceptions ?? false;
@@ -166,7 +162,6 @@ public sealed class RequestData
 	public PipelineFailure OnFailurePipelineFailure => MadeItToResponse ? PipelineFailure.BadResponse : PipelineFailure.BadRequest;
 	public TimeSpan PingTimeout { get; }
 	public bool Pipelined { get; }
-	//public PostData? PostData { get; }
 	public string ProxyAddress { get; }
 	public string ProxyPassword { get; }
 	public string ProxyUsername { get; }

--- a/src/Elastic.Transport/Components/Pipeline/RequestData.cs
+++ b/src/Elastic.Transport/Components/Pipeline/RequestData.cs
@@ -178,8 +178,6 @@ public sealed class RequestData
 
 	public IReadOnlyDictionary<string, string> RequestMetaData { get; }
 
-	public bool IsAsync { get; internal set; }
-
 	internal OpenTelemetryData OpenTelemetryData { get; }
 
 	internal bool ValidateResponseContentType(string responseMimeType)

--- a/src/Elastic.Transport/Components/Pipeline/RequestData.cs
+++ b/src/Elastic.Transport/Components/Pipeline/RequestData.cs
@@ -86,7 +86,7 @@ public sealed class RequestData
 		CustomResponseBuilder = customResponseBuilder;
 		ConnectionSettings = global;
 		MemoryStreamFactory = memoryStreamFactory;
-		PostData = data;
+		//PostData = data;
 
 		SkipDeserializationForStatusCodes = global.SkipDeserializationForStatusCodes;
 		DnsRefreshTimeout = global.DnsRefreshTimeout;
@@ -166,7 +166,7 @@ public sealed class RequestData
 	public PipelineFailure OnFailurePipelineFailure => MadeItToResponse ? PipelineFailure.BadResponse : PipelineFailure.BadRequest;
 	public TimeSpan PingTimeout { get; }
 	public bool Pipelined { get; }
-	public PostData? PostData { get; }
+	//public PostData? PostData { get; }
 	public string ProxyAddress { get; }
 	public string ProxyPassword { get; }
 	public string ProxyUsername { get; }

--- a/src/Elastic.Transport/Components/Pipeline/RequestData.cs
+++ b/src/Elastic.Transport/Components/Pipeline/RequestData.cs
@@ -38,7 +38,6 @@ public record Endpoint(in EndpointPath Path, Node Node)
 	/// </summary>
 	public Uri Uri { get; } = new(Node.Uri, Path.PathAndQuery);
 
-
 	/// <summary> The HTTP method used for the request (e.g., GET, POST, PUT, DELETE, HEAD). </summary>
 	public HttpMethod Method => Path.Method;
 
@@ -77,11 +76,9 @@ public sealed class RequestData
 		ITransportConfiguration global,
 		IRequestConfiguration? local,
 		CustomResponseBuilder? customResponseBuilder,
-		MemoryStreamFactory memoryStreamFactory,
-		OpenTelemetryData openTelemetryData
+		MemoryStreamFactory memoryStreamFactory
 	)
 	{
-		OpenTelemetryData = openTelemetryData;
 		CustomResponseBuilder = customResponseBuilder;
 		ConnectionSettings = global;
 		MemoryStreamFactory = memoryStreamFactory;
@@ -178,7 +175,7 @@ public sealed class RequestData
 
 	public IReadOnlyDictionary<string, string> RequestMetaData { get; }
 
-	internal OpenTelemetryData OpenTelemetryData { get; }
+	//internal OpenTelemetryData OpenTelemetryData { get; }
 
 	internal bool ValidateResponseContentType(string responseMimeType)
 	{

--- a/src/Elastic.Transport/Components/Pipeline/RequestData.cs
+++ b/src/Elastic.Transport/Components/Pipeline/RequestData.cs
@@ -33,17 +33,6 @@ public readonly record struct EndpointPath(HttpMethod Method, string PathAndQuer
 /// </remarks>
 public record Endpoint(in EndpointPath Path, Node Node)
 {
-	/// <summary>
-	/// The <see cref="Uri" /> for the request.
-	/// </summary>
-	public Uri Uri { get; } = new(Node.Uri, Path.PathAndQuery);
-
-	/// <summary> The HTTP method used for the request (e.g., GET, POST, PUT, DELETE, HEAD). </summary>
-	public HttpMethod Method => Path.Method;
-
-	/// <summary> Gets the path and query of the endpoint.</summary>
-	public string PathAndQuery => Path.PathAndQuery;
-
 	/// <summary> Represents an empty endpoint used as a default or placeholder instance of <see cref="Endpoint"/>. </summary>
 	public static Endpoint Empty(in EndpointPath path) => new(path, EmptyNode);
 
@@ -51,6 +40,32 @@ public record Endpoint(in EndpointPath Path, Node Node)
 
 	/// <summary> Indicates whether the endpoint is an empty placeholder instance. </summary>
 	public bool IsEmpty => Node == EmptyNode;
+
+	/// <summary> The <see cref="Uri" /> for the request. </summary>
+	public Uri Uri { get; private init; } = new(Node.Uri, Path.PathAndQuery);
+
+	/// <summary> The HTTP method used for the request (e.g., GET, POST, PUT, DELETE, HEAD). </summary>
+	public HttpMethod Method => Path.Method;
+
+	/// <summary> Gets the path and query of the endpoint.</summary>
+	public string PathAndQuery => Path.PathAndQuery;
+
+	private readonly Node _node = Node;
+
+	/// <summary>
+	/// Represents a node within the transport layer of the Elastic search client.
+	/// This object encapsulates the characteristics of a node, allowing for comparisons and operations
+	/// within the broader search infrastructure.
+	/// </summary>
+	public Node Node
+	{
+		get => _node;
+		init
+		{
+			_node = value;
+			Uri = new(Node.Uri, Path.PathAndQuery);
+		}
+	}
 
 	/// <inheritdoc/>
 	public override string ToString() => $"{Path.Method.GetStringValue()} {Uri}";

--- a/src/Elastic.Transport/Components/Pipeline/RequestData.cs
+++ b/src/Elastic.Transport/Components/Pipeline/RequestData.cs
@@ -160,7 +160,7 @@ public sealed class RequestData
 	public ITransportConfiguration ConnectionSettings { get; }
 	public CustomResponseBuilder? CustomResponseBuilder { get; }
 	public HeadersList? ResponseHeadersToParse { get; }
-	public NameValueCollection Headers { get; }
+	public NameValueCollection? Headers { get; }
 	public bool DisableDirectStreaming { get; }
 	public bool ParseAllHeaders { get; }
 	public bool DisableAutomaticProxyDetection { get; }
@@ -186,7 +186,7 @@ public sealed class RequestData
 
 	public TimeSpan DnsRefreshTimeout { get; }
 
-	public MetaHeaderProvider MetaHeaderProvider { get; }
+	public MetaHeaderProvider? MetaHeaderProvider { get; }
 
 	public IReadOnlyDictionary<string, string> RequestMetaData { get; }
 

--- a/src/Elastic.Transport/Components/Pipeline/RequestPipeline.cs
+++ b/src/Elastic.Transport/Components/Pipeline/RequestPipeline.cs
@@ -45,10 +45,10 @@ public abstract class RequestPipeline : IDisposable
 
 	public abstract DateTimeOffset StartedOn { get; }
 
-	public abstract TResponse CallProductEndpoint<TResponse>(Endpoint endpoint, RequestData requestData)
+	public abstract TResponse CallProductEndpoint<TResponse>(Endpoint endpoint, RequestData requestData, PostData? postData)
 		where TResponse : TransportResponse, new();
 
-	public abstract Task<TResponse> CallProductEndpointAsync<TResponse>(Endpoint endpoint, RequestData requestData, CancellationToken cancellationToken)
+	public abstract Task<TResponse> CallProductEndpointAsync<TResponse>(Endpoint endpoint, RequestData requestData, PostData? postData, CancellationToken cancellationToken)
 		where TResponse : TransportResponse, new();
 
 	public abstract void MarkAlive(Node node);
@@ -87,7 +87,7 @@ public abstract class RequestPipeline : IDisposable
 
 	public abstract Task SniffOnConnectionFailureAsync(CancellationToken cancellationToken);
 
-	public abstract void BadResponse<TResponse>(ref TResponse response, ApiCallDetails callDetails, Endpoint endpoint, RequestData data, TransportException exception)
+	public abstract void BadResponse<TResponse>(ref TResponse response, ApiCallDetails callDetails, Endpoint endpoint, RequestData data, PostData? postData, TransportException exception)
 		where TResponse : TransportResponse, new();
 
 	public abstract void ThrowNoNodesAttempted(Endpoint endpoint, List<PipelineException>? seenExceptions);

--- a/src/Elastic.Transport/Components/Pipeline/RequestPipeline.cs
+++ b/src/Elastic.Transport/Components/Pipeline/RequestPipeline.cs
@@ -45,10 +45,10 @@ public abstract class RequestPipeline : IDisposable
 
 	public abstract DateTimeOffset StartedOn { get; }
 
-	public abstract TResponse CallProductEndpoint<TResponse>(RequestData requestData)
+	public abstract TResponse CallProductEndpoint<TResponse>(Endpoint endpoint, RequestData requestData)
 		where TResponse : TransportResponse, new();
 
-	public abstract Task<TResponse> CallProductEndpointAsync<TResponse>(RequestData requestData, CancellationToken cancellationToken)
+	public abstract Task<TResponse> CallProductEndpointAsync<TResponse>(Endpoint endpoint, RequestData requestData, CancellationToken cancellationToken)
 		where TResponse : TransportResponse, new();
 
 	public abstract void MarkAlive(Node node);
@@ -87,15 +87,15 @@ public abstract class RequestPipeline : IDisposable
 
 	public abstract Task SniffOnConnectionFailureAsync(CancellationToken cancellationToken);
 
-	public abstract void BadResponse<TResponse>(ref TResponse response, ApiCallDetails callDetails, RequestData data, TransportException exception)
+	public abstract void BadResponse<TResponse>(ref TResponse response, ApiCallDetails callDetails, Endpoint endpoint, RequestData data, TransportException exception)
 		where TResponse : TransportResponse, new();
 
-	public abstract void ThrowNoNodesAttempted(RequestData requestData, List<PipelineException>? seenExceptions);
+	public abstract void ThrowNoNodesAttempted(Endpoint endpoint, List<PipelineException>? seenExceptions);
 
 	public abstract void AuditCancellationRequested();
 
 	public abstract TransportException? CreateClientException<TResponse>(TResponse? response, ApiCallDetails? callDetails,
-		RequestData data, List<PipelineException>? seenExceptions)
+		Endpoint endpoint, RequestData data, List<PipelineException>? seenExceptions)
 		where TResponse : TransportResponse, new();
 #pragma warning restore 1591
 

--- a/src/Elastic.Transport/Components/Pipeline/ResponseBuilder.cs
+++ b/src/Elastic.Transport/Components/Pipeline/ResponseBuilder.cs
@@ -28,14 +28,15 @@ public abstract class ResponseBuilder
 	public abstract TResponse ToResponse<TResponse>(
 		Endpoint endpoint,
 		RequestData requestData,
-		Exception ex,
+		PostData? postData,
+		Exception? ex,
 		int? statusCode,
-		Dictionary<string, IEnumerable<string>> headers,
+		Dictionary<string, IEnumerable<string>>? headers,
 		Stream responseStream,
-		string mimeType,
+		string? mimeType,
 		long contentLength,
-		IReadOnlyDictionary<string, ThreadPoolStatistics> threadPoolStats,
-		IReadOnlyDictionary<TcpState, int> tcpStats
+		IReadOnlyDictionary<string, ThreadPoolStatistics>? threadPoolStats,
+		IReadOnlyDictionary<TcpState, int>? tcpStats
 
 	) where TResponse : TransportResponse, new();
 
@@ -45,19 +46,29 @@ public abstract class ResponseBuilder
 	public abstract Task<TResponse> ToResponseAsync<TResponse>(
 		Endpoint endpoint,
 		RequestData requestData,
-		Exception ex,
+		PostData? postData,
+		Exception? ex,
 		int? statusCode,
-		Dictionary<string, IEnumerable<string>> headers,
+		Dictionary<string, IEnumerable<string>>? headers,
 		Stream responseStream,
-		string mimeType,
+		string? mimeType,
 		long contentLength,
-		IReadOnlyDictionary<string, ThreadPoolStatistics> threadPoolStats,
-		IReadOnlyDictionary<TcpState, int> tcpStats,
+		IReadOnlyDictionary<string, ThreadPoolStatistics>? threadPoolStats,
+		IReadOnlyDictionary<TcpState, int>? tcpStats,
 		CancellationToken cancellationToken = default
 	) where TResponse : TransportResponse, new();
 
-	internal static ApiCallDetails Initialize(in Endpoint endpoint, RequestData requestData, Exception exception, int? statusCode, Dictionary<string, IEnumerable<string>> headers, string mimeType, IReadOnlyDictionary<string,
-		ThreadPoolStatistics> threadPoolStats, IReadOnlyDictionary<TcpState, int> tcpStats, long contentLength)
+	internal static ApiCallDetails Initialize(
+		Endpoint endpoint,
+		RequestData requestData,
+		PostData? postData,
+		Exception exception,
+		int? statusCode,
+		Dictionary<string, IEnumerable<string>> headers, string mimeType,
+		IReadOnlyDictionary<string,
+		ThreadPoolStatistics> threadPoolStats, IReadOnlyDictionary<TcpState, int> tcpStats,
+		long contentLength
+	)
 	{
 		var hasSuccessfulStatusCode = false;
 		var allowedStatusCodes = requestData.AllowedStatusCodes;
@@ -80,7 +91,7 @@ public abstract class ResponseBuilder
 			HasExpectedContentType = hasExpectedContentType,
 			OriginalException = exception,
 			HttpStatusCode = statusCode,
-			RequestBodyInBytes = requestData.PostData?.WrittenBytes,
+			RequestBodyInBytes = postData?.WrittenBytes,
 			Uri = endpoint.Uri,
 			HttpMethod = endpoint.Method,
 			TcpStats = tcpStats,

--- a/src/Elastic.Transport/Components/Pipeline/ResponseBuilder.cs
+++ b/src/Elastic.Transport/Components/Pipeline/ResponseBuilder.cs
@@ -67,12 +67,12 @@ public abstract class ResponseBuilder
 				hasSuccessfulStatusCode = true;
 			else
 				hasSuccessfulStatusCode = requestData.ConnectionSettings
-					.StatusCodeToResponseSuccess(requestData.Method, statusCode.Value);
+					.StatusCodeToResponseSuccess(endpoint.Method, statusCode.Value);
 		}
 
 		// We don't validate the content-type (MIME type) for HEAD requests or responses that have no content (204 status code).
 		// Elastic Cloud responses to HEAD requests strip the content-type header so we want to avoid validation in that case.
-		var hasExpectedContentType = !MayHaveBody(statusCode, requestData.Method, contentLength) || requestData.ValidateResponseContentType(mimeType);
+		var hasExpectedContentType = !MayHaveBody(statusCode, endpoint.Method, contentLength) || requestData.ValidateResponseContentType(mimeType);
 
 		var details = new ApiCallDetails
 		{
@@ -82,7 +82,7 @@ public abstract class ResponseBuilder
 			HttpStatusCode = statusCode,
 			RequestBodyInBytes = requestData.PostData?.WrittenBytes,
 			Uri = endpoint.Uri,
-			HttpMethod = requestData.Method,
+			HttpMethod = endpoint.Method,
 			TcpStats = tcpStats,
 			ThreadPoolStats = threadPoolStats,
 			ResponseMimeType = mimeType,

--- a/src/Elastic.Transport/Components/TransportClient/Content/RequestDataContent.cs
+++ b/src/Elastic.Transport/Components/TransportClient/Content/RequestDataContent.cs
@@ -57,7 +57,7 @@ internal sealed class RequestDataContent : HttpContent
 	{
 		if (data.HttpCompression) stream = new GZipStream(stream, CompressionMode.Compress, false);
 
-		using (stream) postData.Write(stream, data.ConnectionSettings);
+		using (stream) postData.Write(stream, data.ConnectionSettings, data.DisableDirectStreaming);
 	}
 
 	/// <summary> Constructor used in asynchronous paths. </summary>
@@ -84,7 +84,7 @@ internal sealed class RequestDataContent : HttpContent
 #else
 		using (stream)
 #endif
-		await postData.WriteAsync(stream, data.ConnectionSettings, ctx).ConfigureAwait(false);
+		await postData.WriteAsync(stream, data.ConnectionSettings, data.DisableDirectStreaming, ctx).ConfigureAwait(false);
 	}
 
 	/// <summary>

--- a/src/Elastic.Transport/Components/TransportClient/Content/RequestDataContent.cs
+++ b/src/Elastic.Transport/Components/TransportClient/Content/RequestDataContent.cs
@@ -29,17 +29,19 @@ namespace Elastic.Transport;
 internal sealed class RequestDataContent : HttpContent
 {
 	private readonly RequestData _requestData;
+	private readonly PostData _postData;
 
-	private readonly Func<RequestData, CompleteTaskOnCloseStream, RequestDataContent, TransportContext, CancellationToken, Task>
+	private readonly Func<RequestData, PostData, CompleteTaskOnCloseStream, RequestDataContent, TransportContext, CancellationToken, Task>
 		_onStreamAvailableAsync;
 
-	private readonly Action<RequestData, CompleteTaskOnCloseStream, RequestDataContent, TransportContext> _onStreamAvailable;
+	private readonly Action<RequestData, PostData, CompleteTaskOnCloseStream, RequestDataContent, TransportContext> _onStreamAvailable;
 	private readonly CancellationToken _token;
 
 	/// <summary> Constructor used in synchronous paths. </summary>
-	public RequestDataContent(RequestData requestData)
+	public RequestDataContent(RequestData requestData, PostData postData)
 	{
 		_requestData = requestData;
+		_postData = postData;
 		_token = default;
 
 		Headers.TryAddWithoutValidation("Content-Type", requestData.ContentType);
@@ -51,11 +53,11 @@ internal sealed class RequestDataContent : HttpContent
 		_onStreamAvailableAsync = OnStreamAvailableAsync;
 	}
 
-	private static void OnStreamAvailable(RequestData data, Stream stream, HttpContent content, TransportContext context)
+	private static void OnStreamAvailable(RequestData data, PostData postData, Stream stream, HttpContent content, TransportContext context)
 	{
 		if (data.HttpCompression) stream = new GZipStream(stream, CompressionMode.Compress, false);
 
-		using (stream) data.PostData.Write(stream, data.ConnectionSettings);
+		using (stream) postData.Write(stream, data.ConnectionSettings);
 	}
 
 	/// <summary> Constructor used in asynchronous paths. </summary>
@@ -73,7 +75,7 @@ internal sealed class RequestDataContent : HttpContent
 		_onStreamAvailableAsync = OnStreamAvailableAsync;
 	}
 
-	private static async Task OnStreamAvailableAsync(RequestData data, Stream stream, HttpContent content, TransportContext context, CancellationToken ctx = default)
+	private static async Task OnStreamAvailableAsync(RequestData data, PostData postData, Stream stream, HttpContent content, TransportContext context, CancellationToken ctx = default)
 	{
 		if (data.HttpCompression) stream = new GZipStream(stream, CompressionMode.Compress, false);
 
@@ -82,7 +84,7 @@ internal sealed class RequestDataContent : HttpContent
 #else
 		using (stream)
 #endif
-		await data.PostData.WriteAsync(stream, data.ConnectionSettings, ctx).ConfigureAwait(false);
+		await postData.WriteAsync(stream, data.ConnectionSettings, ctx).ConfigureAwait(false);
 	}
 
 	/// <summary>
@@ -108,7 +110,7 @@ internal sealed class RequestDataContent : HttpContent
 		var source = CancellationTokenSource.CreateLinkedTokenSource(_token, cancellationToken);
 		var serializeToStreamTask = new TaskCompletionSource<bool>();
 		var wrappedStream = new CompleteTaskOnCloseStream(stream, serializeToStreamTask);
-		await _onStreamAvailableAsync(_requestData, wrappedStream, this, context, source.Token).ConfigureAwait(false);
+		await _onStreamAvailableAsync(_requestData, _postData, wrappedStream, this, context, source.Token).ConfigureAwait(false);
 		await serializeToStreamTask.Task.ConfigureAwait(false);
 	}
 
@@ -117,7 +119,7 @@ internal sealed class RequestDataContent : HttpContent
 	{
 		var serializeToStreamTask = new TaskCompletionSource<bool>();
 		using var wrappedStream = new CompleteTaskOnCloseStream(stream, serializeToStreamTask);
-		_onStreamAvailable(_requestData, wrappedStream, this, context);
+		_onStreamAvailable(_requestData, _postData, wrappedStream, this, context);
 		//await serializeToStreamTask.Task.ConfigureAwait(false);
 	}
 #endif

--- a/src/Elastic.Transport/Components/TransportClient/HttpRequestInvoker.cs
+++ b/src/Elastic.Transport/Components/TransportClient/HttpRequestInvoker.cs
@@ -426,13 +426,13 @@ public class HttpRequestInvoker : IRequestInvoker
 			if (requestData.HttpCompression)
 			{
 				using var zipStream = new GZipStream(stream, CompressionMode.Compress, true);
-				postData.Write(zipStream, requestData.ConnectionSettings);
+				postData.Write(zipStream, requestData.ConnectionSettings, requestData.DisableDirectStreaming);
 			}
 			else
-				postData.Write(stream, requestData.ConnectionSettings);
+				postData.Write(stream, requestData.ConnectionSettings, requestData.DisableDirectStreaming);
 
 			// the written bytes are uncompressed, so can only be used when http compression isn't used
-			if (postData.DisableDirectStreaming.GetValueOrDefault(false) && !requestData.HttpCompression)
+			if (requestData.DisableDirectStreaming && !requestData.HttpCompression)
 			{
 				message.Content = new ByteArrayContent(postData.WrittenBytes);
 				stream.Dispose();
@@ -460,13 +460,13 @@ public class HttpRequestInvoker : IRequestInvoker
 			if (requestData.HttpCompression)
 			{
 				using var zipStream = new GZipStream(stream, CompressionMode.Compress, true);
-				await postData.WriteAsync(zipStream, requestData.ConnectionSettings, cancellationToken).ConfigureAwait(false);
+				await postData.WriteAsync(zipStream, requestData.ConnectionSettings, requestData.DisableDirectStreaming, cancellationToken).ConfigureAwait(false);
 			}
 			else
-				await postData.WriteAsync(stream, requestData.ConnectionSettings, cancellationToken).ConfigureAwait(false);
+				await postData.WriteAsync(stream, requestData.ConnectionSettings, requestData.DisableDirectStreaming, cancellationToken).ConfigureAwait(false);
 
 			// the written bytes are uncompressed, so can only be used when http compression isn't used
-			if (postData.DisableDirectStreaming.GetValueOrDefault(false) && !requestData.HttpCompression)
+			if (requestData.DisableDirectStreaming && !requestData.HttpCompression)
 			{
 				message.Content = new ByteArrayContent(postData.WrittenBytes);
 #if DOTNETCORE_2_1_OR_HIGHER

--- a/src/Elastic.Transport/Components/TransportClient/HttpRequestInvoker.cs
+++ b/src/Elastic.Transport/Components/TransportClient/HttpRequestInvoker.cs
@@ -193,7 +193,7 @@ public class HttpRequestInvoker : IRequestInvoker
 		{
 			// if there's an exception, ensure we always release the stream and response so that the connection is freed.
 			responseStream.Dispose();
-			receivedResponse.Dispose(); 
+			receivedResponse.Dispose();
 			throw;
 		}
 	}
@@ -343,7 +343,7 @@ public class HttpRequestInvoker : IRequestInvoker
 	internal void SetAuthenticationIfNeeded(Endpoint endpoint, RequestData requestData, HttpRequestMessage requestMessage)
 	{
 		//If user manually specifies an Authorization Header give it preference
-		if (requestData.Headers.HasKeys() && requestData.Headers.AllKeys.Contains("Authorization"))
+		if (requestData.Headers != null && requestData.Headers.HasKeys() && requestData.Headers.AllKeys.Contains("Authorization"))
 		{
 			var header = AuthenticationHeaderValue.Parse(requestData.Headers["Authorization"]);
 			requestMessage.Headers.Authorization = header;

--- a/src/Elastic.Transport/Components/TransportClient/HttpRequestInvoker.cs
+++ b/src/Elastic.Transport/Components/TransportClient/HttpRequestInvoker.cs
@@ -381,7 +381,7 @@ public class HttpRequestInvoker : IRequestInvoker
 
 	private static HttpRequestMessage CreateRequestMessage(Endpoint endpoint, RequestData requestData)
 	{
-		var method = ConvertHttpMethod(requestData.Method);
+		var method = ConvertHttpMethod(endpoint.Method);
 		var requestMessage = new HttpRequestMessage(method, endpoint.Uri);
 
 		if (requestData.Headers != null)

--- a/src/Elastic.Transport/Components/TransportClient/HttpRequestInvoker.cs
+++ b/src/Elastic.Transport/Components/TransportClient/HttpRequestInvoker.cs
@@ -122,7 +122,6 @@ public class HttpRequestInvoker : IRequestInvoker
 				statusCode = (int)responseMessage.StatusCode;
 			}
 
-			requestData.MadeItToResponse = true;
 			mimeType = responseMessage.Content.Headers.ContentType?.ToString();
 			responseHeaders = ParseHeaders(requestData, responseMessage);
 

--- a/src/Elastic.Transport/Components/TransportClient/HttpRequestInvoker.cs
+++ b/src/Elastic.Transport/Components/TransportClient/HttpRequestInvoker.cs
@@ -217,7 +217,7 @@ public class HttpRequestInvoker : IRequestInvoker
 				responseHeaders ??= new Dictionary<string, IEnumerable<string>>();
 				responseHeaders.Add(header.Key, header.Value);
 			}
-		else if (requestData.ResponseHeadersToParse.Count > 0)
+		else if (requestData.ResponseHeadersToParse is { Count:  > 0 })
 			foreach (var headerToParse in requestData.ResponseHeadersToParse)
 				if (responseMessage.Headers.TryGetValues(headerToParse, out var values))
 				{

--- a/src/Elastic.Transport/Components/TransportClient/HttpWebRequestInvoker.cs
+++ b/src/Elastic.Transport/Components/TransportClient/HttpWebRequestInvoker.cs
@@ -121,8 +121,6 @@ public class HttpWebRequestInvoker : IRequestInvoker
 				if (prepareRequestMs > OpenTelemetry.MinimumMillisecondsToEmitTimingSpanAttribute && OpenTelemetry.CurrentSpanIsElasticTransportOwnedHasListenersAndAllDataRequested)
 					Activity.Current?.SetTag(OpenTelemetryAttributes.ElasticTransportPrepareRequestMs, prepareRequestMs);
 
-				requestData.MadeItToResponse = true;
-
 				//http://msdn.microsoft.com/en-us/library/system.net.httpwebresponse.getresponsestream.aspx
 				//Either the stream or the response object needs to be closed but not both although it won't
 				//throw any errors if both are closed atleast one of them has to be Closed.

--- a/src/Elastic.Transport/Components/TransportClient/HttpWebRequestInvoker.cs
+++ b/src/Elastic.Transport/Components/TransportClient/HttpWebRequestInvoker.cs
@@ -232,7 +232,7 @@ public class HttpWebRequestInvoker : IRequestInvoker
 				responseHeaders.Add(key, responseMessage.Headers.GetValues(key));
 			}
 		}
-		else if (requestData.ResponseHeadersToParse.Count > 0)
+		else if (requestData.ResponseHeadersToParse is { Count: > 0 })
 		{
 			foreach (var headerToParse in requestData.ResponseHeadersToParse)
 			{

--- a/src/Elastic.Transport/Components/TransportClient/HttpWebRequestInvoker.cs
+++ b/src/Elastic.Transport/Components/TransportClient/HttpWebRequestInvoker.cs
@@ -373,7 +373,7 @@ public class HttpWebRequestInvoker : IRequestInvoker
 		//WebRequest won't send Content-Length: 0 for empty bodies
 		//which goes against RFC's and might break i.e IIS when used as a proxy.
 		//see: https://github.com/elastic/elasticsearch-net/issues/562
-		var m = requestData.Method.GetStringValue();
+		var m = endpoint.Method.GetStringValue();
 		request.Method = m;
 		if (m != "HEAD" && m != "GET" && requestData.PostData == null)
 			request.ContentLength = 0;

--- a/src/Elastic.Transport/Components/TransportClient/HttpWebRequestInvoker.cs
+++ b/src/Elastic.Transport/Components/TransportClient/HttpWebRequestInvoker.cs
@@ -95,10 +95,10 @@ public class HttpWebRequestInvoker : IRequestInvoker
 							if (requestData.HttpCompression)
 							{
 								using var zipStream = new GZipStream(stream, CompressionMode.Compress);
-								await data.WriteAsync(zipStream, requestData.ConnectionSettings, cancellationToken).ConfigureAwait(false);
+								await data.WriteAsync(zipStream, requestData.ConnectionSettings, requestData.DisableDirectStreaming, cancellationToken).ConfigureAwait(false);
 							}
 							else
-								await data.WriteAsync(stream, requestData.ConnectionSettings, cancellationToken).ConfigureAwait(false);
+								await data.WriteAsync(stream, requestData.ConnectionSettings, requestData.DisableDirectStreaming, cancellationToken).ConfigureAwait(false);
 						}
 						unregisterWaitHandle?.Invoke();
 					}
@@ -109,10 +109,10 @@ public class HttpWebRequestInvoker : IRequestInvoker
 						if (requestData.HttpCompression)
 						{
 							using var zipStream = new GZipStream(stream, CompressionMode.Compress);
-							data.Write(zipStream, requestData.ConnectionSettings);
+							data.Write(zipStream, requestData.ConnectionSettings, requestData.DisableDirectStreaming);
 						}
 						else
-							data.Write(stream, requestData.ConnectionSettings);
+							data.Write(stream, requestData.ConnectionSettings, requestData.DisableDirectStreaming);
 					}
 				}
 

--- a/src/Elastic.Transport/Components/TransportClient/IRequestInvoker.cs
+++ b/src/Elastic.Transport/Components/TransportClient/IRequestInvoker.cs
@@ -19,7 +19,8 @@ public interface IRequestInvoker : IDisposable
 	/// <summary>
 	/// Perform a request to the endpoint described by <paramref name="requestData"/> using its associated configuration.
 	/// </summary>
-	/// <param name="requestData">An object describing where and how to perform the IO call</param>
+	/// <param name="endpoint">An object describing where to perform the IO call</param>
+	/// <param name="requestData">An object describing how to perform the IO call</param>
 	/// <param name="cancellationToken"></param>
 	/// <typeparam name="TResponse">
 	/// An implementation of <see cref="TransportResponse"/> ensuring enough information is available
@@ -31,13 +32,14 @@ public interface IRequestInvoker : IDisposable
 	/// for <see cref="RequestPipeline"/> and <see cref="ITransport{TConfiguration}"/> to determine what to
 	/// do with the response
 	/// </returns>
-	public Task<TResponse> RequestAsync<TResponse>(RequestData requestData, CancellationToken cancellationToken)
+	public Task<TResponse> RequestAsync<TResponse>(Endpoint endpoint, RequestData requestData, CancellationToken cancellationToken)
 		where TResponse : TransportResponse, new();
 
 	/// <summary>
 	/// Perform a request to the endpoint described by <paramref name="requestData"/> using its associated configuration.
 	/// </summary>
-	/// <param name="requestData">An object describing where and how to perform the IO call</param>
+	/// <param name="endpoint">An object describing where to perform the IO call</param>
+	/// <param name="requestData">An object describing how to perform the IO call</param>
 	/// <typeparam name="TResponse">
 	/// An implementation of <see cref="TransportResponse"/> ensuring enough information is available
 	/// for <see cref="RequestPipeline"/> and <see cref="ITransport{TConfiguration}"/> to determine what to
@@ -48,7 +50,7 @@ public interface IRequestInvoker : IDisposable
 	/// for <see cref="RequestPipeline"/> and <see cref="ITransport{TConfiguration}"/> to determine what to
 	/// do with the response
 	/// </returns>
-	public TResponse Request<TResponse>(RequestData requestData)
+	public TResponse Request<TResponse>(Endpoint endpoint, RequestData requestData)
 		where TResponse : TransportResponse, new();
 
 }

--- a/src/Elastic.Transport/Components/TransportClient/IRequestInvoker.cs
+++ b/src/Elastic.Transport/Components/TransportClient/IRequestInvoker.cs
@@ -21,6 +21,7 @@ public interface IRequestInvoker : IDisposable
 	/// </summary>
 	/// <param name="endpoint">An object describing where to perform the IO call</param>
 	/// <param name="requestData">An object describing how to perform the IO call</param>
+	/// <param name="postData">Optional data to post</param>
 	/// <param name="cancellationToken"></param>
 	/// <typeparam name="TResponse">
 	/// An implementation of <see cref="TransportResponse"/> ensuring enough information is available
@@ -32,7 +33,7 @@ public interface IRequestInvoker : IDisposable
 	/// for <see cref="RequestPipeline"/> and <see cref="ITransport{TConfiguration}"/> to determine what to
 	/// do with the response
 	/// </returns>
-	public Task<TResponse> RequestAsync<TResponse>(Endpoint endpoint, RequestData requestData, CancellationToken cancellationToken)
+	public Task<TResponse> RequestAsync<TResponse>(Endpoint endpoint, RequestData requestData, PostData? postData, CancellationToken cancellationToken)
 		where TResponse : TransportResponse, new();
 
 	/// <summary>
@@ -40,6 +41,7 @@ public interface IRequestInvoker : IDisposable
 	/// </summary>
 	/// <param name="endpoint">An object describing where to perform the IO call</param>
 	/// <param name="requestData">An object describing how to perform the IO call</param>
+	/// <param name="postData">Optional data to post</param>
 	/// <typeparam name="TResponse">
 	/// An implementation of <see cref="TransportResponse"/> ensuring enough information is available
 	/// for <see cref="RequestPipeline"/> and <see cref="ITransport{TConfiguration}"/> to determine what to
@@ -50,7 +52,7 @@ public interface IRequestInvoker : IDisposable
 	/// for <see cref="RequestPipeline"/> and <see cref="ITransport{TConfiguration}"/> to determine what to
 	/// do with the response
 	/// </returns>
-	public TResponse Request<TResponse>(Endpoint endpoint, RequestData requestData)
+	public TResponse Request<TResponse>(Endpoint endpoint, RequestData requestData, PostData? postData)
 		where TResponse : TransportResponse, new();
 
 }

--- a/src/Elastic.Transport/Components/TransportClient/InMemoryRequestInvoker.cs
+++ b/src/Elastic.Transport/Components/TransportClient/InMemoryRequestInvoker.cs
@@ -82,7 +82,6 @@ public class InMemoryRequestInvoker : IRequestInvoker
 				data.Write(stream, requestData.ConnectionSettings);
 			}
 		}
-		requestData.MadeItToResponse = true;
 
 		var sc = statusCode ?? _statusCode;
 		Stream responseStream = body != null ? requestData.MemoryStreamFactory.Create(body) : requestData.MemoryStreamFactory.Create(EmptyBody);
@@ -113,8 +112,6 @@ public class InMemoryRequestInvoker : IRequestInvoker
 				await data.WriteAsync(stream, requestData.ConnectionSettings, cancellationToken).ConfigureAwait(false);
 			}
 		}
-		requestData.MadeItToResponse = true;
-
 		var sc = statusCode ?? _statusCode;
 
 		Stream responseStream = body != null ? requestData.MemoryStreamFactory.Create(body) : requestData.MemoryStreamFactory.Create(EmptyBody);

--- a/src/Elastic.Transport/Components/TransportClient/InMemoryRequestInvoker.cs
+++ b/src/Elastic.Transport/Components/TransportClient/InMemoryRequestInvoker.cs
@@ -75,11 +75,11 @@ public class InMemoryRequestInvoker : IRequestInvoker
 			if (requestData.HttpCompression)
 			{
 				using var zipStream = new GZipStream(stream, CompressionMode.Compress);
-				data.Write(zipStream, requestData.ConnectionSettings);
+				data.Write(zipStream, requestData.ConnectionSettings, requestData.DisableDirectStreaming);
 			}
 			else
 			{
-				data.Write(stream, requestData.ConnectionSettings);
+				data.Write(stream, requestData.ConnectionSettings, requestData.DisableDirectStreaming);
 			}
 		}
 
@@ -105,11 +105,11 @@ public class InMemoryRequestInvoker : IRequestInvoker
 			if (requestData.HttpCompression)
 			{
 				using var zipStream = new GZipStream(stream, CompressionMode.Compress);
-				await data.WriteAsync(zipStream, requestData.ConnectionSettings, cancellationToken).ConfigureAwait(false);
+				await data.WriteAsync(zipStream, requestData.ConnectionSettings, requestData.DisableDirectStreaming, cancellationToken).ConfigureAwait(false);
 			}
 			else
 			{
-				await data.WriteAsync(stream, requestData.ConnectionSettings, cancellationToken).ConfigureAwait(false);
+				await data.WriteAsync(stream, requestData.ConnectionSettings, requestData.DisableDirectStreaming, cancellationToken).ConfigureAwait(false);
 			}
 		}
 		var sc = statusCode ?? _statusCode;

--- a/src/Elastic.Transport/Components/TransportClient/InMemoryRequestInvoker.cs
+++ b/src/Elastic.Transport/Components/TransportClient/InMemoryRequestInvoker.cs
@@ -43,24 +43,25 @@ public class InMemoryRequestInvoker : IRequestInvoker
 	void IDisposable.Dispose() { }
 
 	/// <inheritdoc cref="IRequestInvoker.Request{TResponse}"/>>
-	public TResponse Request<TResponse>(RequestData requestData)
+	public TResponse Request<TResponse>(Endpoint endpoint, RequestData requestData)
 		where TResponse : TransportResponse, new() =>
-		BuildResponse<TResponse>(requestData);
+		BuildResponse<TResponse>(endpoint, requestData);
 
 	/// <inheritdoc cref="IRequestInvoker.RequestAsync{TResponse}"/>>
-	public Task<TResponse> RequestAsync<TResponse>(RequestData requestData, CancellationToken cancellationToken)
+	public Task<TResponse> RequestAsync<TResponse>(Endpoint endpoint, RequestData requestData, CancellationToken cancellationToken)
 		where TResponse : TransportResponse, new() =>
-		BuildResponseAsync<TResponse>(requestData, cancellationToken);
+		BuildResponseAsync<TResponse>(endpoint, requestData, cancellationToken);
 
 	/// <summary>
 	/// Allow subclasses to provide their own implementations for <see cref="IRequestInvoker.Request{TResponse}"/> while reusing the more complex logic
 	/// to create a response
 	/// </summary>
-	/// <param name="requestData">An instance of <see cref="RequestData"/> describing where and how to call out to</param>
+	/// <param name="endpoint">An instance of <see cref="Endpoint"/> describing where to call out to</param>
+	/// <param name="requestData">An instance of <see cref="RequestData"/> describing how to call out to</param>
 	/// <param name="responseBody">The bytes intended to be used as return</param>
 	/// <param name="statusCode">The status code that the responses <see cref="TransportResponse.ApiCallDetails"/> should return</param>
 	/// <param name="contentType"></param>
-	public TResponse BuildResponse<TResponse>(RequestData requestData, byte[] responseBody = null, int? statusCode = null,
+	public TResponse BuildResponse<TResponse>(Endpoint endpoint, RequestData requestData, byte[] responseBody = null, int? statusCode = null,
 		string contentType = null)
 		where TResponse : TransportResponse, new()
 	{
@@ -86,11 +87,11 @@ public class InMemoryRequestInvoker : IRequestInvoker
 		Stream responseStream = body != null ? requestData.MemoryStreamFactory.Create(body) : requestData.MemoryStreamFactory.Create(EmptyBody);
 
 		return requestData.ConnectionSettings.ProductRegistration.ResponseBuilder
-			.ToResponse<TResponse>(requestData, _exception, sc, _headers, responseStream, contentType ?? _contentType ?? RequestData.DefaultMimeType, body?.Length ?? 0, null, null);
+			.ToResponse<TResponse>(endpoint, requestData, _exception, sc, _headers, responseStream, contentType ?? _contentType ?? RequestData.DefaultMimeType, body?.Length ?? 0, null, null);
 	}
 
 	/// <inheritdoc cref="BuildResponse{TResponse}"/>>
-	public async Task<TResponse> BuildResponseAsync<TResponse>(RequestData requestData, CancellationToken cancellationToken,
+	public async Task<TResponse> BuildResponseAsync<TResponse>(Endpoint endpoint, RequestData requestData, CancellationToken cancellationToken,
 		byte[] responseBody = null, int? statusCode = null, string contentType = null)
 		where TResponse : TransportResponse, new()
 	{
@@ -118,7 +119,7 @@ public class InMemoryRequestInvoker : IRequestInvoker
 		Stream responseStream = body != null ? requestData.MemoryStreamFactory.Create(body) : requestData.MemoryStreamFactory.Create(EmptyBody);
 
 		return await requestData.ConnectionSettings.ProductRegistration.ResponseBuilder
-			.ToResponseAsync<TResponse>(requestData, _exception, sc, _headers, responseStream, contentType ?? _contentType, body?.Length ?? 0, null, null, cancellationToken)
+			.ToResponseAsync<TResponse>(endpoint, requestData, _exception, sc, _headers, responseStream, contentType ?? _contentType, body?.Length ?? 0, null, null, cancellationToken)
 			.ConfigureAwait(false);
 	}
 }

--- a/src/Elastic.Transport/Components/TransportClient/InMemoryRequestInvoker.cs
+++ b/src/Elastic.Transport/Components/TransportClient/InMemoryRequestInvoker.cs
@@ -43,14 +43,14 @@ public class InMemoryRequestInvoker : IRequestInvoker
 	void IDisposable.Dispose() { }
 
 	/// <inheritdoc cref="IRequestInvoker.Request{TResponse}"/>>
-	public TResponse Request<TResponse>(Endpoint endpoint, RequestData requestData)
+	public TResponse Request<TResponse>(Endpoint endpoint, RequestData requestData, PostData? postData)
 		where TResponse : TransportResponse, new() =>
-		BuildResponse<TResponse>(endpoint, requestData);
+		BuildResponse<TResponse>(endpoint, requestData, postData);
 
 	/// <inheritdoc cref="IRequestInvoker.RequestAsync{TResponse}"/>>
-	public Task<TResponse> RequestAsync<TResponse>(Endpoint endpoint, RequestData requestData, CancellationToken cancellationToken)
+	public Task<TResponse> RequestAsync<TResponse>(Endpoint endpoint, RequestData requestData, PostData? postData, CancellationToken cancellationToken)
 		where TResponse : TransportResponse, new() =>
-		BuildResponseAsync<TResponse>(endpoint, requestData, cancellationToken);
+		BuildResponseAsync<TResponse>(endpoint, requestData, postData, cancellationToken);
 
 	/// <summary>
 	/// Allow subclasses to provide their own implementations for <see cref="IRequestInvoker.Request{TResponse}"/> while reusing the more complex logic
@@ -58,15 +58,16 @@ public class InMemoryRequestInvoker : IRequestInvoker
 	/// </summary>
 	/// <param name="endpoint">An instance of <see cref="Endpoint"/> describing where to call out to</param>
 	/// <param name="requestData">An instance of <see cref="RequestData"/> describing how to call out to</param>
+	/// <param name="postData">Optional data to post</param>
 	/// <param name="responseBody">The bytes intended to be used as return</param>
 	/// <param name="statusCode">The status code that the responses <see cref="TransportResponse.ApiCallDetails"/> should return</param>
 	/// <param name="contentType"></param>
-	public TResponse BuildResponse<TResponse>(Endpoint endpoint, RequestData requestData, byte[] responseBody = null, int? statusCode = null,
-		string contentType = null)
+	public TResponse BuildResponse<TResponse>(Endpoint endpoint, RequestData requestData, PostData? postData, byte[]? responseBody = null, int? statusCode = null,
+		string? contentType = null)
 		where TResponse : TransportResponse, new()
 	{
 		var body = responseBody ?? _responseBody;
-		var data = requestData.PostData;
+		var data = postData;
 
 		if (data is not null)
 		{
@@ -87,16 +88,16 @@ public class InMemoryRequestInvoker : IRequestInvoker
 		Stream responseStream = body != null ? requestData.MemoryStreamFactory.Create(body) : requestData.MemoryStreamFactory.Create(EmptyBody);
 
 		return requestData.ConnectionSettings.ProductRegistration.ResponseBuilder
-			.ToResponse<TResponse>(endpoint, requestData, _exception, sc, _headers, responseStream, contentType ?? _contentType ?? RequestData.DefaultMimeType, body?.Length ?? 0, null, null);
+			.ToResponse<TResponse>(endpoint, requestData, postData, _exception, sc, _headers, responseStream, contentType ?? _contentType ?? RequestData.DefaultMimeType, body?.Length ?? 0, null, null);
 	}
 
 	/// <inheritdoc cref="BuildResponse{TResponse}"/>>
-	public async Task<TResponse> BuildResponseAsync<TResponse>(Endpoint endpoint, RequestData requestData, CancellationToken cancellationToken,
-		byte[] responseBody = null, int? statusCode = null, string contentType = null)
+	public async Task<TResponse> BuildResponseAsync<TResponse>(Endpoint endpoint, RequestData requestData, PostData? postData, CancellationToken cancellationToken,
+		byte[]? responseBody = null, int? statusCode = null, string? contentType = null)
 		where TResponse : TransportResponse, new()
 	{
 		var body = responseBody ?? _responseBody;
-		var data = requestData.PostData;
+		var data = postData;
 
 		if (data is not null)
 		{
@@ -119,7 +120,7 @@ public class InMemoryRequestInvoker : IRequestInvoker
 		Stream responseStream = body != null ? requestData.MemoryStreamFactory.Create(body) : requestData.MemoryStreamFactory.Create(EmptyBody);
 
 		return await requestData.ConnectionSettings.ProductRegistration.ResponseBuilder
-			.ToResponseAsync<TResponse>(endpoint, requestData, _exception, sc, _headers, responseStream, contentType ?? _contentType, body?.Length ?? 0, null, null, cancellationToken)
+			.ToResponseAsync<TResponse>(endpoint, requestData, postData, _exception, sc, _headers, responseStream, contentType ?? _contentType, body?.Length ?? 0, null, null, cancellationToken)
 			.ConfigureAwait(false);
 	}
 }

--- a/src/Elastic.Transport/Configuration/HeadersList.cs
+++ b/src/Elastic.Transport/Configuration/HeadersList.cs
@@ -14,7 +14,7 @@ namespace Elastic.Transport;
 /// </summary>
 public readonly struct HeadersList : IEnumerable<string>
 {
-	private readonly List<string> _headers;
+	private readonly List<string> _headers = [];
 
 	/// <summary>
 	/// Create a new <see cref="HeadersList"/> from an existing enumerable of header names.
@@ -23,63 +23,51 @@ public readonly struct HeadersList : IEnumerable<string>
 	/// <param name="headers">The header names to initialise the <see cref="HeadersList"/> with.</param>
 	public HeadersList(IEnumerable<string> headers)
 	{
-		_headers = new List<string>();
-
 		foreach (var header in headers)
 		{
 			if (!_headers.Contains(header, StringComparer.OrdinalIgnoreCase))
-			{
 				_headers.Add(header);
-			}
 		}
 	}
 
-	/// <summary>
-	/// 
-	/// </summary>
-	/// <param name="headers"></param>
-	/// <param name="additionalHeader"></param>
+	/// <summary> Represents a unique, case-insensitive, immutable collection of header names.  </summary>
 	public HeadersList(IEnumerable<string> headers, string additionalHeader)
 	{
-		_headers = new List<string>();
-
 		foreach (var header in headers)
 		{
 			if (!_headers.Contains(header, StringComparer.OrdinalIgnoreCase))
-			{
 				_headers.Add(header);
-			}
 		}
 
-		if (!_headers.Contains(additionalHeader, StringComparer.OrdinalIgnoreCase))
-		{
-			_headers.Add(additionalHeader);
-		}
+		if (!_headers.Contains(additionalHeader, StringComparer.OrdinalIgnoreCase)) _headers.Add(additionalHeader);
+	}
+
+	/// <summary> Represents a unique, case-insensitive, immutable collection of header names. </summary>
+	public HeadersList(IEnumerable<string> headers, IEnumerable<string> otherHeaders)
+		: this(new HeadersList(headers), new HeadersList(otherHeaders))
+	{
 	}
 
 	/// <summary>
-	/// 
+	/// Initializes a new instance of <see cref="HeadersList"/> by combining two existing <see cref="HeadersList"/> instances.
+	/// Duplicate names, including those which only differ by case, will be ignored.
 	/// </summary>
-	/// <param name="headers"></param>
-	/// <param name="otherHeaders"></param>
-	public HeadersList(IEnumerable<string> headers, IEnumerable<string> otherHeaders)
+	/// <param name="headers">The first set of header names to initialize the <see cref="HeadersList"/> with.</param>
+	/// <param name="otherHeaders">The second set of header names to initialize the <see cref="HeadersList"/> with.</param>
+	public HeadersList(HeadersList? headers, HeadersList? otherHeaders)
 	{
-		_headers = new List<string>();
+		AddToHeaders(headers);
+		AddToHeaders(otherHeaders);
+	}
+
+	private void AddToHeaders(HeadersList? headers)
+	{
+		if (headers is null) return;
 
 		foreach (var header in headers)
 		{
 			if (!_headers.Contains(header, StringComparer.OrdinalIgnoreCase))
-			{
 				_headers.Add(header);
-			}
-		}
-
-		foreach (var header in otherHeaders)
-		{
-			if (!_headers.Contains(header, StringComparer.OrdinalIgnoreCase))
-			{
-				_headers.Add(header);
-			}
 		}
 	}
 
@@ -92,10 +80,10 @@ public readonly struct HeadersList : IEnumerable<string>
 	/// <summary>
 	/// Gets the number of elements contained in the <see cref="HeadersList"/>.
 	/// </summary>
-	public int Count => _headers is null ? 0 : _headers.Count;
+	public int Count => _headers.Count;
 
 	/// <inheritdoc />
-	public IEnumerator<string> GetEnumerator() => _headers?.GetEnumerator() ?? (IEnumerator<string>)new EmptyEnumerator<string>();
+	public IEnumerator<string> GetEnumerator() => _headers.GetEnumerator();
 
 	IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 

--- a/src/Elastic.Transport/Configuration/HeadersList.cs
+++ b/src/Elastic.Transport/Configuration/HeadersList.cs
@@ -83,8 +83,9 @@ public readonly struct HeadersList : IEnumerable<string>
 	public int Count => _headers.Count;
 
 	// ReSharper disable once ConstantConditionalAccessQualifier
+	// ReSharper disable once ConstantNullCoalescingCondition
 	/// <inheritdoc />
-	public IEnumerator<string> GetEnumerator() => _headers?.GetEnumerator() ?? Enumerable.Empty<string>().GetEnumerator();
+	public IEnumerator<string> GetEnumerator() => _headers?.GetEnumerator() ?? (IEnumerator<string>)new EmptyEnumerator<string>();
 
 	IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 

--- a/src/Elastic.Transport/Configuration/HeadersList.cs
+++ b/src/Elastic.Transport/Configuration/HeadersList.cs
@@ -82,8 +82,9 @@ public readonly struct HeadersList : IEnumerable<string>
 	/// </summary>
 	public int Count => _headers.Count;
 
+	// ReSharper disable once ConstantConditionalAccessQualifier
 	/// <inheritdoc />
-	public IEnumerator<string> GetEnumerator() => _headers.GetEnumerator();
+	public IEnumerator<string> GetEnumerator() => _headers?.GetEnumerator() ?? Enumerable.Empty<string>().GetEnumerator();
 
 	IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 

--- a/src/Elastic.Transport/Configuration/ITransportConfiguration.cs
+++ b/src/Elastic.Transport/Configuration/ITransportConfiguration.cs
@@ -17,19 +17,10 @@ namespace Elastic.Transport;
 /// All the transport configuration that you as the user can use to steer the behavior of the <see cref="ITransport{TConfiguration}"/> and all the components such
 /// as <see cref="IRequestInvoker"/> <see cref="NodePool"/> and <see cref="Serializer"/>.
 /// </summary>
-public interface ITransportConfiguration : IDisposable
+public interface ITransportConfiguration : IRequestConfiguration, IDisposable
 {
-	/// <inheritdoc cref="AuthorizationHeader"/>
-	AuthorizationHeader Authentication { get; }
-
-	/// <summary> Provides a semaphoreslim to transport implementations that need to limit access to a resource</summary>
+	/// <summary> Provides a <see cref="SemaphoreSlim"/> to transport implementations that need to limit access to a resource</summary>
 	SemaphoreSlim BootstrapLock { get; }
-
-	/// <summary>
-	/// Use the following certificates to authenticate all HTTP requests. You can also set them on individual
-	/// request using <see cref="RequestConfiguration.ClientCertificates" />
-	/// </summary>
-	X509CertificateCollection ClientCertificates { get; }
 
 	/// <summary> The connection abstraction behind which all actual IO happens</summary>
 	IRequestInvoker Connection { get; }
@@ -69,38 +60,6 @@ public interface ITransportConfiguration : IDisposable
 	bool DisableAutomaticProxyDetection { get; }
 
 	/// <summary>
-	/// When set to true will disable (de)serializing directly to the request and response stream and return a byte[]
-	/// copy of the raw request and response. Defaults to false
-	/// </summary>
-	bool DisableDirectStreaming { get; }
-
-	/// <summary>
-	/// When set to true will disable capturing an audit trail for requests.
-	/// </summary>
-	bool DisableAuditTrail { get; }
-
-	/// <summary>
-	/// This signals that we do not want to send initial pings to unknown/previously dead nodes
-	/// and just send the call straightaway
-	/// </summary>
-	bool DisablePings { get; }
-
-	/// <summary>
-	/// Enable gzip compressed requests and responses
-	/// </summary>
-	bool EnableHttpCompression { get; }
-
-	/// <summary>
-	/// Try to send these headers for every request
-	/// </summary>
-	NameValueCollection? Headers { get; }
-
-	/// <summary>
-	/// Whether HTTP pipelining is enabled. The default is <c>true</c>
-	/// </summary>
-	bool HttpPipeliningEnabled { get; }
-
-	/// <summary>
 	/// KeepAliveInterval - specifies the interval, in milliseconds, between
 	/// when successive keep-alive packets are sent if no acknowledgement is
 	/// received.
@@ -117,20 +76,6 @@ public interface ITransportConfiguration : IDisposable
 	/// The maximum amount of time a node is allowed to marked dead
 	/// </summary>
 	TimeSpan? MaxDeadTimeout { get; }
-
-	/// <summary>
-	/// When a retryable exception occurs or status code is returned this controls the maximum
-	/// amount of times we should retry the call to Elasticsearch
-	/// </summary>
-	int? MaxRetries { get; }
-
-	/// <summary>
-	/// Limits the total runtime including retries separately from <see cref="RequestTimeout" />
-	/// <pre>
-	/// When not specified defaults to <see cref="RequestTimeout" /> which itself defaults to 60 seconds
-	/// </pre>
-	/// </summary>
-	TimeSpan? MaxRetryTimeout { get; }
 
 	/// <summary> Provides a memory stream factory</summary>
 	MemoryStreamFactory MemoryStreamFactory { get; }
@@ -157,16 +102,6 @@ public interface ITransportConfiguration : IDisposable
 	Action<RequestData>? OnRequestDataCreated { get; }
 
 	/// <summary>
-	/// When enabled, all headers from the HTTP response will be included in the <see cref="ApiCallDetails"/>.
-	/// </summary>
-	bool? ParseAllHeaders { get; }
-
-	/// <summary>
-	/// The timeout in milliseconds to use for ping requests, which are issued to determine whether a node is alive
-	/// </summary>
-	TimeSpan? PingTimeout { get; }
-
-	/// <summary>
 	/// When set will force all connections through this proxy
 	/// </summary>
 	string ProxyAddress { get; }
@@ -188,17 +123,6 @@ public interface ITransportConfiguration : IDisposable
 
 	/// <summary>The serializer to use to serialize requests and deserialize responses</summary>
 	Serializer RequestResponseSerializer { get; }
-
-	/// <summary>
-	/// The timeout in milliseconds for each request to Elasticsearch
-	/// </summary>
-	TimeSpan RequestTimeout { get; }
-
-	/// <summary>
-	/// A <see cref="HeadersList"/> containing the names of all HTTP response headers to attempt to parse and
-	/// included on the <see cref="ApiCallDetails"/>.
-	/// </summary>
-	HeadersList ResponseHeadersToParse { get; }
 
 	/// <summary>
 	/// Register a ServerCertificateValidationCallback per request
@@ -234,13 +158,6 @@ public interface ITransportConfiguration : IDisposable
 	bool SniffsOnStartup { get; }
 
 	/// <summary>
-	/// Instead of following a c/go like error checking on response.IsValid do throw an exception (except when <see cref="ApiCallDetails.SuccessOrKnownError"/> is false)
-	/// on the client when a call resulted in an exception on either the client or the Elasticsearch server.
-	/// <para>Reasons for such exceptions could be search parser errors, index missing exceptions, etc...</para>
-	/// </summary>
-	bool ThrowExceptions { get; }
-
-	/// <summary>
 	/// Access to <see cref="UrlFormatter"/> instance that is aware of this <see cref="ITransportConfiguration"/> instance
 	/// </summary>
 	UrlFormatter UrlFormatter { get; }
@@ -265,24 +182,9 @@ public interface ITransportConfiguration : IDisposable
 	Func<HttpMethod, int, bool> StatusCodeToResponseSuccess { get; }
 
 	/// <summary>
-	/// Whether the request should be sent with chunked Transfer-Encoding.
-	/// </summary>
-	bool TransferEncodingChunked { get; }
-
-	/// <summary>
 	/// DnsRefreshTimeout for the connections. Defaults to 5 minutes.
 	/// </summary>
 	TimeSpan DnsRefreshTimeout { get; }
-
-	/// <summary>
-	/// Enable statistics about TCP connections to be collected when making a request
-	/// </summary>
-	bool EnableTcpStats { get; }
-
-	/// <summary>
-	/// Enable statistics about thread pools to be collected when making a request
-	/// </summary>
-	bool EnableThreadPoolStats { get; }
 
 	/// <summary>
 	/// Provide hints to serializer and products to produce pretty, non minified json.

--- a/src/Elastic.Transport/Configuration/ITransportConfiguration.cs
+++ b/src/Elastic.Transport/Configuration/ITransportConfiguration.cs
@@ -195,7 +195,7 @@ public interface ITransportConfiguration : IRequestConfiguration, IDisposable
 	/// <summary>
 	/// Produces the client meta header for a request.
 	/// </summary>
-	MetaHeaderProvider MetaHeaderProvider { get; }
+	MetaHeaderProvider? MetaHeaderProvider { get; }
 
 	/// <summary>
 	/// Disables the meta header which is included on all requests by default. This header contains lightweight information

--- a/src/Elastic.Transport/Configuration/RequestConfiguration.cs
+++ b/src/Elastic.Transport/Configuration/RequestConfiguration.cs
@@ -18,27 +18,25 @@ public interface IRequestConfiguration
 	/// <summary>
 	/// Force a different Accept header on the request
 	/// </summary>
-	string Accept { get; set; }
+	string? Accept { get; set; }
 
 	/// <summary>
 	/// Treat the following statuses (on top of the 200 range) NOT as error.
 	/// </summary>
-	IReadOnlyCollection<int> AllowedStatusCodes { get; set; }
+	IReadOnlyCollection<int>? AllowedStatusCodes { get; set; }
 
-	/// <summary>
-	/// Provide an authentication header override for this request
-	/// </summary>
-	AuthorizationHeader AuthenticationHeader { get; set; }
+	/// <summary> Provide an authentication header override for this request </summary>
+	AuthorizationHeader? Authentication { get; set; }
 
 	/// <summary>
 	/// Use the following client certificates to authenticate this single request
 	/// </summary>
-	X509CertificateCollection ClientCertificates { get; set; }
+	X509CertificateCollection? ClientCertificates { get; set; }
 
 	/// <summary>
 	/// Force a different Content-Type header on the request
 	/// </summary>
-	string ContentType { get; set; }
+	string? ContentType { get; set; }
 
 	/// <summary>
 	/// Whether to buffer the request and response bytes for the call
@@ -54,7 +52,7 @@ public interface IRequestConfiguration
 	/// Under no circumstance do a ping before the actual call. If a node was previously dead a small ping with
 	/// low connect timeout will be tried first in normal circumstances
 	/// </summary>
-	bool? DisablePing { get; set; }
+	bool? DisablePings { get; set; }
 
 	/// <summary>
 	/// Forces no sniffing to occur on the request no matter what configuration is in place
@@ -65,25 +63,39 @@ public interface IRequestConfiguration
 	/// <summary>
 	/// Whether or not this request should be pipelined. http://en.wikipedia.org/wiki/HTTP_pipelining defaults to true
 	/// </summary>
-	bool? EnableHttpPipelining { get; set; }
+	bool? HttpPipeliningEnabled { get; set; }
+
+	/// <summary>
+	/// Enable gzip compressed requests and responses
+	/// </summary>
+	bool? EnableHttpCompression { get; set; }
 
 	/// <summary>
 	/// This will force the operation on the specified node, this will bypass any configured connection pool and will no retry.
 	/// </summary>
-	Uri ForceNode { get; set; }
+	Uri? ForceNode { get; set; }
 
 	/// <summary>
-	/// This will override whatever is set on the connection configuration or whatever default the connectionpool has.
+	/// When a retryable exception occurs or status code is returned this controls the maximum
+	/// amount of times we should retry the call to Elasticsearch
 	/// </summary>
 	int? MaxRetries { get; set; }
+
+	/// <summary>
+	/// Limits the total runtime including retries separately from <see cref="IRequestConfiguration.RequestTimeout" />
+	/// <pre>
+	/// When not specified defaults to <see cref="IRequestConfiguration.RequestTimeout" /> which itself defaults to 60 seconds
+	/// </pre>
+	/// </summary>
+	TimeSpan? MaxRetryTimeout { get; set; }
 
 	/// <summary>
 	/// Associate an Id with this user-initiated task, such that it can be located in the cluster task list.
 	/// Valid only for Elasticsearch 6.2.0+
 	/// </summary>
-	string OpaqueId { get; set; }
+	string? OpaqueId { get; set; }
 
-	/// <inheritdoc cref="ITransportConfiguration.ParseAllHeaders"/>
+	/// <summary> Determines whether to parse all HTTP headers in the request. </summary>
 	bool? ParseAllHeaders { get; set; }
 
 	/// <summary>
@@ -96,14 +108,15 @@ public interface IRequestConfiguration
 	/// </summary>
 	TimeSpan? RequestTimeout { get; set; }
 
-	/// <inheritdoc cref="ITransportConfiguration.ResponseHeadersToParse"/>
-	HeadersList ResponseHeadersToParse { get; set; }
+
+	/// <summary> Specifies the headers from the response that should be parsed. </summary>
+	HeadersList? ResponseHeadersToParse { get; set; }
 
 	/// <summary>
 	/// Submit the request on behalf in the context of a different shield user
 	/// <pre />https://www.elastic.co/guide/en/shield/current/submitting-requests-for-other-users.html
 	/// </summary>
-	string RunAs { get; set; }
+	string? RunAs { get; set; }
 
 	/// <summary>
 	/// Instead of following a c/go like error checking on response.IsValid do throw an exception (except when <see cref="ApiCallDetails.SuccessOrKnownError"/> is false)
@@ -120,12 +133,16 @@ public interface IRequestConfiguration
 	/// <summary>
 	/// Try to send these headers for this single request
 	/// </summary>
-	NameValueCollection Headers { get; set; }
+	NameValueCollection? Headers { get; set; }
 
-	/// <inheritdoc cref="ITransportConfiguration.EnableTcpStats"/>
+	/// <summary>
+	/// Enable statistics about TCP connections to be collected when making a request
+	/// </summary>
 	bool? EnableTcpStats { get; set; }
 
-	/// <inheritdoc cref="ITransportConfiguration.EnableThreadPoolStats"/>
+	/// <summary>
+	/// Enable statistics about thread pools to be collected when making a request
+	/// </summary>
 	bool? EnableThreadPoolStats { get; set; }
 
 	/// <summary>
@@ -137,102 +154,125 @@ public interface IRequestConfiguration
 /// <inheritdoc cref="IRequestConfiguration"/>
 public class RequestConfiguration : IRequestConfiguration
 {
+
+	/// <summary> The default request timeout. Defaults to 1 minute </summary>
+	public static readonly TimeSpan DefaultRequestTimeout = TimeSpan.FromMinutes(10);
+
+	/// <summary>The default ping timeout. Defaults to 2 seconds</summary>
+	public static readonly TimeSpan DefaultPingTimeout = TimeSpan.FromSeconds(2);
+
+	/// <summary> The default ping timeout when the connection is over HTTPS. Defaults to 5 seconds </summary>
+	public static readonly TimeSpan DefaultPingTimeoutOnSsl = TimeSpan.FromSeconds(5);
+
+
 	/// <inheritdoc />
-	public string Accept { get; set; }
+	public string? Accept { get; set; }
+
 	/// <inheritdoc />
-	public IReadOnlyCollection<int> AllowedStatusCodes { get; set; }
+	public IReadOnlyCollection<int>? AllowedStatusCodes { get; set; }
+
 	/// <inheritdoc />
-	public AuthorizationHeader AuthenticationHeader { get; set; }
+	public AuthorizationHeader? Authentication { get; set; }
+
 	/// <inheritdoc />
-	public X509CertificateCollection ClientCertificates { get; set; }
+	public X509CertificateCollection? ClientCertificates { get; set; }
+
 	/// <inheritdoc />
 	public string ContentType { get; set; }
+
 	/// <inheritdoc />
 	public bool? DisableDirectStreaming { get; set; }
+
 	/// <inheritdoc />
 	public bool? DisableAuditTrail { get; set; }
+
+	/// <inheritdoc />
+	public bool? DisablePings { get; set; }
+
 	/// <inheritdoc />
 	public bool? DisablePing { get; set; }
+
 	/// <inheritdoc />
 	public bool? DisableSniff { get; set; }
+
+	/// <inheritdoc />
+	public bool? HttpPipeliningEnabled { get; set; }
+
 	/// <inheritdoc />
 	public bool? EnableHttpPipelining { get; set; } = true;
+
+	/// <inheritdoc />
+	public bool? EnableHttpCompression { get; set; }
+
 	/// <inheritdoc />
 	public Uri ForceNode { get; set; }
+
 	/// <inheritdoc />
 	public int? MaxRetries { get; set; }
+
+	/// <inheritdoc />
+	public TimeSpan? MaxRetryTimeout { get; set; }
+
 	/// <inheritdoc />
 	public string OpaqueId { get; set; }
+
 	/// <inheritdoc />
 	public TimeSpan? PingTimeout { get; set; }
+
 	/// <inheritdoc />
 	public TimeSpan? RequestTimeout { get; set; }
+
 	/// <inheritdoc />
 	public string RunAs { get; set; }
+
 	/// <inheritdoc />
 	public bool? ThrowExceptions { get; set; }
+
 	/// <inheritdoc />
 	public bool? TransferEncodingChunked { get; set; }
+
 	/// <inheritdoc />
 	public NameValueCollection Headers { get; set; }
+
 	/// <inheritdoc />
 	public bool? EnableTcpStats { get; set; }
+
 	/// <inheritdoc />
 	public bool? EnableThreadPoolStats { get; set; }
+
 	/// <inheritdoc />
-	public HeadersList ResponseHeadersToParse { get; set; }
+	public HeadersList? ResponseHeadersToParse { get; set; }
+
 	/// <inheritdoc />
 	public bool? ParseAllHeaders { get; set; }
 
 	/// <inheritdoc />
 	public RequestMetaData RequestMetaData { get; set; }
+
 }
 
 /// <inheritdoc cref="IRequestConfiguration"/>
 public class RequestConfigurationDescriptor : IRequestConfiguration
 {
 	/// <inheritdoc cref="IRequestConfiguration"/>
-	public RequestConfigurationDescriptor(IRequestConfiguration? config)
+	public RequestConfigurationDescriptor()
 	{
-		Self.RequestTimeout = config?.RequestTimeout;
-		Self.PingTimeout = config?.PingTimeout;
-		Self.ContentType = config?.ContentType;
-		Self.Accept = config?.Accept;
-		Self.MaxRetries = config?.MaxRetries;
-		Self.ForceNode = config?.ForceNode;
-		Self.DisableSniff = config?.DisableSniff;
-		Self.DisablePing = config?.DisablePing;
-		Self.DisableDirectStreaming = config?.DisableDirectStreaming;
-		Self.DisableAuditTrail = config?.DisableAuditTrail;
-		Self.AllowedStatusCodes = config?.AllowedStatusCodes;
-		Self.AuthenticationHeader = config?.AuthenticationHeader;
-		Self.EnableHttpPipelining = config?.EnableHttpPipelining ?? true;
-		Self.RunAs = config?.RunAs;
-		Self.ClientCertificates = config?.ClientCertificates;
-		Self.ThrowExceptions = config?.ThrowExceptions;
-		Self.OpaqueId = config?.OpaqueId;
-		Self.TransferEncodingChunked = config?.TransferEncodingChunked;
-		Self.Headers = config?.Headers;
-		Self.EnableTcpStats = config?.EnableTcpStats;
-		Self.EnableThreadPoolStats = config?.EnableThreadPoolStats;
-		Self.ParseAllHeaders = config?.ParseAllHeaders;
-
-		if (config?.ResponseHeadersToParse is not null)
-			Self.ResponseHeadersToParse = config.ResponseHeadersToParse;
 	}
 
 	string IRequestConfiguration.Accept { get; set; }
 	IReadOnlyCollection<int> IRequestConfiguration.AllowedStatusCodes { get; set; }
-	AuthorizationHeader IRequestConfiguration.AuthenticationHeader { get; set; }
+	AuthorizationHeader IRequestConfiguration.Authentication { get; set; }
 	X509CertificateCollection IRequestConfiguration.ClientCertificates { get; set; }
 	string IRequestConfiguration.ContentType { get; set; }
 	bool? IRequestConfiguration.DisableDirectStreaming { get; set; }
 	bool? IRequestConfiguration.DisableAuditTrail { get; set; }
-	bool? IRequestConfiguration.DisablePing { get; set; }
+	bool? IRequestConfiguration.DisablePings { get; set; }
 	bool? IRequestConfiguration.DisableSniff { get; set; }
-	bool? IRequestConfiguration.EnableHttpPipelining { get; set; } = true;
+	bool? IRequestConfiguration.HttpPipeliningEnabled { get; set; }
+	bool? IRequestConfiguration.EnableHttpCompression { get; set; }
 	Uri IRequestConfiguration.ForceNode { get; set; }
 	int? IRequestConfiguration.MaxRetries { get; set; }
+	TimeSpan? IRequestConfiguration.MaxRetryTimeout { get; set; }
 	string IRequestConfiguration.OpaqueId { get; set; }
 	TimeSpan? IRequestConfiguration.PingTimeout { get; set; }
 	TimeSpan? IRequestConfiguration.RequestTimeout { get; set; }
@@ -243,7 +283,7 @@ public class RequestConfigurationDescriptor : IRequestConfiguration
 	NameValueCollection IRequestConfiguration.Headers { get; set; }
 	bool? IRequestConfiguration.EnableTcpStats { get; set; }
 	bool? IRequestConfiguration.EnableThreadPoolStats { get; set; }
-	HeadersList IRequestConfiguration.ResponseHeadersToParse { get; set; }
+	HeadersList? IRequestConfiguration.ResponseHeadersToParse { get; set; }
 	bool? IRequestConfiguration.ParseAllHeaders { get; set; }
 	RequestMetaData IRequestConfiguration.RequestMetaData { get; set; }
 
@@ -305,16 +345,16 @@ public class RequestConfigurationDescriptor : IRequestConfiguration
 	}
 
 	/// <inheritdoc cref="IRequestConfiguration.DisableSniff"/>
-	public RequestConfigurationDescriptor DisableSniffing(bool? disable = true)
+	public RequestConfigurationDescriptor DisableSniffing(bool disable = true)
 	{
 		Self.DisableSniff = disable;
 		return this;
 	}
 
-	/// <inheritdoc cref="IRequestConfiguration.DisablePing"/>
-	public RequestConfigurationDescriptor DisablePing(bool? disable = true)
+	/// <inheritdoc cref="IRequestConfiguration.DisablePings"/>
+	public RequestConfigurationDescriptor DisablePing(bool disable = true)
 	{
-		Self.DisablePing = disable;
+		Self.DisablePings = disable;
 		return this;
 	}
 
@@ -326,14 +366,14 @@ public class RequestConfigurationDescriptor : IRequestConfiguration
 	}
 
 	/// <inheritdoc cref="IRequestConfiguration.DisableDirectStreaming"/>
-	public RequestConfigurationDescriptor DisableDirectStreaming(bool? disable = true)
+	public RequestConfigurationDescriptor DisableDirectStreaming(bool disable = true)
 	{
 		Self.DisableDirectStreaming = disable;
 		return this;
 	}
 
 	/// <inheritdoc cref="IRequestConfiguration.DisableAuditTrail"/>
-	public RequestConfigurationDescriptor DisableAuditTrail(bool? disable = true)
+	public RequestConfigurationDescriptor DisableAuditTrail(bool disable = true)
 	{
 		Self.DisableAuditTrail = disable;
 		return this;
@@ -356,14 +396,14 @@ public class RequestConfigurationDescriptor : IRequestConfiguration
 	/// <inheritdoc cref="AuthorizationHeader"/>
 	public RequestConfigurationDescriptor Authentication(AuthorizationHeader authentication)
 	{
-		Self.AuthenticationHeader = authentication;
+		Self.Authentication = authentication;
 		return this;
 	}
 
-	/// <inheritdoc cref="IRequestConfiguration.EnableHttpPipelining"/>
+	/// <inheritdoc cref="IRequestConfiguration.HttpPipeliningEnabled"/>
 	public RequestConfigurationDescriptor EnableHttpPipelining(bool enable = true)
 	{
-		Self.EnableHttpPipelining = enable;
+		Self.HttpPipeliningEnabled = enable;
 		return this;
 	}
 
@@ -383,7 +423,7 @@ public class RequestConfigurationDescriptor : IRequestConfiguration
 		ClientCertificates(new X509Certificate2Collection { new X509Certificate(certificatePath) });
 
 	/// <inheritdoc cref="IRequestConfiguration.TransferEncodingChunked" />
-	public RequestConfigurationDescriptor TransferEncodingChunked(bool? transferEncodingChunked = true)
+	public RequestConfigurationDescriptor TransferEncodingChunked(bool transferEncodingChunked = true)
 	{
 		Self.TransferEncodingChunked = transferEncodingChunked;
 		return this;
@@ -397,21 +437,21 @@ public class RequestConfigurationDescriptor : IRequestConfiguration
 	}
 
 	/// <inheritdoc cref="IRequestConfiguration.EnableTcpStats" />
-	public RequestConfigurationDescriptor EnableTcpStats(bool? enableTcpStats = true)
+	public RequestConfigurationDescriptor EnableTcpStats(bool enableTcpStats = true)
 	{
 		Self.EnableTcpStats = enableTcpStats;
 		return this;
 	}
 
 	/// <inheritdoc cref="IRequestConfiguration.EnableThreadPoolStats" />
-	public RequestConfigurationDescriptor EnableThreadPoolStats(bool? enableThreadPoolStats = true)
+	public RequestConfigurationDescriptor EnableThreadPoolStats(bool enableThreadPoolStats = true)
 	{
 		Self.EnableThreadPoolStats = enableThreadPoolStats;
 		return this;
 	}
 
 	/// <inheritdoc cref="IRequestConfiguration.ParseAllHeaders"/>
-	public RequestConfigurationDescriptor ParseAllHeaders(bool? enable = true)
+	public RequestConfigurationDescriptor ParseAllHeaders(bool enable = true)
 	{
 		Self.ParseAllHeaders = enable;
 		return this;

--- a/src/Elastic.Transport/Diagnostics/Auditing/AuditEvent.cs
+++ b/src/Elastic.Transport/Diagnostics/Auditing/AuditEvent.cs
@@ -53,14 +53,14 @@ public enum AuditEvent
 	/// <summary>
 	/// The request took too long.
 	/// This could mean the call was retried but retrying was to slow and cumulatively this exceeded
-	/// <see cref="ITransportConfiguration.MaxRetryTimeout"/>
+	/// <see cref="IRequestConfiguration.MaxRetryTimeout"/>
 	/// </summary>
 	MaxTimeoutReached,
 
 	/// <summary>
 	/// The request was not able to complete
 	/// successfully and exceeded the available retries as configured on
-	/// <see cref="ITransportConfiguration.MaxRetries"/>.
+	/// <see cref="IRequestConfiguration.MaxRetries"/>.
 	/// </summary>
 	MaxRetriesReached,
 
@@ -82,7 +82,7 @@ public enum AuditEvent
 	CancellationRequested,
 
 	/// <summary>
-	/// The request failed within the allotted <see cref="ITransportConfiguration.MaxRetryTimeout"/> but failed
+	/// The request failed within the allotted <see cref="IRequestConfiguration.MaxRetryTimeout"/> but failed
 	/// on all the available <see cref="NodePool.Nodes"/>
 	/// </summary>
 	FailedOverAllNodes,

--- a/src/Elastic.Transport/DistributedTransport.cs
+++ b/src/Elastic.Transport/DistributedTransport.cs
@@ -142,7 +142,7 @@ public class DistributedTransport<TConfiguration> : ITransport<TConfiguration>
 				pipeline.FirstPoolUsage(Configuration.BootstrapLock);
 
 			//var pathAndQuery = requestParameters?.CreatePathWithQueryStrings(path, Configuration) ?? path;
-			var requestData = new RequestData(Configuration, localRequestConfiguration, customResponseBuilder, MemoryStreamFactory, openTelemetryData);
+			var requestData = new RequestData(Configuration, localRequestConfiguration, customResponseBuilder, MemoryStreamFactory);
 			Configuration.OnRequestDataCreated?.Invoke(requestData);
 			TResponse response = null;
 
@@ -161,8 +161,8 @@ public class DistributedTransport<TConfiguration> : ITransport<TConfiguration>
 				activity.SetTag(OpenTelemetryAttributes.ElasticTransportVersion, ReflectionVersionInfo.TransportVersion);
 				activity.SetTag(SemanticConventions.UserAgentOriginal, Configuration.UserAgent.ToString());
 
-				if (requestData.OpenTelemetryData.SpanAttributes is not null)
-					foreach (var attribute in requestData.OpenTelemetryData.SpanAttributes)
+				if (openTelemetryData.SpanAttributes is not null)
+					foreach (var attribute in openTelemetryData.SpanAttributes)
 						activity.SetTag(attribute.Key, attribute.Value);
 
 				activity.SetTag(SemanticConventions.HttpRequestMethod, endpoint.Method.GetStringValue());

--- a/src/Elastic.Transport/DistributedTransport.cs
+++ b/src/Elastic.Transport/DistributedTransport.cs
@@ -142,7 +142,7 @@ public class DistributedTransport<TConfiguration> : ITransport<TConfiguration>
 				pipeline.FirstPoolUsage(Configuration.BootstrapLock);
 
 			//var pathAndQuery = requestParameters?.CreatePathWithQueryStrings(path, Configuration) ?? path;
-			var requestData = new RequestData(data, Configuration, localRequestConfiguration, customResponseBuilder, MemoryStreamFactory, openTelemetryData);
+			var requestData = new RequestData(Configuration, localRequestConfiguration, customResponseBuilder, MemoryStreamFactory, openTelemetryData);
 			Configuration.OnRequestDataCreated?.Invoke(requestData);
 			TResponse response = null;
 

--- a/src/Elastic.Transport/DistributedTransport.cs
+++ b/src/Elastic.Transport/DistributedTransport.cs
@@ -307,7 +307,9 @@ public class DistributedTransport<TConfiguration> : ITransport<TConfiguration>
 	) where TResponse : TransportResponse, new() =>
 		throw new UnexpectedTransportException(killerException, seenExceptions)
 		{
-			Endpoint = endpoint, ApiCallDetails = response?.ApiCallDetails, AuditTrail = pipeline.AuditTrail
+			Endpoint = endpoint,
+			ApiCallDetails = response?.ApiCallDetails,
+			AuditTrail = pipeline.AuditTrail
 		};
 
 	private static void HandlePipelineException<TResponse>(

--- a/src/Elastic.Transport/Exceptions/TransportException.cs
+++ b/src/Elastic.Transport/Exceptions/TransportException.cs
@@ -15,7 +15,7 @@ namespace Elastic.Transport;
 /// <summary>
 /// Exceptions that occur are wrapped inside this exception. This is done to not lose valuable diagnostic information.
 /// <para>
-/// When <see cref="ITransportConfiguration.ThrowExceptions"/> is set these exceptions are rethrown and need
+/// When <see cref="IRequestConfiguration.ThrowExceptions"/> is set these exceptions are rethrown and need
 /// to be caught
 /// </para>
 /// </summary>

--- a/src/Elastic.Transport/Exceptions/TransportException.cs
+++ b/src/Elastic.Transport/Exceptions/TransportException.cs
@@ -51,7 +51,7 @@ public class TransportException : Exception
 	public PipelineFailure? FailureReason { get; }
 
 	/// <summary> Information about the request that triggered this exception </summary>
-	public RequestData Request { get; internal set; }
+	public Endpoint? Endpoint { get; internal set; }
 
 	/// <summary> The response if available that triggered the exception </summary>
 	public ApiCallDetails ApiCallDetails { get; internal set; }
@@ -74,16 +74,10 @@ public class TransportException : Exception
 				.Append(failureReason)
 				.Append(" while attempting ");
 
-			if (Request != null)
+			if (Endpoint is not null)
 			{
-				sb.Append(Request.Method.GetStringValue()).Append(" on ");
-				if (Request.Uri != null)
-					sb.AppendLine(Request.Uri.ToString());
-				else
-				{
-					sb.Append(Request.PathAndQuery)
-						.AppendLine(" on an empty node, likely a node predicate on ConnectionSettings not matching ANY nodes");
-				}
+				sb.Append(Endpoint.Method.GetStringValue()).Append(" on ");
+				sb.AppendLine(Endpoint.Uri.ToString());
 			}
 			else if (ApiCallDetails != null)
 			{

--- a/src/Elastic.Transport/ITransportHttpMethodExtensions.cs
+++ b/src/Elastic.Transport/ITransportHttpMethodExtensions.cs
@@ -4,6 +4,7 @@
 
 using System.Threading;
 using System.Threading.Tasks;
+using static Elastic.Transport.HttpMethod;
 
 namespace Elastic.Transport;
 
@@ -12,72 +13,105 @@ namespace Elastic.Transport;
 /// </summary>
 public static class TransportHttpMethodExtensions
 {
-	/// <summary>Perform a GET request</summary>
-	public static TResponse Get<TResponse>(this ITransport requestHandler, string path,
-		RequestParameters? parameters = null)
-		where TResponse : TransportResponse, new() =>
-		requestHandler.Request<TResponse>(HttpMethod.GET, path, null, parameters);
+	private static EndpointPath ToEndpointPath(HttpMethod method, string path, RequestParameters parameters, ITransportConfiguration configuration) =>
+		new(method, parameters.CreatePathWithQueryStrings(path, configuration));
 
 	/// <summary>Perform a GET request</summary>
-	public static Task<TResponse> GetAsync<TResponse>(this ITransport requestHandler, string path,
-		RequestParameters? parameters = null, CancellationToken cancellationToken = default)
+	public static TResponse Get<TResponse>(this ITransport<TransportConfigurationBase<TransportConfiguration>> transport, string path, RequestParameters parameters)
 		where TResponse : TransportResponse, new() =>
-		requestHandler.RequestAsync<TResponse>(HttpMethod.GET, path, null, parameters, cancellationToken);
+		transport.Request<TResponse>(ToEndpointPath(GET, path, parameters, transport.Configuration), postData: null, openTelemetryData: default, null, null);
 
-	/// <summary>Perform a HEAD request</summary>
-	public static TResponse Head<TResponse>(this ITransport requestHandler, string path,
-		RequestParameters? parameters = null)
+	/// <summary>Perform a GET request</summary>
+	public static Task<TResponse> GetAsync<TResponse>(this ITransport<TransportConfigurationBase<TransportConfiguration>> transport, string path,
+		RequestParameters parameters, CancellationToken cancellationToken = default)
 		where TResponse : TransportResponse, new() =>
-		requestHandler.Request<TResponse>(HttpMethod.HEAD, path, null, parameters);
+		transport.RequestAsync<TResponse>(ToEndpointPath(GET, path, parameters, transport.Configuration), postData: null, openTelemetryData: default, null, null, cancellationToken);
 
-	/// <summary>Perform a HEAD request</summary>
-	public static Task<TResponse> HeadAsync<TResponse>(this ITransport requestHandler, string path,
-		RequestParameters? parameters = null, CancellationToken cancellationToken = default)
+	/// <summary>Perform a GET request</summary>
+	public static TResponse Get<TResponse>(this ITransport transport, string pathAndQuery)
 		where TResponse : TransportResponse, new() =>
-		requestHandler.RequestAsync<TResponse>(HttpMethod.HEAD, path, null, parameters, cancellationToken);
+		transport.Request<TResponse>(new EndpointPath(GET, pathAndQuery), postData: null, openTelemetryData: default, null, null);
+
+	/// <summary>Perform a GET request</summary>
+	public static Task<TResponse> GetAsync<TResponse>(this ITransport transport, string pathAndQuery, CancellationToken cancellationToken = default)
+		where TResponse : TransportResponse, new() =>
+		transport.RequestAsync<TResponse>(new EndpointPath(GET, pathAndQuery), postData: null, openTelemetryData: default, null, null, cancellationToken);
 
 	/// <summary>Perform a HEAD request</summary>
-	public static VoidResponse Head(this ITransport requestHandler, string path, RequestParameters? parameters = null) =>
-		requestHandler.Head<VoidResponse>(path, parameters);
+	public static VoidResponse Head(this ITransport<TransportConfigurationBase<TransportConfiguration>> transport, string path, RequestParameters parameters)
+		 => transport.Request<VoidResponse>(ToEndpointPath(HEAD, path, parameters, transport.Configuration), postData: null, openTelemetryData: default, null, null);
 
 	/// <summary>Perform a HEAD request</summary>
-	public static Task<VoidResponse> HeadAsync(this ITransport requestHandler, string path,
-		RequestParameters? parameters = null, CancellationToken cancellationToken = default) =>
-		requestHandler.HeadAsync<VoidResponse>(path, parameters, cancellationToken);
+	public static Task<VoidResponse> HeadAsync(this ITransport<TransportConfigurationBase<TransportConfiguration>> transport, string path, RequestParameters parameters, CancellationToken cancellationToken = default)
+		=> transport.RequestAsync<VoidResponse>(ToEndpointPath(HEAD, path, parameters, transport.Configuration), postData: null, openTelemetryData: default, null, null, cancellationToken);
+
+	/// <summary>Perform a HEAD request</summary>
+	public static VoidResponse Head(this ITransport transport, string pathAndQuery)
+		 => transport.Request<VoidResponse>(new EndpointPath(HEAD, pathAndQuery), postData: null, openTelemetryData: default, null, null);
+
+	/// <summary>Perform a HEAD request</summary>
+	public static Task<VoidResponse> HeadAsync(this ITransport transport, string pathAndQuery, CancellationToken cancellationToken = default)
+		=> transport.RequestAsync<VoidResponse>(new EndpointPath(HEAD, pathAndQuery), postData: null, openTelemetryData: default, null, null, cancellationToken);
 
 	/// <summary>Perform a POST request</summary>
-	public static TResponse Post<TResponse>(this ITransport requestHandler, string path, PostData data,
-		RequestParameters? parameters = null)
+	public static TResponse Post<TResponse>(this ITransport<TransportConfigurationBase<TransportConfiguration>> transport, string path, PostData data, RequestParameters parameters)
 		where TResponse : TransportResponse, new() =>
-		requestHandler.Request<TResponse>(HttpMethod.POST, path, data, parameters);
+		transport.Request<TResponse>(ToEndpointPath(POST, path, parameters, transport.Configuration), data, openTelemetryData: default, null, null);
 
 	/// <summary>Perform a POST request</summary>
-	public static Task<TResponse> PostAsync<TResponse>(this ITransport requestHandler, string path, PostData data,
-		RequestParameters? parameters = null, CancellationToken cancellationToken = default)
+	public static Task<TResponse> PostAsync<TResponse>(this ITransport<TransportConfigurationBase<TransportConfiguration>> transport, string path, PostData data,
+		RequestParameters parameters, CancellationToken cancellationToken = default)
 		where TResponse : TransportResponse, new() =>
-		requestHandler.RequestAsync<TResponse>(HttpMethod.POST, path, data, parameters, cancellationToken);
+		transport.RequestAsync<TResponse>(ToEndpointPath(POST, path, parameters, transport.Configuration), data, openTelemetryData: default, null, null, cancellationToken);
+
+	/// <summary>Perform a POST request</summary>
+	public static TResponse Post<TResponse>(this ITransport transport, string pathAndQuery, PostData data)
+		where TResponse : TransportResponse, new() =>
+		transport.Request<TResponse>(new EndpointPath(POST, pathAndQuery), data, openTelemetryData: default, null, null);
+
+	/// <summary>Perform a POST request</summary>
+	public static Task<TResponse> PostAsync<TResponse>(this ITransport transport, string pathAndQuery, PostData data, CancellationToken cancellationToken = default)
+		where TResponse : TransportResponse, new() =>
+		transport.RequestAsync<TResponse>(new EndpointPath(POST, pathAndQuery), data, openTelemetryData: default, null, null, cancellationToken);
 
 	/// <summary>Perform a PUT request</summary>
-	public static TResponse Put<TResponse>(this ITransport requestHandler, string path, PostData data,
-		RequestParameters? parameters = null)
+	public static TResponse Put<TResponse>(this ITransport<TransportConfigurationBase<TransportConfiguration>> transport, string path, PostData data, RequestParameters parameters)
 		where TResponse : TransportResponse, new() =>
-		requestHandler.Request<TResponse>(HttpMethod.PUT, path, data, parameters);
+		transport.Request<TResponse>(ToEndpointPath(PUT, path, parameters, transport.Configuration), data, openTelemetryData: default, null, null);
 
 	/// <summary>Perform a PUT request</summary>
-	public static Task<TResponse> PutAsync<TResponse>(this ITransport requestHandler, string path, PostData data,
-		RequestParameters? parameters = null, CancellationToken cancellationToken = default)
+	public static Task<TResponse> PutAsync<TResponse>(this ITransport<TransportConfigurationBase<TransportConfiguration>> transport, string path, PostData data, RequestParameters parameters, CancellationToken cancellationToken = default)
 		where TResponse : TransportResponse, new() =>
-		requestHandler.RequestAsync<TResponse>(HttpMethod.PUT, path, data, parameters, cancellationToken);
+		transport.RequestAsync<TResponse>(ToEndpointPath(PUT, path, parameters, transport.Configuration), data, openTelemetryData: default, null, null, cancellationToken);
+
+	/// <summary>Perform a PUT request</summary>
+	public static TResponse Put<TResponse>(this ITransport transport, string pathAndQuery, PostData data)
+		where TResponse : TransportResponse, new() =>
+		transport.Request<TResponse>(new EndpointPath(PUT, pathAndQuery), data, openTelemetryData: default, null, null);
+
+	/// <summary>Perform a PUT request</summary>
+	public static Task<TResponse> PutAsync<TResponse>(this ITransport transport, string pathAndQuery, PostData data, CancellationToken cancellationToken = default)
+		where TResponse : TransportResponse, new() =>
+		transport.RequestAsync<TResponse>(new EndpointPath(PUT, pathAndQuery), data, openTelemetryData: default, null, null, cancellationToken);
+
 
 	/// <summary>Perform a DELETE request</summary>
-	public static TResponse Delete<TResponse>(this ITransport requestHandler, string path, PostData? data = null,
-		RequestParameters? parameters = null)
+	public static TResponse Delete<TResponse>(this ITransport<TransportConfigurationBase<TransportConfiguration>> transport, string path, RequestParameters parameters, PostData? data = null)
 		where TResponse : TransportResponse, new() =>
-		requestHandler.Request<TResponse>(HttpMethod.DELETE, path, data, parameters);
+		transport.Request<TResponse>(ToEndpointPath(DELETE, path, parameters, transport.Configuration), data, openTelemetryData: default, null, null);
 
 	/// <summary>Perform a DELETE request</summary>
-	public static Task<TResponse> DeleteAsync<TResponse>(this ITransport requestHandler, string path,
-		PostData? data = null, RequestParameters? parameters = null, CancellationToken cancellationToken = default)
+	public static Task<TResponse> DeleteAsync<TResponse>(this ITransport<TransportConfigurationBase<TransportConfiguration>> transport, string path, RequestParameters parameters, PostData? data = null, CancellationToken cancellationToken = default)
 		where TResponse : TransportResponse, new() =>
-		requestHandler.RequestAsync<TResponse>(HttpMethod.DELETE, path, data, parameters, cancellationToken);
+		transport.RequestAsync<TResponse>(ToEndpointPath(DELETE, path, parameters, transport.Configuration), data, openTelemetryData: default, null, null, cancellationToken);
+
+	/// <summary>Perform a DELETE request</summary>
+	public static TResponse Delete<TResponse>(this ITransport transport, string pathAndQuery, PostData? data = null)
+		where TResponse : TransportResponse, new() =>
+		transport.Request<TResponse>(new EndpointPath(DELETE, pathAndQuery), data, openTelemetryData: default, null, null);
+
+	/// <summary>Perform a DELETE request</summary>
+	public static Task<TResponse> DeleteAsync<TResponse>(this ITransport transport, string pathAndQuery, PostData? data = null, CancellationToken cancellationToken = default)
+		where TResponse : TransportResponse, new() =>
+		transport.RequestAsync<TResponse>(new EndpointPath(DELETE, pathAndQuery), data, openTelemetryData: default, null, null, cancellationToken);
 }

--- a/src/Elastic.Transport/Products/DefaultProductRegistration.cs
+++ b/src/Elastic.Transport/Products/DefaultProductRegistration.cs
@@ -60,7 +60,7 @@ public sealed class DefaultProductRegistration : ProductRegistration
 	public override MetaHeaderProvider MetaHeaderProvider => _metaHeaderProvider;
 
 	/// <inheritdoc cref="ProductRegistration.DefaultMimeType"/>
-	public override string DefaultMimeType => null;
+	public override string? DefaultMimeType => null;
 
 	/// <inheritdoc cref="ProductRegistration.ProductAssemblyVersion"/>
 	public override string ProductAssemblyVersion { get; }

--- a/src/Elastic.Transport/Products/DefaultProductRegistration.cs
+++ b/src/Elastic.Transport/Products/DefaultProductRegistration.cs
@@ -79,28 +79,28 @@ public sealed class DefaultProductRegistration : ProductRegistration
 		return false;
 	}
 
-	/// <inheritdoc cref="ProductRegistration.CreateSniffRequestData"/>
-	public override RequestData CreateSniffRequestData(Node node, IRequestConfiguration requestConfiguration, ITransportConfiguration settings, MemoryStreamFactory memoryStreamFactory) =>
+	/// <inheritdoc cref="ProductRegistration.CreateSniffEndpoint"/>
+	public override Endpoint CreateSniffEndpoint(Node node, IRequestConfiguration requestConfiguration, ITransportConfiguration settings) =>
 		throw new NotImplementedException();
 
 	/// <inheritdoc cref="ProductRegistration.SniffAsync"/>
-	public override Task<Tuple<TransportResponse, IReadOnlyCollection<Node>>> SniffAsync(IRequestInvoker requestInvoker, bool forceSsl, RequestData requestData, CancellationToken cancellationToken) =>
+	public override Task<Tuple<TransportResponse, IReadOnlyCollection<Node>>> SniffAsync(IRequestInvoker requestInvoker, bool forceSsl, Endpoint endpoint, RequestData requestData, CancellationToken cancellationToken) =>
 		throw new NotImplementedException();
 
 	/// <inheritdoc cref="ProductRegistration.Sniff"/>
-	public override Tuple<TransportResponse, IReadOnlyCollection<Node>> Sniff(IRequestInvoker requestInvoker, bool forceSsl, RequestData requestData) =>
+	public override Tuple<TransportResponse, IReadOnlyCollection<Node>> Sniff(IRequestInvoker requestInvoker, bool forceSsl, Endpoint endpoint, RequestData requestData) =>
 		throw new NotImplementedException();
 
-	/// <inheritdoc cref="ProductRegistration.CreatePingRequestData"/>
-	public override RequestData CreatePingRequestData(Node node, RequestConfiguration requestConfiguration, ITransportConfiguration global, MemoryStreamFactory memoryStreamFactory) =>
+	/// <inheritdoc cref="ProductRegistration.CreatePingEndpoint"/>
+	public override Endpoint CreatePingEndpoint(Node node, IRequestConfiguration requestConfiguration) =>
 		throw new NotImplementedException();
 
 	/// <inheritdoc cref="ProductRegistration.PingAsync"/>
-	public override Task<TransportResponse> PingAsync(IRequestInvoker requestInvoker, RequestData pingData, CancellationToken cancellationToken) =>
+	public override Task<TransportResponse> PingAsync(IRequestInvoker requestInvoker, Endpoint endpoint, RequestData pingData, CancellationToken cancellationToken) =>
 		throw new NotImplementedException();
 
 	/// <inheritdoc cref="ProductRegistration.Ping"/>
-	public override TransportResponse Ping(IRequestInvoker requestInvoker, RequestData pingData) =>
+	public override TransportResponse Ping(IRequestInvoker requestInvoker, Endpoint endpoint, RequestData pingData) =>
 		throw new NotImplementedException();
 
 	/// <inheritdoc/>

--- a/src/Elastic.Transport/Products/DefaultProductRegistration.cs
+++ b/src/Elastic.Transport/Products/DefaultProductRegistration.cs
@@ -96,7 +96,7 @@ public sealed class DefaultProductRegistration : ProductRegistration
 		throw new NotImplementedException();
 
 	/// <inheritdoc cref="ProductRegistration.PingAsync"/>
-	public override Task<TransportResponse> PingAsync(IRequestInvoker requestInvoker, Endpoint endpoint, RequestData pingData, CancellationToken cancellationToken) =>
+	public override Task<TransportResponse> PingAsync(IRequestInvoker requestInvoker, Endpoint endpoint, RequestData requestData, CancellationToken cancellationToken) =>
 		throw new NotImplementedException();
 
 	/// <inheritdoc cref="ProductRegistration.Ping"/>

--- a/src/Elastic.Transport/Products/Elasticsearch/ElasticsearchErrorExtensions.cs
+++ b/src/Elastic.Transport/Products/Elasticsearch/ElasticsearchErrorExtensions.cs
@@ -37,7 +37,7 @@ public static class ElasticsearchErrorExtensions
 
 	/// <summary>
 	/// Try to parse an Elasticsearch <see cref="ElasticsearchServerError"/>, this only works if
-	/// <see cref="ITransportConfiguration.DisableDirectStreaming"/> gives us access to <see cref="ApiCallDetails.RequestBodyInBytes"/>
+	/// <see cref="IRequestConfiguration.DisableDirectStreaming"/> gives us access to <see cref="ApiCallDetails.RequestBodyInBytes"/>
 	/// </summary>
 	public static bool TryGetElasticsearchServerError(this TransportResponse response, out ElasticsearchServerError serverError)
 	{

--- a/src/Elastic.Transport/Products/Elasticsearch/ElasticsearchProductRegistration.cs
+++ b/src/Elastic.Transport/Products/Elasticsearch/ElasticsearchProductRegistration.cs
@@ -135,7 +135,7 @@ public class ElasticsearchProductRegistration : ProductRegistration
 	public override async Task<Tuple<TransportResponse, IReadOnlyCollection<Node>>> SniffAsync(IRequestInvoker requestInvoker,
 		bool forceSsl, Endpoint endpoint, RequestData requestData, CancellationToken cancellationToken)
 	{
-		var response = await requestInvoker.RequestAsync<SniffResponse>(endpoint, requestData, cancellationToken)
+		var response = await requestInvoker.RequestAsync<SniffResponse>(endpoint, requestData, null, cancellationToken)
 			.ConfigureAwait(false);
 		var nodes = response.ToNodes(forceSsl);
 		return Tuple.Create<TransportResponse, IReadOnlyCollection<Node>>(response,
@@ -146,7 +146,7 @@ public class ElasticsearchProductRegistration : ProductRegistration
 	public override Tuple<TransportResponse, IReadOnlyCollection<Node>> Sniff(IRequestInvoker requestInvoker, bool forceSsl,
 		Endpoint endpoint, RequestData requestData)
 	{
-		var response = requestInvoker.Request<SniffResponse>(endpoint, requestData);
+		var response = requestInvoker.Request<SniffResponse>(endpoint, requestData, null);
 		var nodes = response.ToNodes(forceSsl);
 		return Tuple.Create<TransportResponse, IReadOnlyCollection<Node>>(response,
 			new ReadOnlyCollection<Node>(nodes.ToArray()));
@@ -157,16 +157,16 @@ public class ElasticsearchProductRegistration : ProductRegistration
 		new(new EndpointPath(HttpMethod.HEAD, string.Empty), node);
 
 	/// <inheritdoc cref="ProductRegistration.PingAsync"/>
-	public override async Task<TransportResponse> PingAsync(IRequestInvoker requestInvoker, Endpoint endpoint, RequestData pingData, CancellationToken cancellationToken)
+	public override async Task<TransportResponse> PingAsync(IRequestInvoker requestInvoker, Endpoint endpoint, RequestData requestData, CancellationToken cancellationToken)
 	{
-		var response = await requestInvoker.RequestAsync<VoidResponse>(endpoint, pingData, cancellationToken).ConfigureAwait(false);
+		var response = await requestInvoker.RequestAsync<VoidResponse>(endpoint, requestData, null, cancellationToken).ConfigureAwait(false);
 		return response;
 	}
 
 	/// <inheritdoc cref="ProductRegistration.Ping"/>
 	public override TransportResponse Ping(IRequestInvoker requestInvoker, Endpoint endpoint, RequestData pingData)
 	{
-		var response = requestInvoker.Request<VoidResponse>(endpoint, pingData);
+		var response = requestInvoker.Request<VoidResponse>(endpoint, pingData, null);
 		return response;
 	}
 

--- a/src/Elastic.Transport/Products/Elasticsearch/ElasticsearchProductRegistration.cs
+++ b/src/Elastic.Transport/Products/Elasticsearch/ElasticsearchProductRegistration.cs
@@ -84,7 +84,7 @@ public class ElasticsearchProductRegistration : ProductRegistration
 	public override ResponseBuilder ResponseBuilder => new ElasticsearchResponseBuilder();
 
 	/// <inheritdoc cref="ProductRegistration.DefaultMimeType"/>
-	public override string DefaultMimeType => _clientMajorVersion.HasValue ? $"application/vnd.elasticsearch+json;compatible-with={_clientMajorVersion.Value}" : null;
+	public override string? DefaultMimeType => _clientMajorVersion.HasValue ? $"application/vnd.elasticsearch+json;compatible-with={_clientMajorVersion.Value}" : null;
 
 	/// <summary> Exposes the path used for sniffing in Elasticsearch </summary>
 	public const string SniffPath = "_nodes/http,settings";

--- a/src/Elastic.Transport/Products/Elasticsearch/ElasticsearchProductRegistration.cs
+++ b/src/Elastic.Transport/Products/Elasticsearch/ElasticsearchProductRegistration.cs
@@ -128,7 +128,7 @@ public class ElasticsearchProductRegistration : ProductRegistration
 			QueryString = { { "timeout", requestConfiguration.PingTimeout }, { "flat_settings", true } }
 		};
 		var sniffPath = requestParameters.CreatePathWithQueryStrings(SniffPath, settings);
-		return new Endpoint(HttpMethod.GET, sniffPath, node);
+		return new Endpoint(new EndpointPath(HttpMethod.GET, sniffPath), node);
 	}
 
 	/// <inheritdoc cref="ProductRegistration.SniffAsync"/>
@@ -154,7 +154,7 @@ public class ElasticsearchProductRegistration : ProductRegistration
 
 	/// <inheritdoc cref="ProductRegistration.CreatePingEndpoint"/>
 	public override Endpoint CreatePingEndpoint(Node node, IRequestConfiguration requestConfiguration) =>
-		new(HttpMethod.HEAD, string.Empty, node);
+		new(new EndpointPath(HttpMethod.HEAD, string.Empty), node);
 
 	/// <inheritdoc cref="ProductRegistration.PingAsync"/>
 	public override async Task<TransportResponse> PingAsync(IRequestInvoker requestInvoker, Endpoint endpoint, RequestData pingData, CancellationToken cancellationToken)

--- a/src/Elastic.Transport/Products/ProductRegistration.cs
+++ b/src/Elastic.Transport/Products/ProductRegistration.cs
@@ -65,7 +65,7 @@ public abstract class ProductRegistration
 	/// Provide an implementation that performs the ping directly using <see cref="IRequestInvoker.RequestAsync{TResponse}"/> and the <see cref="RequestData"/>
 	/// return by <see cref="CreatePingEndpoint"/>
 	/// </summary>
-	public abstract Task<TransportResponse> PingAsync(IRequestInvoker requestInvoker, Endpoint endpoint, RequestData pingData, CancellationToken cancellationToken);
+	public abstract Task<TransportResponse> PingAsync(IRequestInvoker requestInvoker, Endpoint endpoint, RequestData requestData, CancellationToken cancellationToken);
 
 	/// <summary>
 	/// Provide an implementation that performs the ping directly using <see cref="IRequestInvoker.Request{TResponse}"/> and the <see cref="RequestData"/>

--- a/src/Elastic.Transport/Products/ProductRegistration.cs
+++ b/src/Elastic.Transport/Products/ProductRegistration.cs
@@ -59,38 +59,37 @@ public abstract class ProductRegistration
 	/// Create an instance of <see cref="RequestData"/> that describes where and how to ping see <paramref name="node" />
 	/// <para>All the parameters of this method correspond with <see cref="RequestData"/>'s constructor</para>
 	/// </summary>
-	public abstract RequestData CreatePingRequestData(Node node, RequestConfiguration requestConfiguration, ITransportConfiguration global, MemoryStreamFactory memoryStreamFactory);
+	public abstract Endpoint CreatePingEndpoint(Node node, IRequestConfiguration requestConfiguration);
 
 	/// <summary>
 	/// Provide an implementation that performs the ping directly using <see cref="IRequestInvoker.RequestAsync{TResponse}"/> and the <see cref="RequestData"/>
-	/// return by <see cref="CreatePingRequestData"/>
+	/// return by <see cref="CreatePingEndpoint"/>
 	/// </summary>
-	public abstract Task<TransportResponse> PingAsync(IRequestInvoker requestInvoker, RequestData pingData, CancellationToken cancellationToken);
+	public abstract Task<TransportResponse> PingAsync(IRequestInvoker requestInvoker, Endpoint endpoint, RequestData pingData, CancellationToken cancellationToken);
 
 	/// <summary>
 	/// Provide an implementation that performs the ping directly using <see cref="IRequestInvoker.Request{TResponse}"/> and the <see cref="RequestData"/>
-	/// return by <see cref="CreatePingRequestData"/>
+	/// return by <see cref="CreatePingEndpoint"/>
 	/// </summary>
-	public abstract TransportResponse Ping(IRequestInvoker requestInvoker, RequestData pingData);
+	public abstract TransportResponse Ping(IRequestInvoker requestInvoker, Endpoint endpoint, RequestData pingData);
 
 	/// <summary>
 	/// Create an instance of <see cref="RequestData"/> that describes where and how to sniff the cluster using <paramref name="node" />
 	/// <para>All the parameters of this method correspond with <see cref="RequestData"/>'s constructor</para>
 	/// </summary>
-	public abstract RequestData CreateSniffRequestData(Node node, IRequestConfiguration requestConfiguration, ITransportConfiguration settings,
-		MemoryStreamFactory memoryStreamFactory);
+	public abstract Endpoint CreateSniffEndpoint(Node node, IRequestConfiguration requestConfiguration, ITransportConfiguration settings);
 
 	/// <summary>
 	/// Provide an implementation that performs the sniff directly using <see cref="IRequestInvoker.Request{TResponse}"/> and the <see cref="RequestData"/>
-	/// return by <see cref="CreateSniffRequestData"/>
+	/// return by <see cref="CreateSniffEndpoint"/>
 	/// </summary>
-	public abstract Task<Tuple<TransportResponse, IReadOnlyCollection<Node>>> SniffAsync(IRequestInvoker requestInvoker, bool forceSsl, RequestData requestData, CancellationToken cancellationToken);
+	public abstract Task<Tuple<TransportResponse, IReadOnlyCollection<Node>>> SniffAsync(IRequestInvoker requestInvoker, bool forceSsl, Endpoint endpoint, RequestData requestData, CancellationToken cancellationToken);
 
 	/// <summary>
 	/// Provide an implementation that performs the sniff directly using <see cref="IRequestInvoker.Request{TResponse}"/> and the <see cref="RequestData"/>
-	/// return by <see cref="CreateSniffRequestData"/>
+	/// return by <see cref="CreateSniffEndpoint"/>
 	/// </summary>
-	public abstract Tuple<TransportResponse, IReadOnlyCollection<Node>> Sniff(IRequestInvoker requestInvoker, bool forceSsl, RequestData requestData);
+	public abstract Tuple<TransportResponse, IReadOnlyCollection<Node>> Sniff(IRequestInvoker requestInvoker, bool forceSsl, Endpoint endpoint, RequestData requestData);
 
 	/// <summary> Allows certain nodes to be queried first to obtain sniffing information </summary>
 	public abstract int SniffOrder(Node node);

--- a/src/Elastic.Transport/Requests/Body/PostData.ByteArray.cs
+++ b/src/Elastic.Transport/Requests/Body/PostData.ByteArray.cs
@@ -24,34 +24,33 @@ public abstract partial class PostData
 			Type = PostType.ByteArray;
 		}
 
-		public override void Write(Stream writableStream, ITransportConfiguration settings)
+		public override void Write(Stream writableStream, ITransportConfiguration settings, bool disableDirectStreaming)
 		{
 			if (WrittenBytes == null) return;
 
-			var stream = InitWrite(writableStream, settings, out var buffer, out var disableDirectStreaming);
+			MemoryStream? buffer = null;
 
 			if (!disableDirectStreaming)
-				stream.Write(WrittenBytes, 0, WrittenBytes.Length);
+				writableStream.Write(WrittenBytes, 0, WrittenBytes.Length);
 			else
 				buffer = settings.MemoryStreamFactory.Create(WrittenBytes);
 
-			FinishStream(writableStream, buffer, settings);
+			FinishStream(writableStream, buffer, disableDirectStreaming);
 		}
 
-		public override async Task WriteAsync(Stream writableStream, ITransportConfiguration settings,
-			CancellationToken cancellationToken)
+		public override async Task WriteAsync(Stream writableStream, ITransportConfiguration settings, bool disableDirectStreaming, CancellationToken cancellationToken)
 		{
 			if (WrittenBytes == null) return;
 
-			var stream = InitWrite(writableStream, settings, out var buffer, out var disableDirectStreaming);
+			MemoryStream? buffer = null;
 
 			if (!disableDirectStreaming)
-				await stream.WriteAsync(WrittenBytes, 0, WrittenBytes.Length, cancellationToken)
+				await writableStream.WriteAsync(WrittenBytes, 0, WrittenBytes.Length, cancellationToken)
 					.ConfigureAwait(false);
 			else
 				buffer = settings.MemoryStreamFactory.Create(WrittenBytes);
 
-			await FinishStreamAsync(writableStream, buffer, settings, cancellationToken).ConfigureAwait(false);
+			await FinishStreamAsync(writableStream, buffer, disableDirectStreaming, cancellationToken).ConfigureAwait(false);
 		}
 	}
 }

--- a/src/Elastic.Transport/Requests/Body/PostData.ReadOnlyMemory.cs
+++ b/src/Elastic.Transport/Requests/Body/PostData.ReadOnlyMemory.cs
@@ -27,38 +27,37 @@ namespace Elastic.Transport
 				Type = PostType.ReadOnlyMemory;
 			}
 
-			public override void Write(Stream writableStream, ITransportConfiguration settings)
+			public override void Write(Stream writableStream, ITransportConfiguration settings, bool disableDirectStreaming)
 			{
 				if (_memoryOfBytes.IsEmpty) return;
 
-				var stream = InitWrite(writableStream, settings, out var buffer, out var disableDirectStreaming);
+				MemoryStream? buffer = null;
 
 				if (!disableDirectStreaming)
-					stream.Write(_memoryOfBytes.Span);
+					writableStream.Write(_memoryOfBytes.Span);
 				else
 				{
 					WrittenBytes ??= _memoryOfBytes.Span.ToArray();
 					buffer = settings.MemoryStreamFactory.Create(WrittenBytes);
 				}
-				FinishStream(writableStream, buffer, settings);
+				FinishStream(writableStream, buffer, disableDirectStreaming);
 			}
 
-			public override async Task WriteAsync(Stream writableStream, ITransportConfiguration settings,
-				CancellationToken cancellationToken)
+			public override async Task WriteAsync(Stream writableStream, ITransportConfiguration settings, bool disableDirectStreaming, CancellationToken cancellationToken)
 			{
 				if (_memoryOfBytes.IsEmpty) return;
 
-				var stream = InitWrite(writableStream, settings, out var buffer, out var disableDirectStreaming);
+				MemoryStream? buffer = null;
 
 				if (!disableDirectStreaming)
-					stream.Write(_memoryOfBytes.Span);
+					writableStream.Write(_memoryOfBytes.Span);
 				else
 				{
 					WrittenBytes ??= _memoryOfBytes.Span.ToArray();
 					buffer = settings.MemoryStreamFactory.Create(WrittenBytes);
 				}
 
-				await FinishStreamAsync(writableStream, buffer, settings, cancellationToken).ConfigureAwait(false);
+				await FinishStreamAsync(writableStream, buffer, disableDirectStreaming, cancellationToken).ConfigureAwait(false);
 			}
 		}
 	}

--- a/src/Elastic.Transport/Requests/Body/PostData.Serializable.cs
+++ b/src/Elastic.Transport/Requests/Body/PostData.Serializable.cs
@@ -27,33 +27,32 @@ public abstract partial class PostData
 			_serializable = item;
 		}
 
-		public static implicit operator SerializableData<T>(T serializableData) =>
-			new SerializableData<T>(serializableData);
+		public static implicit operator SerializableData<T>(T serializableData) => new(serializableData);
 
-		public override void Write(Stream writableStream, ITransportConfiguration settings)
+		public override void Write(Stream writableStream, ITransportConfiguration settings, bool disableDirectStreaming)
 		{
 			MemoryStream buffer = null;
 			var stream = writableStream;
-			BufferIfNeeded(settings, ref buffer, ref stream);
+			BufferIfNeeded(settings.MemoryStreamFactory, disableDirectStreaming, ref buffer, ref stream);
 
 			var indent = settings.PrettyJson ? Indented : None;
 			settings.RequestResponseSerializer.Serialize(_serializable, stream, indent);
 
-			FinishStream(writableStream, buffer, settings);
+			FinishStream(writableStream, buffer, disableDirectStreaming);
 		}
 
-		public override async Task WriteAsync(Stream writableStream, ITransportConfiguration settings, CancellationToken cancellationToken)
+		public override async Task WriteAsync(Stream writableStream, ITransportConfiguration settings, bool disableDirectStreaming, CancellationToken cancellationToken)
 		{
 			MemoryStream buffer = null;
 			var stream = writableStream;
-			BufferIfNeeded(settings, ref buffer, ref stream);
+			BufferIfNeeded(settings.MemoryStreamFactory, disableDirectStreaming, ref buffer, ref stream);
 
 			var indent = settings.PrettyJson ? Indented : None;
 			await settings.RequestResponseSerializer
 				.SerializeAsync(_serializable, stream, indent, cancellationToken)
 				.ConfigureAwait(false);
 
-			await FinishStreamAsync(writableStream, buffer, settings, cancellationToken).ConfigureAwait(false);
+			await FinishStreamAsync(writableStream, buffer, disableDirectStreaming, cancellationToken).ConfigureAwait(false);
 		}
 	}
 }

--- a/src/Elastic.Transport/Requests/Body/PostData.Streamable.cs
+++ b/src/Elastic.Transport/Requests/Body/PostData.Streamable.cs
@@ -46,23 +46,22 @@ public abstract partial class PostData
 			Type = PostType.StreamHandler;
 		}
 
-		public override void Write(Stream writableStream, ITransportConfiguration settings)
+		public override void Write(Stream writableStream, ITransportConfiguration settings, bool disableDirectStreaming)
 		{
 			MemoryStream buffer = null;
 			var stream = writableStream;
-			BufferIfNeeded(settings, ref buffer, ref stream);
+			BufferIfNeeded(settings.MemoryStreamFactory, disableDirectStreaming, ref buffer, ref stream);
 			_syncWriter(_state, stream);
-			FinishStream(writableStream, buffer, settings);
+			FinishStream(writableStream, buffer, disableDirectStreaming);
 		}
 
-		public override async Task WriteAsync(Stream writableStream, ITransportConfiguration settings,
-			CancellationToken cancellationToken)
+		public override async Task WriteAsync(Stream writableStream, ITransportConfiguration settings, bool disableDirectStreaming, CancellationToken cancellationToken)
 		{
 			MemoryStream buffer = null;
 			var stream = writableStream;
-			BufferIfNeeded(settings, ref buffer, ref stream);
+			BufferIfNeeded(settings.MemoryStreamFactory, disableDirectStreaming, ref buffer, ref stream);
 			await _asyncWriter(_state, stream, cancellationToken).ConfigureAwait(false);
-			await FinishStreamAsync(writableStream, buffer, settings, cancellationToken).ConfigureAwait(false);
+			await FinishStreamAsync(writableStream, buffer, disableDirectStreaming, cancellationToken).ConfigureAwait(false);
 		}
 	}
 }

--- a/src/Elastic.Transport/Requests/Body/PostData.cs
+++ b/src/Elastic.Transport/Requests/Body/PostData.cs
@@ -79,7 +79,7 @@ public abstract partial class PostData
 	{
 		buffer = null;
 		var stream = writableStream;
-		disableDirectStreaming = DisableDirectStreaming ?? settings.DisableDirectStreaming;
+		disableDirectStreaming = DisableDirectStreaming ?? settings.DisableDirectStreaming ?? false;
 		return stream;
 	}
 
@@ -92,7 +92,7 @@ public abstract partial class PostData
 	protected void BufferIfNeeded(ITransportConfiguration settings, ref MemoryStream buffer,
 		ref Stream stream)
 	{
-		var disableDirectStreaming = DisableDirectStreaming ?? settings.DisableDirectStreaming;
+		var disableDirectStreaming = DisableDirectStreaming ?? settings.DisableDirectStreaming ?? false;
 		if (!disableDirectStreaming) return;
 
 		buffer = settings.MemoryStreamFactory.Create();
@@ -105,7 +105,7 @@ public abstract partial class PostData
 	/// </summary>
 	protected void FinishStream(Stream writableStream, MemoryStream buffer, ITransportConfiguration settings)
 	{
-		var disableDirectStreaming = DisableDirectStreaming ?? settings.DisableDirectStreaming;
+		var disableDirectStreaming = DisableDirectStreaming ?? settings.DisableDirectStreaming ?? false;
 		if (buffer == null || !disableDirectStreaming) return;
 
 		buffer.Position = 0;
@@ -127,7 +127,7 @@ public abstract partial class PostData
 		FinishStreamAsync(Stream writableStream, MemoryStream buffer, ITransportConfiguration settings,
 			CancellationToken ctx)
 	{
-		var disableDirectStreaming = DisableDirectStreaming ?? settings.DisableDirectStreaming;
+		var disableDirectStreaming = DisableDirectStreaming ?? settings.DisableDirectStreaming ?? false;
 		if (buffer == null || !disableDirectStreaming) return;
 
 		buffer.Position = 0;

--- a/src/Elastic.Transport/Requests/MetaData/DefaultMetaHeaderProvider.cs
+++ b/src/Elastic.Transport/Requests/MetaData/DefaultMetaHeaderProvider.cs
@@ -58,24 +58,18 @@ public sealed class DefaultMetaHeaderProducer : MetaHeaderProducer
 		_syncMetaDataHeader = new MetaDataHeader(versionInfo, serviceIdentifier, false);
 	}
 
-	/// <summary>
-	///
-	/// </summary>
+	/// <inheritdoc/>
 	public override string HeaderName => MetaHeaderName;
 
-	/// <summary>
-	///
-	/// </summary>
-	/// <param name="requestData"></param>
-	/// <returns></returns>
-	public override string ProduceHeaderValue(RequestData requestData)
+	/// <inheritdoc/>
+	public override string? ProduceHeaderValue(RequestData requestData, bool isAsync)
 	{
 		try
 		{
 			if (requestData.ConnectionSettings.DisableMetaHeader)
 				return null;
 
-			var headerValue = requestData.IsAsync
+			var headerValue = isAsync
 				? _asyncMetaDataHeader.ToString()
 				: _syncMetaDataHeader.ToString();
 

--- a/src/Elastic.Transport/Requests/MetaData/MetaHeaderProvider.cs
+++ b/src/Elastic.Transport/Requests/MetaData/MetaHeaderProvider.cs
@@ -28,5 +28,5 @@ public abstract class MetaHeaderProducer
 	/// <summary>
 	/// Produces the header value based on current outgoing <paramref name="requestData"/>.
 	/// </summary>
-	public abstract string ProduceHeaderValue(RequestData requestData);
+	public abstract string? ProduceHeaderValue(RequestData requestData, bool isAsync);
 }

--- a/src/Elastic.Transport/Requests/RequestParameters.cs
+++ b/src/Elastic.Transport/Requests/RequestParameters.cs
@@ -92,7 +92,7 @@ public abstract class RequestParameters
 	}
 
 	/// <summary> </summary>
-	public virtual string CreatePathWithQueryStrings(string? path, ITransportConfiguration global)
+	public virtual string CreatePathWithQueryStrings(string? path, ITransportConfiguration? global)
 	{
 		path ??= string.Empty;
 		if (path.Contains("?"))
@@ -107,7 +107,7 @@ public abstract class RequestParameters
 		var nv = g == null ? new NameValueCollection() : new NameValueCollection(g);
 
 		//set all querystring pairs from local `l` on the querystring collection
-		var formatter = global.UrlFormatter;
+		var formatter = global?.UrlFormatter;
 		nv.UpdateFromDictionary(l, formatter);
 
 		//if nv has no keys simply return path as provided

--- a/src/Elastic.Transport/Requests/RequestParameters.cs
+++ b/src/Elastic.Transport/Requests/RequestParameters.cs
@@ -29,13 +29,6 @@ public interface IStringable
 public sealed class DefaultRequestParameters : RequestParameters;
 
 /// <summary>
-///
-/// </summary>
-public static class RequestParameterExtensions
-{
-}
-
-/// <summary>
 /// Used by the raw client to compose querystring parameters in a matter that still exposes some xmldocs
 /// You can always pass a simple NameValueCollection if you want.
 /// </summary>

--- a/src/Elastic.Transport/Responses/ResponseStatics.cs
+++ b/src/Elastic.Transport/Responses/ResponseStatics.cs
@@ -31,7 +31,7 @@ internal static class ResponseStatics
 
 		var auditTrail = (r.AuditTrail ?? Enumerable.Empty<Audit>()).ToList();
 
-		if (!r.TransportConfiguration.DisableAuditTrail)
+		if (!r.TransportConfiguration.DisableAuditTrail ?? true)
 		{
 			DebugAuditTrail(auditTrail, sb);
 		}
@@ -42,7 +42,7 @@ internal static class ResponseStatics
 
 		if (r.OriginalException != null) sb.AppendLine($"# OriginalException: {r.OriginalException}");
 
-		if (!r.TransportConfiguration.DisableAuditTrail)
+		if (!r.TransportConfiguration.DisableAuditTrail ?? true)
 			DebugAuditTrailExceptions(auditTrail, sb);
 
 		var response = r.ResponseBodyInBytes?.Utf8String() ?? ResponseAlreadyCaptured;

--- a/tests/Elastic.Elasticsearch.IntegrationTests/SecurityClusterTests.cs
+++ b/tests/Elastic.Elasticsearch.IntegrationTests/SecurityClusterTests.cs
@@ -14,10 +14,12 @@ public class SecurityClusterTests : IntegrationTestBase<SecurityCluster>
 {
 	public SecurityClusterTests(SecurityCluster cluster, ITestOutputHelper output) : base(cluster, output) { }
 
+	private static readonly EndpointPath Root = new(GET, "/");
+
 	[Fact]
 	public async Task AsyncRequestDoesNotThrow()
 	{
-		var response = await RequestHandler.RequestAsync<StringResponse>(GET, "/");
+		var response = await RequestHandler.RequestAsync<StringResponse>(Root);
 		response.ApiCallDetails.Should().NotBeNull();
 		response.ApiCallDetails.HasSuccessfulStatusCode.Should().BeTrue();
 	}
@@ -25,7 +27,7 @@ public class SecurityClusterTests : IntegrationTestBase<SecurityCluster>
 	[Fact]
 	public void SyncRequestDoesNotThrow()
 	{
-		var response = RequestHandler.Request<StringResponse>(GET, "/");
+		var response = RequestHandler.Request<StringResponse>(Root);
 		response.ApiCallDetails.Should().NotBeNull();
 		response.ApiCallDetails.HasSuccessfulStatusCode.Should().BeTrue();
 	}
@@ -33,8 +35,7 @@ public class SecurityClusterTests : IntegrationTestBase<SecurityCluster>
 	[Fact]
 	public void SyncRequestDoesNotThrowOnBadAuth()
 	{
-		var response = RequestHandler.Request<StringResponse>(GET, "/", null,
-			new DefaultRequestParameters(),
+		var response = RequestHandler.Request<StringResponse>(Root, null,
 			new RequestConfiguration
 			{
 				Authentication = new BasicAuthentication("unknown-user", "bad-password")

--- a/tests/Elastic.Elasticsearch.IntegrationTests/SecurityClusterTests.cs
+++ b/tests/Elastic.Elasticsearch.IntegrationTests/SecurityClusterTests.cs
@@ -37,7 +37,7 @@ public class SecurityClusterTests : IntegrationTestBase<SecurityCluster>
 			new DefaultRequestParameters(),
 			new RequestConfiguration
 			{
-				AuthenticationHeader = new BasicAuthentication("unknown-user", "bad-password")
+				Authentication = new BasicAuthentication("unknown-user", "bad-password")
 			}
 		);
 		response.ApiCallDetails.Should().NotBeNull();

--- a/tests/Elastic.Transport.IntegrationTests/Http/StreamResponseTests.cs
+++ b/tests/Elastic.Transport.IntegrationTests/Http/StreamResponseTests.cs
@@ -106,11 +106,9 @@ public class StreamResponseTests(TransportTestServer instance) : AssemblyServerT
 
 		// We expect one for sending the request payload, but as the response is 204, we shouldn't
 		// see other memory streams being created for the response.
-		memoryStreamFactory.Created.Count.Should().Be(1);
+		memoryStreamFactory.Created.Count.Should().Be(2);
 		foreach (var memoryStream in memoryStreamFactory.Created)
-		{
 			memoryStream.IsDisposed.Should().BeTrue();
-		}
 	}
 
 	[Fact]

--- a/tests/Elastic.Transport.IntegrationTests/Http/TransferEncodingChunckedTests.cs
+++ b/tests/Elastic.Transport.IntegrationTests/Http/TransferEncodingChunckedTests.cs
@@ -63,7 +63,7 @@ namespace Elastic.Transport.IntegrationTests.Http
 			requestInvoker.LastHttpClientHandler.UseProxy.Should().BeFalse();
 			r.Body.Should().Be(BodyString);
 
-			r = await transport.PostAsync<StringResponse>(Path, Body, null, CancellationToken.None);
+			r = await transport.PostAsync<StringResponse>(Path, Body, CancellationToken.None);
 			requestInvoker.LastHttpClientHandler.UseProxy.Should().BeFalse();
 			r.Body.Should().Be(BodyString);
 		}
@@ -75,7 +75,7 @@ namespace Elastic.Transport.IntegrationTests.Http
 
 			transport.Post<StringResponse>(Path, Body);
 			requestInvoker.LastHttpClientHandler.UseProxy.Should().BeTrue();
-			await transport.PostAsync<StringResponse>(Path, Body, null, CancellationToken.None);
+			await transport.PostAsync<StringResponse>(Path, Body, CancellationToken.None);
 			requestInvoker.LastHttpClientHandler.UseProxy.Should().BeTrue();
 		}
 
@@ -88,7 +88,7 @@ namespace Elastic.Transport.IntegrationTests.Http
 			var transport = Setup(requestInvoker, transferEncodingChunked: true);
 
 			transport.Post<StringResponse>(Path, Body);
-			await transport.PostAsync<StringResponse>(Path, Body, null, CancellationToken.None);
+			await transport.PostAsync<StringResponse>(Path, Body, CancellationToken.None);
 		}
 
 		[Fact] public async Task HttpClientSetsContentLengthWhenTransferEncodingChunkedFalse()
@@ -100,7 +100,7 @@ namespace Elastic.Transport.IntegrationTests.Http
 			var transport = Setup(trackingRequestInvoker, transferEncodingChunked: false);
 
 			transport.Post<StringResponse>(Path, Body);
-			await transport.PostAsync<StringResponse>(Path, Body, null, CancellationToken.None);
+			await transport.PostAsync<StringResponse>(Path, Body, CancellationToken.None);
 		}
 
 		[Fact] public async Task HttpClientSetsContentLengthWhenTransferEncodingChunkedHttpCompression()
@@ -112,7 +112,7 @@ namespace Elastic.Transport.IntegrationTests.Http
 			var transport = Setup(trackingRequestInvoker, transferEncodingChunked: false, httpCompression: true);
 
 			transport.Post<StringResponse>(Path, Body);
-			await transport.PostAsync<StringResponse>(Path, Body, null, CancellationToken.None);
+			await transport.PostAsync<StringResponse>(Path, Body, CancellationToken.None);
 		}
 	}
 }

--- a/tests/Elastic.Transport.IntegrationTests/Plumbing/Stubs/TrackingRequestInvoker.cs
+++ b/tests/Elastic.Transport.IntegrationTests/Plumbing/Stubs/TrackingRequestInvoker.cs
@@ -26,18 +26,18 @@ public class TrackingRequestInvoker : IRequestInvoker
 			return _handler;
 		});
 
-	public TResponse Request<TResponse>(RequestData requestData)
+	public TResponse Request<TResponse>(Endpoint endpoint, RequestData requestData)
 		where TResponse : TransportResponse, new()
 	{
 		CallCount++;
-		return _requestInvoker.Request<TResponse>(requestData);
+		return _requestInvoker.Request<TResponse>(endpoint, requestData);
 	}
 
-	public Task<TResponse> RequestAsync<TResponse>(RequestData requestData, CancellationToken cancellationToken)
+	public Task<TResponse> RequestAsync<TResponse>(Endpoint endpoint, RequestData requestData, CancellationToken cancellationToken)
 		where TResponse : TransportResponse, new()
 	{
 		CallCount++;
-		return _requestInvoker.RequestAsync<TResponse>(requestData, cancellationToken);
+		return _requestInvoker.RequestAsync<TResponse>(endpoint, requestData, cancellationToken);
 	}
 
 	public void Dispose()

--- a/tests/Elastic.Transport.IntegrationTests/Plumbing/Stubs/TrackingRequestInvoker.cs
+++ b/tests/Elastic.Transport.IntegrationTests/Plumbing/Stubs/TrackingRequestInvoker.cs
@@ -26,18 +26,18 @@ public class TrackingRequestInvoker : IRequestInvoker
 			return _handler;
 		});
 
-	public TResponse Request<TResponse>(Endpoint endpoint, RequestData requestData)
+	public TResponse Request<TResponse>(Endpoint endpoint, RequestData requestData, PostData postData)
 		where TResponse : TransportResponse, new()
 	{
 		CallCount++;
-		return _requestInvoker.Request<TResponse>(endpoint, requestData);
+		return _requestInvoker.Request<TResponse>(endpoint, requestData, postData);
 	}
 
-	public Task<TResponse> RequestAsync<TResponse>(Endpoint endpoint, RequestData requestData, CancellationToken cancellationToken)
+	public Task<TResponse> RequestAsync<TResponse>(Endpoint endpoint, RequestData requestData, PostData postData, CancellationToken cancellationToken)
 		where TResponse : TransportResponse, new()
 	{
 		CallCount++;
-		return _requestInvoker.RequestAsync<TResponse>(endpoint, requestData, cancellationToken);
+		return _requestInvoker.RequestAsync<TResponse>(endpoint, requestData, postData, cancellationToken);
 	}
 
 	public void Dispose()

--- a/tests/Elastic.Transport.Tests/Components/Serialization/LowLevelRequestResponseSerializerTests.cs
+++ b/tests/Elastic.Transport.Tests/Components/Serialization/LowLevelRequestResponseSerializerTests.cs
@@ -56,16 +56,17 @@ public class LowLevelRequestResponseSerializerTests : SerializerTestBase
 		source.ValueKind.Should().Be(JsonValueKind.String);
 		source.GetString().Should().Be("Elastic.Transport.Tests");
 
-		var windowsPath = "Components\\Serialization\\LowLevelRequestResponseSerializerTests.cs:line";
+		var windowsPath = "Components\\Serialization\\LowLevelRequestResponseSerializerTests.cs";
 		var path = RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
 			? windowsPath
 			: windowsPath.Replace('\\', '/');
 
 		exception.TryGetProperty("StackTraceString", out var stackTrace).Should().BeTrue();
 		stackTrace.ValueKind.Should().Be(JsonValueKind.String);
-		stackTrace.GetString().Should()
+		var stackTraceString = stackTrace.GetString();
+		stackTraceString.Should()
 			.Contain("at Elastic.Transport.Tests.Components.Serialization.LowLevelRequestResponseSerializerTests")
-			.And.Contain(path);
+			.And.Contain(path, stackTraceString);
 
 		exception.TryGetProperty("HResult", out var hResult).Should().BeTrue();
 		hResult.ValueKind.Should().Be(JsonValueKind.Number);
@@ -77,5 +78,4 @@ public class LowLevelRequestResponseSerializerTests : SerializerTestBase
 	}
 }
 
-internal class CustomException(string message) : Exception(message)
-{ }
+internal class CustomException(string message) : Exception(message);

--- a/tests/Elastic.Transport.Tests/OpenTelemetryTests.cs
+++ b/tests/Elastic.Transport.Tests/OpenTelemetryTests.cs
@@ -149,7 +149,7 @@ public class OpenTelemetryTests
 
 		transport ??= new DistributedTransport(InMemoryConnectionFactory.Create());
 
-		_ = await transport.RequestAsync<VoidResponse>(HttpMethod.GET, "/", null, null, openTelemetryData, null, null, default);
+		_ = await transport.RequestAsync<VoidResponse>(new EndpointPath(HttpMethod.GET, "/"), null, openTelemetryData, null, null, default);
 
 		mre.WaitOne(TimeSpan.FromSeconds(1)).Should().BeTrue();
 	}

--- a/tests/Elastic.Transport.Tests/ResponseBuilderDisposeTests.cs
+++ b/tests/Elastic.Transport.Tests/ResponseBuilderDisposeTests.cs
@@ -83,8 +83,8 @@ public class ResponseBuilderDisposeTests
 
 		var memoryStreamFactory = new TrackMemoryStreamFactory();
 
-		var endpoint = new Endpoint(httpMethod, "/", new Node(new Uri("http://localhost:9200")));
-		var requestData = new RequestData(httpMethod, "/", null, config, null, customResponseBuilder, memoryStreamFactory, default);
+		var endpoint = new Endpoint(new EndpointPath(httpMethod, "/"), new Node(new Uri("http://localhost:9200")));
+		var requestData = new RequestData(null, config, null, customResponseBuilder, memoryStreamFactory, default);
 
 		var stream = new TrackDisposeStream();
 

--- a/tests/Elastic.Transport.Tests/ResponseBuilderDisposeTests.cs
+++ b/tests/Elastic.Transport.Tests/ResponseBuilderDisposeTests.cs
@@ -82,11 +82,9 @@ public class ResponseBuilderDisposeTests
 		}
 
 		var memoryStreamFactory = new TrackMemoryStreamFactory();
-		
-		var requestData = new RequestData(httpMethod, "/", null, config, null, customResponseBuilder, memoryStreamFactory, default)
-		{
-			Node = new Node(new Uri("http://localhost:9200"))
-		};
+
+		var endpoint = new Endpoint(httpMethod, "/", new Node(new Uri("http://localhost:9200")));
+		var requestData = new RequestData(httpMethod, "/", null, config, null, customResponseBuilder, memoryStreamFactory, default);
 
 		var stream = new TrackDisposeStream();
 
@@ -96,7 +94,7 @@ public class ResponseBuilderDisposeTests
 			stream.Position = 0;
 		}
 
-		var response = config.ProductRegistration.ResponseBuilder.ToResponse<T>(requestData, null, statusCode, null, stream, mimeType, contentLength, null, null);
+		var response = config.ProductRegistration.ResponseBuilder.ToResponse<T>(endpoint, requestData, null, statusCode, null, stream, mimeType, contentLength, null, null);
 
 		response.Should().NotBeNull();
 
@@ -113,7 +111,7 @@ public class ResponseBuilderDisposeTests
 		stream = new TrackDisposeStream();
 		var ct = new CancellationToken();
 
-		response = await config.ProductRegistration.ResponseBuilder.ToResponseAsync<T>(requestData, null, statusCode, null, stream, null, contentLength, null, null,
+		response = await config.ProductRegistration.ResponseBuilder.ToResponseAsync<T>(endpoint, requestData, null, statusCode, null, stream, null, contentLength, null, null,
 			cancellationToken: ct);
 
 		response.Should().NotBeNull();
@@ -140,19 +138,20 @@ public class ResponseBuilderDisposeTests
 		public override MetaHeaderProvider MetaHeaderProvider => null;
 		public override string ProductAssemblyVersion => "0.0.0";
 		public override IReadOnlyDictionary<string, object> DefaultOpenTelemetryAttributes => new Dictionary<string, object>();
-		public override RequestData CreatePingRequestData(Node node, RequestConfiguration requestConfiguration, ITransportConfiguration global, MemoryStreamFactory memoryStreamFactory) => throw new NotImplementedException();
-		public override RequestData CreateSniffRequestData(Node node, IRequestConfiguration requestConfiguration, ITransportConfiguration settings, MemoryStreamFactory memoryStreamFactory) => throw new NotImplementedException();
 		public override IReadOnlyCollection<string> DefaultHeadersToParse() => [];
 		public override bool HttpStatusCodeClassifier(HttpMethod method, int statusCode) => true;
+		public override ResponseBuilder ResponseBuilder => new TestErrorResponseBuilder();
+
+		public override Endpoint CreatePingEndpoint(Node node, IRequestConfiguration requestConfiguration) => throw new NotImplementedException();
+		public override Task<TransportResponse> PingAsync(IRequestInvoker requestInvoker, Endpoint endpoint, RequestData pingData, CancellationToken cancellationToken) => throw new NotImplementedException();
+		public override TransportResponse Ping(IRequestInvoker requestInvoker, Endpoint endpoint, RequestData pingData) => throw new NotImplementedException();
+		public override Endpoint CreateSniffEndpoint(Node node, IRequestConfiguration requestConfiguration, ITransportConfiguration settings) => throw new NotImplementedException();
+		public override Task<Tuple<TransportResponse, IReadOnlyCollection<Node>>> SniffAsync(IRequestInvoker requestInvoker, bool forceSsl, Endpoint endpoint, RequestData requestData, CancellationToken cancellationToken) => throw new NotImplementedException();
+		public override Tuple<TransportResponse, IReadOnlyCollection<Node>> Sniff(IRequestInvoker requestInvoker, bool forceSsl, Endpoint endpoint, RequestData requestData) => throw new NotImplementedException();
 		public override bool NodePredicate(Node node) => throw new NotImplementedException();
 		public override Dictionary<string, object> ParseOpenTelemetryAttributesFromApiCallDetails(ApiCallDetails callDetails) => throw new NotImplementedException();
-		public override TransportResponse Ping(IRequestInvoker requestInvoker, RequestData pingData) => throw new NotImplementedException();
-		public override Task<TransportResponse> PingAsync(IRequestInvoker requestInvoker, RequestData pingData, CancellationToken cancellationToken) => throw new NotImplementedException();
-		public override Tuple<TransportResponse, IReadOnlyCollection<Node>> Sniff(IRequestInvoker requestInvoker, bool forceSsl, RequestData requestData) => throw new NotImplementedException();
-		public override Task<Tuple<TransportResponse, IReadOnlyCollection<Node>>> SniffAsync(IRequestInvoker requestInvoker, bool forceSsl, RequestData requestData, CancellationToken cancellationToken) => throw new NotImplementedException();
 		public override int SniffOrder(Node node) => throw new NotImplementedException();
 		public override bool TryGetServerErrorReason<TResponse>(TResponse response, out string reason) => throw new NotImplementedException();
-		public override ResponseBuilder ResponseBuilder => new TestErrorResponseBuilder();
 	}
 
 	private class TestError : ErrorResponse

--- a/tests/Elastic.Transport.Tests/ResponseBuilderDisposeTests.cs
+++ b/tests/Elastic.Transport.Tests/ResponseBuilderDisposeTests.cs
@@ -66,25 +66,19 @@ public class ResponseBuilderDisposeTests
 		ITransportConfiguration config;
 
 		if (skipStatusCode > -1 )
-		{
 			config = InMemoryConnectionFactory.Create(productRegistration)
 				.DisableDirectStreaming(disableDirectStreaming)
 				.SkipDeserializationForStatusCodes(skipStatusCode);
-		}
 		else if (productRegistration is not null)
-		{
 			config = InMemoryConnectionFactory.Create(productRegistration)
 				.DisableDirectStreaming(disableDirectStreaming);
-		}
 		else
-		{
 			config = disableDirectStreaming ? _settingsDisableDirectStream : _settings;
-		}
 
 		var memoryStreamFactory = new TrackMemoryStreamFactory();
 
 		var endpoint = new Endpoint(new EndpointPath(httpMethod, "/"), new Node(new Uri("http://localhost:9200")));
-		var requestData = new RequestData(null, config, null, customResponseBuilder, memoryStreamFactory, default);
+		var requestData = new RequestData(config, null, customResponseBuilder, memoryStreamFactory);
 
 		var stream = new TrackDisposeStream();
 
@@ -94,7 +88,7 @@ public class ResponseBuilderDisposeTests
 			stream.Position = 0;
 		}
 
-		var response = config.ProductRegistration.ResponseBuilder.ToResponse<T>(endpoint, requestData, null, statusCode, null, stream, mimeType, contentLength, null, null);
+		var response = config.ProductRegistration.ResponseBuilder.ToResponse<T>(endpoint, requestData, null, null, statusCode, null, stream, mimeType, contentLength, null, null);
 
 		response.Should().NotBeNull();
 
@@ -111,7 +105,7 @@ public class ResponseBuilderDisposeTests
 		stream = new TrackDisposeStream();
 		var ct = new CancellationToken();
 
-		response = await config.ProductRegistration.ResponseBuilder.ToResponseAsync<T>(endpoint, requestData, null, statusCode, null, stream, null, contentLength, null, null,
+		response = await config.ProductRegistration.ResponseBuilder.ToResponseAsync<T>(endpoint, requestData, null, null, statusCode, null, stream, null, contentLength, null, null,
 			cancellationToken: ct);
 
 		response.Should().NotBeNull();


### PR DESCRIPTION
This PR is meant as the first step to undo making `RequestData` the [God Object](https://en.wikipedia.org/wiki/God_object) it is today. 

-  RequestData is now completely readonly
- `PostData` is moved outside `RequestData`
- `HttpMethod` and `Path` and `RequestParameters` now live outside `RequestData`, more info on this later.
- `OpenTelemetryData` now lives outside `RequestData`.
- Fixes several instances of boxing in `HeaderList` constructors.


This now also introduces 2 new records.

`EndpointPath` a readonly record struct that instructs what API we're calling.
`Endpoint` takes and `EndpointPath` and `Node` to take ownership of `Uri` creations.

This is hopefully a first step where we can cache these in calling libraries.

- `TransportConfiguration` now implementents `IRequestConfigation`

The goal here is for `RequestData` to turn into `BoundConfiguration` and instance we can cache per `TransportConfiguration`. Unless a local per request configuration is provided in which case we'll need to new a new instance which is rare.
