### PR TITLE
Add copy constructor to `RequestConfiguration{Descriptor}`

### DIFF
--- a/src/Elastic.Transport/Components/Pipeline/RequestPipeline.cs
+++ b/src/Elastic.Transport/Components/Pipeline/RequestPipeline.cs
@@ -58,7 +58,7 @@ public class RequestPipeline
 				PingTimeout = PingTimeout,
 				RequestTimeout = PingTimeout,
 				Authentication = _requestData.AuthenticationHeader,
-				EnableHttpPipelining = _requestData.HttpPipeliningEnabled,
+				HttpPipeliningEnabled = _requestData.HttpPipeliningEnabled,
 				ForceNode = _requestData.ForceNode
 			};
 

--- a/src/Elastic.Transport/Configuration/RequestConfiguration.cs
+++ b/src/Elastic.Transport/Configuration/RequestConfiguration.cs
@@ -181,7 +181,7 @@ public record RequestConfiguration : IRequestConfiguration
 		Accept = config.Accept;
 		AllowedStatusCodes = config.AllowedStatusCodes;
 		Authentication = config.Authentication;
-		ClientCertificates = config.ClientCertificates;
+		ClientCertificates = (config.ClientCertificates is null) ? null : new X509CertificateCollection(config.ClientCertificates);
 		ContentType = config.ContentType;
 		DisableDirectStreaming = config.DisableDirectStreaming;
 		DisableAuditTrail = config.DisableAuditTrail;
@@ -231,16 +231,10 @@ public record RequestConfiguration : IRequestConfiguration
 	public bool? DisablePings { get; init; }
 
 	/// <inheritdoc />
-	public bool? DisablePing { get; init; } // TODO: ?
-
-	/// <inheritdoc />
 	public bool? DisableSniff { get; init; }
 
 	/// <inheritdoc />
 	public bool? HttpPipeliningEnabled { get; init; }
-
-	/// <inheritdoc />
-	public bool? EnableHttpPipelining { get; init; } = true; // TODO: ?
 
 	/// <inheritdoc />
 	public bool? EnableHttpCompression { get; init; }
@@ -306,7 +300,7 @@ public class RequestConfigurationDescriptor : IRequestConfiguration
 		_accept = config.Accept;
 		_allowedStatusCodes= config.AllowedStatusCodes;
 		_authentication = config.Authentication;
-		_clientCertificates = config.ClientCertificates;
+		_clientCertificates = (config.ClientCertificates is null) ? null : new X509CertificateCollection(config.ClientCertificates);;
 		_contentType = config.ContentType;
 		_disableDirectStreaming = config.DisableDirectStreaming;
 		_disableAuditTrail = config.DisableAuditTrail;
@@ -341,8 +335,10 @@ public class RequestConfigurationDescriptor : IRequestConfiguration
 	private bool? _disablePings;
 	private bool? _disableSniff;
 	private bool? _httpPipeliningEnabled;
+	private bool? _enableHttpCompression;
 	private Uri? _forceNode;
 	private int? _maxRetries;
+	private TimeSpan? _maxRetryTimeout; 
 	private string? _opaqueId;
 	private bool? _parseAllHeaders;
 	private TimeSpan? _pingTimeout;
@@ -355,11 +351,6 @@ public class RequestConfigurationDescriptor : IRequestConfiguration
 	private bool? _enableTcpStats;
 	private bool? _enableThreadPoolStats;
 	private RequestMetaData? _requestMetaData;
-
-#pragma warning disable CS0649 // Field is never assigned to, and will always have its default value
-	private bool? _enableHttpCompression; // TODO: ?
-	private TimeSpan? _maxRetryTimeout;   // TODO: ?
-#pragma warning restore CS0649 // Field is never assigned to, and will always have its default value
 
 	/// <inheritdoc cref="IRequestConfiguration.RunAs"/>
 	public RequestConfigurationDescriptor RunAs(string username)
@@ -466,6 +457,13 @@ public class RequestConfigurationDescriptor : IRequestConfiguration
 		return this;
 	}
 
+	/// <inheritdoc cref="IRequestConfiguration.MaxRetryTimeout"/>
+	public RequestConfigurationDescriptor MaxRetries(TimeSpan? timeout)
+	{
+		_maxRetryTimeout = timeout;
+		return this;
+	}
+
 	/// <inheritdoc cref="AuthorizationHeader"/>
 	public RequestConfigurationDescriptor Authentication(AuthorizationHeader authentication)
 	{
@@ -477,6 +475,13 @@ public class RequestConfigurationDescriptor : IRequestConfiguration
 	public RequestConfigurationDescriptor EnableHttpPipelining(bool enable = true)
 	{
 		_httpPipeliningEnabled = enable;
+		return this;
+	}
+
+	/// <inheritdoc cref="IRequestConfiguration.EnableHttpCompression"/>
+	public RequestConfigurationDescriptor EnableHttpCompression(bool enable = true)
+	{
+		_enableHttpCompression = enable;
 		return this;
 	}
 

--- a/src/Elastic.Transport/Configuration/RequestConfiguration.cs
+++ b/src/Elastic.Transport/Configuration/RequestConfiguration.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Security.Cryptography.X509Certificates;
+
 using Elastic.Transport.Extensions;
 
 namespace Elastic.Transport;
@@ -108,7 +109,6 @@ public interface IRequestConfiguration
 	/// </summary>
 	TimeSpan? RequestTimeout { get; }
 
-
 	/// <summary> Specifies the headers from the response that should be parsed. </summary>
 	HeadersList? ResponseHeadersToParse { get; }
 
@@ -163,6 +163,48 @@ public record RequestConfiguration : IRequestConfiguration
 	/// <summary> The default ping timeout when the connection is over HTTPS. Defaults to 5 seconds </summary>
 	public static readonly TimeSpan DefaultPingTimeoutOnSsl = TimeSpan.FromSeconds(5);
 
+	/// <inheritdoc cref="IRequestConfiguration"/>
+	public RequestConfiguration()
+	{
+	}
+
+	/// <inheritdoc cref="IRequestConfiguration"/>
+	public RequestConfiguration(IRequestConfiguration config)
+	{
+#if NET8_0_OR_GREATER
+		ArgumentNullException.ThrowIfNull(config);
+#else
+		if (config is null)
+			throw new ArgumentNullException(nameof(config));
+#endif
+
+		Accept = config.Accept;
+		AllowedStatusCodes = config.AllowedStatusCodes;
+		Authentication = config.Authentication;
+		ClientCertificates = config.ClientCertificates;
+		ContentType = config.ContentType;
+		DisableDirectStreaming = config.DisableDirectStreaming;
+		DisableAuditTrail = config.DisableAuditTrail;
+		DisablePings = config.DisablePings;
+		DisableSniff = config.DisableSniff;
+		HttpPipeliningEnabled = config.HttpPipeliningEnabled;
+		EnableHttpCompression = config.EnableHttpCompression;
+		ForceNode = config.ForceNode;
+		MaxRetries = config.MaxRetries;
+		MaxRetryTimeout = config.MaxRetryTimeout;
+		OpaqueId = config.OpaqueId;
+		PingTimeout = config.PingTimeout;
+		RequestTimeout = config.RequestTimeout;
+		RunAs = config.RunAs;
+		ThrowExceptions = config.ThrowExceptions;
+		TransferEncodingChunked = config.TransferEncodingChunked;
+		Headers = (config.Headers is null) ? null : new NameValueCollection(config.Headers);
+		EnableTcpStats = config.EnableTcpStats;
+		EnableThreadPoolStats = config.EnableThreadPoolStats;
+		ResponseHeadersToParse = (config.ResponseHeadersToParse is null) ? null : new HeadersList(config.ResponseHeadersToParse);
+		ParseAllHeaders = config.ParseAllHeaders;
+		RequestMetaData = config.RequestMetaData;
+	}
 
 	/// <inheritdoc />
 	public string? Accept { get; init; }
@@ -189,7 +231,7 @@ public record RequestConfiguration : IRequestConfiguration
 	public bool? DisablePings { get; init; }
 
 	/// <inheritdoc />
-	public bool? DisablePing { get; init; }
+	public bool? DisablePing { get; init; } // TODO: ?
 
 	/// <inheritdoc />
 	public bool? DisableSniff { get; init; }
@@ -198,7 +240,7 @@ public record RequestConfiguration : IRequestConfiguration
 	public bool? HttpPipeliningEnabled { get; init; }
 
 	/// <inheritdoc />
-	public bool? EnableHttpPipelining { get; init; } = true;
+	public bool? EnableHttpPipelining { get; init; } = true; // TODO: ?
 
 	/// <inheritdoc />
 	public bool? EnableHttpCompression { get; init; }
@@ -247,7 +289,6 @@ public record RequestConfiguration : IRequestConfiguration
 
 	/// <inheritdoc />
 	public RequestMetaData? RequestMetaData { get; init; }
-
 }
 
 /// <inheritdoc cref="IRequestConfiguration"/>
@@ -255,6 +296,40 @@ public class RequestConfigurationDescriptor : IRequestConfiguration
 {
 	/// <inheritdoc cref="IRequestConfiguration"/>
 	public RequestConfigurationDescriptor() { }
+
+	/// <inheritdoc cref="IRequestConfiguration"/>
+	public RequestConfigurationDescriptor(IRequestConfiguration? config)
+	{
+		if (config is null)
+			return;
+
+		_accept = config.Accept;
+		_allowedStatusCodes= config.AllowedStatusCodes;
+		_authentication = config.Authentication;
+		_clientCertificates = config.ClientCertificates;
+		_contentType = config.ContentType;
+		_disableDirectStreaming = config.DisableDirectStreaming;
+		_disableAuditTrail = config.DisableAuditTrail;
+		_disablePings = config.DisablePings;
+		_disableSniff = config.DisableSniff;
+		_httpPipeliningEnabled = config.HttpPipeliningEnabled;
+		_enableHttpCompression = config.EnableHttpCompression;
+		_forceNode = config.ForceNode;
+		_maxRetries = config.MaxRetries;
+		_maxRetryTimeout = config.MaxRetryTimeout;
+		_opaqueId = config.OpaqueId;
+		_pingTimeout = config.PingTimeout;
+		_requestTimeout = config.RequestTimeout;
+		_runAs = config.RunAs;
+		_throwExceptions = config.ThrowExceptions;
+		_transferEncodingChunked = config.TransferEncodingChunked;
+		_headers = (config.Headers is null) ? null : new NameValueCollection(config.Headers);
+		_enableTcpStats = config.EnableTcpStats;
+		_enableThreadPoolStats = config.EnableThreadPoolStats;
+		_responseHeadersToParse = (config.ResponseHeadersToParse is null) ? null : new HeadersList(config.ResponseHeadersToParse);
+		_parseAllHeaders = config.ParseAllHeaders;
+		_requestMetaData = config.RequestMetaData;
+	}
 
 	private string? _accept;
 	private IReadOnlyCollection<int>? _allowedStatusCodes;
@@ -282,10 +357,9 @@ public class RequestConfigurationDescriptor : IRequestConfiguration
 	private RequestMetaData? _requestMetaData;
 
 #pragma warning disable CS0649 // Field is never assigned to, and will always have its default value
-	private bool? _enableHttpCompression;
-	private TimeSpan? _maxRetryTimeout;
+	private bool? _enableHttpCompression; // TODO: ?
+	private TimeSpan? _maxRetryTimeout;   // TODO: ?
 #pragma warning restore CS0649 // Field is never assigned to, and will always have its default value
-
 
 	/// <inheritdoc cref="IRequestConfiguration.RunAs"/>
 	public RequestConfigurationDescriptor RunAs(string username)

--- a/tests/Elastic.Transport.Tests/Configuration/RequestConfigurationTests.cs
+++ b/tests/Elastic.Transport.Tests/Configuration/RequestConfigurationTests.cs
@@ -1,0 +1,54 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading;
+using FluentAssertions;
+using Xunit;
+#if !NETFRAMEWORK
+using Soenneker.Utils.AutoBogus;
+#endif
+
+namespace Elastic.Transport.Tests.Configuration;
+
+public class RequestConfigurationTests
+{
+	[Fact]
+	public void CopiesAllDefaults()
+	{
+		var config = new RequestConfiguration();
+		var newConfig = new RequestConfiguration(config);
+
+		config.Should().BeEquivalentTo(newConfig);
+	}
+
+	[Fact]
+	public void SameDefaults()
+	{
+		IRequestConfiguration config = new RequestConfiguration();
+		IRequestConfiguration newConfig = new RequestConfigurationDescriptor();
+
+		config.Should().BeEquivalentTo(newConfig);
+	}
+
+#if !NETFRAMEWORK
+	[Fact]
+	public void CopiesAllProperties()
+	{
+		var autoFaker = new AutoFaker<RequestConfiguration>();
+		autoFaker.RuleFor(x => x.ClientCertificates, f => new X509CertificateCollection());
+
+		var config = autoFaker.Generate();
+		config.Accept.Should().NotBeEmpty();
+		config.ClientCertificates.Should().NotBeNull();
+
+		IRequestConfiguration newConfig = new RequestConfiguration(config);
+		config.Should().BeEquivalentTo(newConfig);
+
+		IRequestConfiguration newDescriptor = new RequestConfigurationDescriptor(config);
+		config.Should().BeEquivalentTo(newDescriptor);
+	}
+#endif
+}


### PR DESCRIPTION
As titled.

What is the deal with `DisablePing`, `EnableHttpPipelining` in `RequestConfiguration` (both properties are not part of the interface) and `_enableHttpCompression` and `_maxRetryTimeout` in `RequestConfigurationDescriptor` (both fields don't have a corresponding setter-method)?

Is that by design or a leftover of the refactoring?