### PR TITLE
Replace `RequestData` with `BoundConfiguration`

### DIFF
--- a/src/Elastic.Transport.VirtualizedCluster/Components/ExposingPipelineFactory.cs
+++ b/src/Elastic.Transport.VirtualizedCluster/Components/ExposingPipelineFactory.cs
@@ -20,7 +20,6 @@ public sealed class ExposingPipelineFactory<TConfiguration> : RequestPipelineFac
 	private TConfiguration Configuration { get; }
 	public ITransport<TConfiguration> Transport { get; }
 
-	public override RequestPipeline Create(RequestData requestData) =>
-			new RequestPipeline(requestData);
+	public override RequestPipeline Create(BoundConfiguration boundConfiguration) => new(boundConfiguration);
 }
 #nullable restore

--- a/src/Elastic.Transport.VirtualizedCluster/Rules/RuleBase.cs
+++ b/src/Elastic.Transport.VirtualizedCluster/Rules/RuleBase.cs
@@ -80,11 +80,11 @@ public abstract class RuleBase<TRule> : IRule
 			r = ms.ToArray();
 		}
 		Self.ReturnResponse = r;
-		Self.ReturnContentType = RequestData.DefaultContentType;
+		Self.ReturnContentType = BoundConfiguration.DefaultContentType;
 		return (TRule)this;
 	}
 
-	public TRule ReturnByteResponse(byte[] response, string responseContentType = RequestData.DefaultContentType)
+	public TRule ReturnByteResponse(byte[] response, string responseContentType = BoundConfiguration.DefaultContentType)
 	{
 		Self.ReturnResponse = response;
 		Self.ReturnContentType = responseContentType;

--- a/src/Elastic.Transport/Components/Providers/DefaultRequestPipelineFactory.cs
+++ b/src/Elastic.Transport/Components/Providers/DefaultRequestPipelineFactory.cs
@@ -13,6 +13,6 @@ internal sealed class DefaultRequestPipelineFactory : RequestPipelineFactory
 	/// <summary>
 	/// returns instances of <see cref="RequestPipeline"/>
 	/// </summary>
-	public override RequestPipeline Create(RequestData requestData) =>
-			new RequestPipeline(requestData);
+	public override RequestPipeline Create(BoundConfiguration boundConfiguration) =>
+			new RequestPipeline(boundConfiguration);
 }

--- a/src/Elastic.Transport/Components/Providers/RequestPipelineFactory.cs
+++ b/src/Elastic.Transport/Components/Providers/RequestPipelineFactory.cs
@@ -10,5 +10,5 @@ public abstract class RequestPipelineFactory
 	internal RequestPipelineFactory() { }
 
 	/// <summary> Create an instance of <see cref="RequestPipeline"/> </summary>
-	public abstract RequestPipeline Create(RequestData requestData);
+	public abstract RequestPipeline Create(BoundConfiguration boundConfiguration);
 }

--- a/src/Elastic.Transport/Components/TransportClient/IRequestInvoker.cs
+++ b/src/Elastic.Transport/Components/TransportClient/IRequestInvoker.cs
@@ -22,10 +22,10 @@ public interface IRequestInvoker : IDisposable
 	public ResponseFactory ResponseFactory { get; }
 
 	/// <summary>
-	/// Perform a request to the endpoint described by <paramref name="requestData"/> using its associated configuration.
+	/// Perform a request to the endpoint described by <paramref name="boundConfiguration"/> using its associated configuration.
 	/// </summary>
 	/// <param name="endpoint">An object describing where to perform the IO call</param>
-	/// <param name="requestData">An object describing how to perform the IO call</param>
+	/// <param name="boundConfiguration">An object describing how to perform the IO call</param>
 	/// <param name="postData">Optional data to post</param>
 	/// <param name="cancellationToken"></param>
 	/// <typeparam name="TResponse">
@@ -38,14 +38,14 @@ public interface IRequestInvoker : IDisposable
 	/// for <see cref="RequestPipeline"/> and <see cref="ITransport{TConfiguration}"/> to determine what to
 	/// do with the response
 	/// </returns>
-	public Task<TResponse> RequestAsync<TResponse>(Endpoint endpoint, RequestData requestData, PostData? postData, CancellationToken cancellationToken)
+	public Task<TResponse> RequestAsync<TResponse>(Endpoint endpoint, BoundConfiguration boundConfiguration, PostData? postData, CancellationToken cancellationToken)
 		where TResponse : TransportResponse, new();
 
 	/// <summary>
-	/// Perform a request to the endpoint described by <paramref name="requestData"/> using its associated configuration.
+	/// Perform a request to the endpoint described by <paramref name="boundConfiguration"/> using its associated configuration.
 	/// </summary>
 	/// <param name="endpoint">An object describing where to perform the IO call</param>
-	/// <param name="requestData">An object describing how to perform the IO call</param>
+	/// <param name="boundConfiguration">An object describing how to perform the IO call</param>
 	/// <param name="postData">Optional data to post</param>
 	/// <typeparam name="TResponse">
 	/// An implementation of <see cref="TransportResponse"/> ensuring enough information is available
@@ -57,6 +57,6 @@ public interface IRequestInvoker : IDisposable
 	/// for <see cref="RequestPipeline"/> and <see cref="ITransport{TConfiguration}"/> to determine what to
 	/// do with the response
 	/// </returns>
-	public TResponse Request<TResponse>(Endpoint endpoint, RequestData requestData, PostData? postData)
+	public TResponse Request<TResponse>(Endpoint endpoint, BoundConfiguration boundConfiguration, PostData? postData)
 		where TResponse : TransportResponse, new();
 }

--- a/src/Elastic.Transport/Configuration/IRequestConfiguration.cs
+++ b/src/Elastic.Transport/Configuration/IRequestConfiguration.cs
@@ -90,7 +90,6 @@ public interface IRequestConfiguration
 
 	/// <summary>
 	/// Associate an Id with this user-initiated task, such that it can be located in the cluster task list.
-	/// Valid only for Elasticsearch 6.2.0+
 	/// </summary>
 	string? OpaqueId { get; }
 

--- a/src/Elastic.Transport/Configuration/ITransportConfiguration.cs
+++ b/src/Elastic.Transport/Configuration/ITransportConfiguration.cs
@@ -104,10 +104,10 @@ public interface ITransportConfiguration : IRequestConfiguration, IDisposable
 	Action<ApiCallDetails>? OnRequestCompleted { get; }
 
 	/// <summary>
-	/// An action to run when the <see cref="RequestData" /> for a request has been
-	/// created.
+	/// An action to run when the <see cref="BoundConfiguration" /> for a request has been
+	/// bound.
 	/// </summary>
-	Action<RequestData>? OnRequestDataCreated { get; }
+	Action<BoundConfiguration>? OnConfigurationBound { get; }
 
 	/// <summary>
 	/// When set will force all connections through this proxy

--- a/src/Elastic.Transport/Configuration/TransportConfiguration.cs
+++ b/src/Elastic.Transport/Configuration/TransportConfiguration.cs
@@ -159,7 +159,7 @@ public record TransportConfiguration : ITransportConfiguration
 		NodePool = config.NodePool;
 		NodePredicate = config.NodePredicate;
 		OnRequestCompleted = config.OnRequestCompleted;
-		OnRequestDataCreated = config.OnRequestDataCreated;
+		OnConfigurationBound = config.OnConfigurationBound;
 		OpaqueId = config.OpaqueId;
 		ParseAllHeaders = config.ParseAllHeaders;
 		PingTimeout = config.PingTimeout;
@@ -300,7 +300,7 @@ public record TransportConfiguration : ITransportConfiguration
 	/// <inheritdoc />
 	public Action<ApiCallDetails>? OnRequestCompleted { get; init; }
 	/// <inheritdoc />
-	public Action<RequestData>? OnRequestDataCreated { get; init; }
+	public Action<BoundConfiguration>? OnConfigurationBound { get; init; }
 	//TODO URI
 	/// <inheritdoc />
 	public string? ProxyAddress { get; init; }

--- a/src/Elastic.Transport/Configuration/TransportConfigurationDescriptor.cs
+++ b/src/Elastic.Transport/Configuration/TransportConfigurationDescriptor.cs
@@ -154,7 +154,6 @@ public abstract class TransportConfigurationDescriptorBase<T> : ITransportConfig
 		_nodePool = config.NodePool;
 		_nodePredicate = config.NodePredicate;
 		_onRequestCompleted = config.OnRequestCompleted;
-		_onRequestDataCreated = config.OnRequestDataCreated;
 		_opaqueId = config.OpaqueId;
 		_parseAllHeaders = config.ParseAllHeaders;
 		_pingTimeout = config.PingTimeout;
@@ -225,7 +224,7 @@ public abstract class TransportConfigurationDescriptorBase<T> : ITransportConfig
 	private MemoryStreamFactory _memoryStreamFactory;
 	private Func<Node, bool>? _nodePredicate;
 	private Action<ApiCallDetails>? _onRequestCompleted;
-	private Action<RequestData>? _onRequestDataCreated;
+	private Action<BoundConfiguration>? _onConfigurationBound;
 	private string? _proxyAddress;
 	private string? _proxyPassword;
 	private string? _proxyUsername;
@@ -266,7 +265,7 @@ public abstract class TransportConfigurationDescriptorBase<T> : ITransportConfig
 	MemoryStreamFactory ITransportConfiguration.MemoryStreamFactory => _memoryStreamFactory;
 	Func<Node, bool>? ITransportConfiguration.NodePredicate => _nodePredicate;
 	Action<ApiCallDetails>? ITransportConfiguration.OnRequestCompleted => _onRequestCompleted;
-	Action<RequestData>? ITransportConfiguration.OnRequestDataCreated => _onRequestDataCreated;
+	Action<BoundConfiguration>? ITransportConfiguration.OnConfigurationBound => _onConfigurationBound;
 	string? ITransportConfiguration.ProxyAddress => _proxyAddress;
 	string? ITransportConfiguration.ProxyPassword => _proxyPassword;
 	string? ITransportConfiguration.ProxyUsername => _proxyUsername;
@@ -328,7 +327,7 @@ public abstract class TransportConfigurationDescriptorBase<T> : ITransportConfig
 
 	private static void DefaultCompletedRequestHandler(ApiCallDetails response) { }
 
-	private static void DefaultRequestDataCreated(RequestData response) { }
+	private static void DefaultBoundConfigurationCreated(BoundConfiguration boundConfiguration) { }
 
 	/// <summary> Assign a private value and return the current <typeparamref name="T"/> </summary>
 	// ReSharper disable once MemberCanBePrivate.Global
@@ -439,9 +438,9 @@ public abstract class TransportConfigurationDescriptorBase<T> : ITransportConfig
 	public T OnRequestCompleted(Action<ApiCallDetails> handler) =>
 		Assign(handler, static (a, v) => a._onRequestCompleted += v ?? DefaultCompletedRequestHandler);
 
-	/// <inheritdoc cref="ITransportConfiguration.OnRequestDataCreated"/>
-	public T OnRequestDataCreated(Action<RequestData> handler) =>
-		Assign(handler, static (a, v) => a._onRequestDataCreated += v ?? DefaultRequestDataCreated);
+	/// <inheritdoc cref="ITransportConfiguration.OnConfigurationBound"/>
+	public T OnBoundConfigurationCreated(Action<BoundConfiguration> handler) =>
+		Assign(handler, static (a, v) => a._onConfigurationBound += v ?? DefaultBoundConfigurationCreated);
 
 	/// <inheritdoc cref="AuthorizationHeader"/>
 	public T Authentication(AuthorizationHeader header) => Assign(header, static (a, v) => a._authentication = v);

--- a/src/Elastic.Transport/Diagnostics/HttpConnectionDiagnosticObserver.cs
+++ b/src/Elastic.Transport/Diagnostics/HttpConnectionDiagnosticObserver.cs
@@ -8,11 +8,11 @@ using System.Collections.Generic;
 namespace Elastic.Transport.Diagnostics;
 
 /// <summary> Provides a typed listener to the events that <see cref="HttpRequestInvoker"/> emits </summary>
-internal sealed class HttpConnectionDiagnosticObserver : TypedDiagnosticObserver<RequestData, int?>
+internal sealed class HttpConnectionDiagnosticObserver : TypedDiagnosticObserver<BoundConfiguration, int?>
 {
 	/// <inheritdoc cref="HttpConnectionDiagnosticObserver"/>>
 	public HttpConnectionDiagnosticObserver(
-		Action<KeyValuePair<string, RequestData>> onNextStart,
+		Action<KeyValuePair<string, BoundConfiguration>> onNextStart,
 		Action<KeyValuePair<string, int?>> onNextEnd,
 		Action<Exception> onError = null,
 		Action onCompleted = null

--- a/src/Elastic.Transport/Diagnostics/RequestPipelineDiagnosticObserver.cs
+++ b/src/Elastic.Transport/Diagnostics/RequestPipelineDiagnosticObserver.cs
@@ -8,11 +8,11 @@ using System.Collections.Generic;
 namespace Elastic.Transport.Diagnostics;
 
 /// <summary> Provides a typed listener to  actions that <see cref="RequestPipeline"/> takes e.g sniff, ping, or making an API call </summary>;
-internal sealed class RequestPipelineDiagnosticObserver : TypedDiagnosticObserver<RequestData, ApiCallDetails>
+internal sealed class RequestPipelineDiagnosticObserver : TypedDiagnosticObserver<BoundConfiguration, ApiCallDetails>
 {
 	/// <inheritdoc cref="RequestPipelineDiagnosticObserver"/>
 	public RequestPipelineDiagnosticObserver(
-		Action<KeyValuePair<string, RequestData>> onNextStart,
+		Action<KeyValuePair<string, BoundConfiguration>> onNextStart,
 		Action<KeyValuePair<string, ApiCallDetails>> onNextEnd,
 		Action<Exception> onError = null,
 		Action onCompleted = null

--- a/src/Elastic.Transport/ITransport.cs
+++ b/src/Elastic.Transport/ITransport.cs
@@ -33,7 +33,6 @@ public interface ITransport
 	)
 		where TResponse : TransportResponse, new();
 
-
 	/// <summary>
 	/// Orchestrate a request asynchronously into a <see cref="NodePool"/> using the workflow defined in the <see cref="RequestPipeline"/>.
 	/// </summary>

--- a/src/Elastic.Transport/Products/DefaultProductRegistration.cs
+++ b/src/Elastic.Transport/Products/DefaultProductRegistration.cs
@@ -84,11 +84,11 @@ public sealed class DefaultProductRegistration : ProductRegistration
 		throw new NotImplementedException();
 
 	/// <inheritdoc cref="ProductRegistration.SniffAsync"/>
-	public override Task<Tuple<TransportResponse, IReadOnlyCollection<Node>>> SniffAsync(IRequestInvoker requestInvoker, bool forceSsl, Endpoint endpoint, RequestData requestData, CancellationToken cancellationToken) =>
+	public override Task<Tuple<TransportResponse, IReadOnlyCollection<Node>>> SniffAsync(IRequestInvoker requestInvoker, bool forceSsl, Endpoint endpoint, BoundConfiguration boundConfiguration, CancellationToken cancellationToken) =>
 		throw new NotImplementedException();
 
 	/// <inheritdoc cref="ProductRegistration.Sniff"/>
-	public override Tuple<TransportResponse, IReadOnlyCollection<Node>> Sniff(IRequestInvoker requestInvoker, bool forceSsl, Endpoint endpoint, RequestData requestData) =>
+	public override Tuple<TransportResponse, IReadOnlyCollection<Node>> Sniff(IRequestInvoker requestInvoker, bool forceSsl, Endpoint endpoint, BoundConfiguration boundConfiguration) =>
 		throw new NotImplementedException();
 
 	/// <inheritdoc cref="ProductRegistration.CreatePingEndpoint"/>
@@ -96,11 +96,11 @@ public sealed class DefaultProductRegistration : ProductRegistration
 		throw new NotImplementedException();
 
 	/// <inheritdoc cref="ProductRegistration.PingAsync"/>
-	public override Task<TransportResponse> PingAsync(IRequestInvoker requestInvoker, Endpoint endpoint, RequestData requestData, CancellationToken cancellationToken) =>
+	public override Task<TransportResponse> PingAsync(IRequestInvoker requestInvoker, Endpoint endpoint, BoundConfiguration boundConfiguration, CancellationToken cancellationToken) =>
 		throw new NotImplementedException();
 
 	/// <inheritdoc cref="ProductRegistration.Ping"/>
-	public override TransportResponse Ping(IRequestInvoker requestInvoker, Endpoint endpoint, RequestData pingData) =>
+	public override TransportResponse Ping(IRequestInvoker requestInvoker, Endpoint endpoint, BoundConfiguration boundConfiguration) =>
 		throw new NotImplementedException();
 
 	/// <inheritdoc/>

--- a/src/Elastic.Transport/Products/Elasticsearch/ElasticsearchErrorExtensions.cs
+++ b/src/Elastic.Transport/Products/Elasticsearch/ElasticsearchErrorExtensions.cs
@@ -15,7 +15,7 @@ public static class ElasticsearchErrorExtensions
 	public static bool TryGetElasticsearchServerError(this StringResponse response, out ElasticsearchServerError serverError)
 	{
 		serverError = null;
-		if (string.IsNullOrEmpty(response.Body) || response.ApiCallDetails.ResponseContentType != RequestData.DefaultContentType)
+		if (string.IsNullOrEmpty(response.Body) || response.ApiCallDetails.ResponseContentType != BoundConfiguration.DefaultContentType)
 			return false;
 
 		var settings = response.ApiCallDetails.TransportConfiguration;
@@ -27,7 +27,7 @@ public static class ElasticsearchErrorExtensions
 	public static bool TryGetElasticsearchServerError(this BytesResponse response, out ElasticsearchServerError serverError)
 	{
 		serverError = null;
-		if (response.Body == null || response.Body.Length == 0 || response.ApiCallDetails.ResponseContentType != RequestData.DefaultContentType)
+		if (response.Body == null || response.Body.Length == 0 || response.ApiCallDetails.ResponseContentType != BoundConfiguration.DefaultContentType)
 			return false;
 
 		var settings = response.ApiCallDetails.TransportConfiguration;
@@ -43,7 +43,7 @@ public static class ElasticsearchErrorExtensions
 	{
 		serverError = null;
 		var bytes = response.ApiCallDetails.ResponseBodyInBytes;
-		if (bytes == null || response.ApiCallDetails.ResponseContentType != RequestData.DefaultContentType)
+		if (bytes == null || response.ApiCallDetails.ResponseContentType != BoundConfiguration.DefaultContentType)
 			return false;
 
 		var settings = response.ApiCallDetails.TransportConfiguration;

--- a/src/Elastic.Transport/Products/Elasticsearch/ElasticsearchProductRegistration.cs
+++ b/src/Elastic.Transport/Products/Elasticsearch/ElasticsearchProductRegistration.cs
@@ -130,9 +130,9 @@ public class ElasticsearchProductRegistration : ProductRegistration
 
 	/// <inheritdoc cref="ProductRegistration.SniffAsync"/>
 	public override async Task<Tuple<TransportResponse, IReadOnlyCollection<Node>>> SniffAsync(IRequestInvoker requestInvoker,
-		bool forceSsl, Endpoint endpoint, RequestData requestData, CancellationToken cancellationToken)
+		bool forceSsl, Endpoint endpoint, BoundConfiguration boundConfiguration, CancellationToken cancellationToken)
 	{
-		var response = await requestInvoker.RequestAsync<SniffResponse>(endpoint, requestData, null, cancellationToken)
+		var response = await requestInvoker.RequestAsync<SniffResponse>(endpoint, boundConfiguration, null, cancellationToken)
 			.ConfigureAwait(false);
 		var nodes = response.ToNodes(forceSsl);
 		return Tuple.Create<TransportResponse, IReadOnlyCollection<Node>>(response,
@@ -141,9 +141,9 @@ public class ElasticsearchProductRegistration : ProductRegistration
 
 	/// <inheritdoc cref="ProductRegistration.Sniff"/>
 	public override Tuple<TransportResponse, IReadOnlyCollection<Node>> Sniff(IRequestInvoker requestInvoker, bool forceSsl,
-		Endpoint endpoint, RequestData requestData)
+		Endpoint endpoint, BoundConfiguration boundConfiguration)
 	{
-		var response = requestInvoker.Request<SniffResponse>(endpoint, requestData, null);
+		var response = requestInvoker.Request<SniffResponse>(endpoint, boundConfiguration, null);
 		var nodes = response.ToNodes(forceSsl);
 		return Tuple.Create<TransportResponse, IReadOnlyCollection<Node>>(response,
 			new ReadOnlyCollection<Node>(nodes.ToArray()));
@@ -154,16 +154,16 @@ public class ElasticsearchProductRegistration : ProductRegistration
 		new(new EndpointPath(HttpMethod.HEAD, string.Empty), node);
 
 	/// <inheritdoc cref="ProductRegistration.PingAsync"/>
-	public override async Task<TransportResponse> PingAsync(IRequestInvoker requestInvoker, Endpoint endpoint, RequestData requestData, CancellationToken cancellationToken)
+	public override async Task<TransportResponse> PingAsync(IRequestInvoker requestInvoker, Endpoint endpoint, BoundConfiguration boundConfiguration, CancellationToken cancellationToken)
 	{
-		var response = await requestInvoker.RequestAsync<VoidResponse>(endpoint, requestData, null, cancellationToken).ConfigureAwait(false);
+		var response = await requestInvoker.RequestAsync<VoidResponse>(endpoint, boundConfiguration, null, cancellationToken).ConfigureAwait(false);
 		return response;
 	}
 
 	/// <inheritdoc cref="ProductRegistration.Ping"/>
-	public override TransportResponse Ping(IRequestInvoker requestInvoker, Endpoint endpoint, RequestData pingData)
+	public override TransportResponse Ping(IRequestInvoker requestInvoker, Endpoint endpoint, BoundConfiguration boundConfiguration)
 	{
-		var response = requestInvoker.Request<VoidResponse>(endpoint, pingData, null);
+		var response = requestInvoker.Request<VoidResponse>(endpoint, boundConfiguration, null);
 		return response;
 	}
 

--- a/src/Elastic.Transport/Products/ProductRegistration.cs
+++ b/src/Elastic.Transport/Products/ProductRegistration.cs
@@ -56,40 +56,40 @@ public abstract class ProductRegistration
 	public abstract HeadersList ResponseHeadersToParse { get; }
 
 	/// <summary>
-	/// Create an instance of <see cref="RequestData"/> that describes where and how to ping see <paramref name="node" />
-	/// <para>All the parameters of this method correspond with <see cref="RequestData"/>'s constructor</para>
+	/// Create an instance of <see cref="BoundConfiguration"/> that describes where and how to ping see <paramref name="node" />
+	/// <para>All the parameters of this method correspond with <see cref="BoundConfiguration"/>'s constructor</para>
 	/// </summary>
 	public abstract Endpoint CreatePingEndpoint(Node node, IRequestConfiguration requestConfiguration);
 
 	/// <summary>
-	/// Provide an implementation that performs the ping directly using <see cref="IRequestInvoker.RequestAsync{TResponse}"/> and the <see cref="RequestData"/>
+	/// Provide an implementation that performs the ping directly using <see cref="IRequestInvoker.RequestAsync{TResponse}"/> and the <see cref="BoundConfiguration"/>
 	/// return by <see cref="CreatePingEndpoint"/>
 	/// </summary>
-	public abstract Task<TransportResponse> PingAsync(IRequestInvoker requestInvoker, Endpoint endpoint, RequestData requestData, CancellationToken cancellationToken);
+	public abstract Task<TransportResponse> PingAsync(IRequestInvoker requestInvoker, Endpoint endpoint, BoundConfiguration boundConfiguration, CancellationToken cancellationToken);
 
 	/// <summary>
-	/// Provide an implementation that performs the ping directly using <see cref="IRequestInvoker.Request{TResponse}"/> and the <see cref="RequestData"/>
+	/// Provide an implementation that performs the ping directly using <see cref="IRequestInvoker.Request{TResponse}"/> and the <see cref="BoundConfiguration"/>
 	/// return by <see cref="CreatePingEndpoint"/>
 	/// </summary>
-	public abstract TransportResponse Ping(IRequestInvoker requestInvoker, Endpoint endpoint, RequestData pingData);
+	public abstract TransportResponse Ping(IRequestInvoker requestInvoker, Endpoint endpoint, BoundConfiguration boundConfiguration);
 
 	/// <summary>
-	/// Create an instance of <see cref="RequestData"/> that describes where and how to sniff the cluster using <paramref name="node" />
-	/// <para>All the parameters of this method correspond with <see cref="RequestData"/>'s constructor</para>
+	/// Create an instance of <see cref="BoundConfiguration"/> that describes where and how to sniff the cluster using <paramref name="node" />
+	/// <para>All the parameters of this method correspond with <see cref="BoundConfiguration"/>'s constructor</para>
 	/// </summary>
 	public abstract Endpoint CreateSniffEndpoint(Node node, IRequestConfiguration requestConfiguration, ITransportConfiguration settings);
 
 	/// <summary>
-	/// Provide an implementation that performs the sniff directly using <see cref="IRequestInvoker.Request{TResponse}"/> and the <see cref="RequestData"/>
+	/// Provide an implementation that performs the sniff directly using <see cref="IRequestInvoker.Request{TResponse}"/> and the <see cref="BoundConfiguration"/>
 	/// return by <see cref="CreateSniffEndpoint"/>
 	/// </summary>
-	public abstract Task<Tuple<TransportResponse, IReadOnlyCollection<Node>>> SniffAsync(IRequestInvoker requestInvoker, bool forceSsl, Endpoint endpoint, RequestData requestData, CancellationToken cancellationToken);
+	public abstract Task<Tuple<TransportResponse, IReadOnlyCollection<Node>>> SniffAsync(IRequestInvoker requestInvoker, bool forceSsl, Endpoint endpoint, BoundConfiguration boundConfiguration, CancellationToken cancellationToken);
 
 	/// <summary>
-	/// Provide an implementation that performs the sniff directly using <see cref="IRequestInvoker.Request{TResponse}"/> and the <see cref="RequestData"/>
+	/// Provide an implementation that performs the sniff directly using <see cref="IRequestInvoker.Request{TResponse}"/> and the <see cref="BoundConfiguration"/>
 	/// return by <see cref="CreateSniffEndpoint"/>
 	/// </summary>
-	public abstract Tuple<TransportResponse, IReadOnlyCollection<Node>> Sniff(IRequestInvoker requestInvoker, bool forceSsl, Endpoint endpoint, RequestData requestData);
+	public abstract Tuple<TransportResponse, IReadOnlyCollection<Node>> Sniff(IRequestInvoker requestInvoker, bool forceSsl, Endpoint endpoint, BoundConfiguration boundConfiguration);
 
 	/// <summary> Allows certain nodes to be queried first to obtain sniffing information </summary>
 	public abstract int SniffOrder(Node node);

--- a/src/Elastic.Transport/Requests/MetaData/DefaultMetaHeaderProvider.cs
+++ b/src/Elastic.Transport/Requests/MetaData/DefaultMetaHeaderProvider.cs
@@ -60,11 +60,11 @@ public sealed class DefaultMetaHeaderProducer : MetaHeaderProducer
 	public override string HeaderName => MetaHeaderName;
 
 	/// <inheritdoc/>
-	public override string? ProduceHeaderValue(RequestData requestData, bool isAsync)
+	public override string? ProduceHeaderValue(BoundConfiguration boundConfiguration, bool isAsync)
 	{
 		try
 		{
-			if (requestData.ConnectionSettings.DisableMetaHeader)
+			if (boundConfiguration.ConnectionSettings.DisableMetaHeader)
 				return null;
 
 			var headerValue = isAsync
@@ -72,7 +72,7 @@ public sealed class DefaultMetaHeaderProducer : MetaHeaderProducer
 				: _syncMetaDataHeader.ToString();
 
 			// TODO - Cache values against key to avoid allocating a string each time
-			if (requestData.RequestMetaData.TryGetValue(RequestMetaData.HelperKey, out var helperSuffix))
+			if (boundConfiguration.RequestMetaData.Items.TryGetValue(RequestMetaData.HelperKey, out var helperSuffix))
 				headerValue = $"{headerValue},h={helperSuffix}";
 
 			return headerValue;

--- a/src/Elastic.Transport/Requests/MetaData/MetaHeaderProvider.cs
+++ b/src/Elastic.Transport/Requests/MetaData/MetaHeaderProvider.cs
@@ -26,7 +26,7 @@ public abstract class MetaHeaderProducer
 	public abstract string HeaderName { get; }
 
 	/// <summary>
-	/// Produces the header value based on current outgoing <paramref name="requestData"/>.
+	/// Produces the header value based on current outgoing <paramref name="boundConfiguration"/>.
 	/// </summary>
-	public abstract string? ProduceHeaderValue(RequestData requestData, bool isAsync);
+	public abstract string? ProduceHeaderValue(BoundConfiguration boundConfiguration, bool isAsync);
 }

--- a/src/Elastic.Transport/Requests/MetaData/RequestMetaData.cs
+++ b/src/Elastic.Transport/Requests/MetaData/RequestMetaData.cs
@@ -3,7 +3,6 @@
 // See the LICENSE file in the project root for more information
 
 using System.Collections.Generic;
-using Elastic.Transport.Extensions;
 
 namespace Elastic.Transport;
 
@@ -21,7 +20,7 @@ public sealed class RequestMetaData
 
 	internal bool TryAddMetaData(string key, string value)
 	{
-		_metaDataItems ??= new();
+		_metaDataItems ??= [];
 
 #if NETSTANDARD2_1 || NET6_0_OR_GREATER
 		return _metaDataItems.TryAdd(key, value);

--- a/src/Elastic.Transport/Responses/Dynamic/DynamicResponseBuilder.cs
+++ b/src/Elastic.Transport/Responses/Dynamic/DynamicResponseBuilder.cs
@@ -16,19 +16,19 @@ namespace Elastic.Transport;
 
 internal class DynamicResponseBuilder : TypedResponseBuilder<DynamicResponse>
 {
-	protected override DynamicResponse Build(ApiCallDetails apiCallDetails, RequestData requestData, Stream responseStream, string contentType, long contentLength) =>
-		BuildCoreAsync(false, apiCallDetails, requestData, responseStream, contentType, contentLength).EnsureCompleted();
+	protected override DynamicResponse Build(ApiCallDetails apiCallDetails, BoundConfiguration boundConfiguration, Stream responseStream, string contentType, long contentLength) =>
+		BuildCoreAsync(false, apiCallDetails, boundConfiguration, responseStream, contentType, contentLength).EnsureCompleted();
 
-	protected override Task<DynamicResponse> BuildAsync(ApiCallDetails apiCallDetails, RequestData requestData, Stream responseStream, string contentType, long contentLength, CancellationToken cancellationToken = default) =>
-		BuildCoreAsync(true, apiCallDetails, requestData, responseStream, contentType, contentLength, cancellationToken).AsTask();
+	protected override Task<DynamicResponse> BuildAsync(ApiCallDetails apiCallDetails, BoundConfiguration boundConfiguration, Stream responseStream, string contentType, long contentLength, CancellationToken cancellationToken = default) =>
+		BuildCoreAsync(true, apiCallDetails, boundConfiguration, responseStream, contentType, contentLength, cancellationToken).AsTask();
 
-	private static async ValueTask<DynamicResponse> BuildCoreAsync(bool isAsync, ApiCallDetails apiCallDetails, RequestData requestData, Stream responseStream,
+	private static async ValueTask<DynamicResponse> BuildCoreAsync(bool isAsync, ApiCallDetails apiCallDetails, BoundConfiguration boundConfiguration, Stream responseStream,
 		string contentType, long contentLength, CancellationToken cancellationToken = default)
 	{
 		DynamicResponse response;
 
 		//if not json store the result under "body"
-		if (contentType == null || !contentType.StartsWith(RequestData.DefaultContentType))
+		if (contentType == null || !contentType.StartsWith(BoundConfiguration.DefaultContentType))
 		{
 			DynamicDictionary dictionary;
 			string stringValue;

--- a/src/Elastic.Transport/Responses/IResponseBuilder.cs
+++ b/src/Elastic.Transport/Responses/IResponseBuilder.cs
@@ -25,12 +25,12 @@ public interface IResponseBuilder
 	/// </summary>
 	/// <typeparam name="TResponse">The specific type of the <see cref="TransportResponse"/> to be built.</typeparam>
 	/// <param name="apiCallDetails">The initialized <see cref="ApiCallDetails"/> for the response.</param>
-	/// <param name="requestData">The <see cref="RequestData"/> for the HTTP request.</param>
+	/// <param name="boundConfiguration">The <see cref="BoundConfiguration"/> for the HTTP request.</param>
 	/// <param name="responseStream">The readable <see cref="Stream"/> containing the response body.</param>
 	/// <param name="contentType">The value of the Content-Type header for the response.</param>
 	/// <param name="contentLength">The length of the content, if available in the response headers.</param>
 	/// <returns>A potentiall null response of type <typeparamref name="TResponse"/>.</returns>
-	TResponse? Build<TResponse>(ApiCallDetails apiCallDetails, RequestData requestData,
+	TResponse? Build<TResponse>(ApiCallDetails apiCallDetails, BoundConfiguration boundConfiguration,
 		Stream responseStream, string contentType, long contentLength) where TResponse : TransportResponse, new();
 
 	/// <summary>
@@ -38,12 +38,12 @@ public interface IResponseBuilder
 	/// </summary>
 	/// <typeparam name="TResponse">The specific type of the <see cref="TransportResponse"/> to be built.</typeparam>
 	/// <param name="apiCallDetails">The initialized <see cref="ApiCallDetails"/> for the response.</param>
-	/// <param name="requestData">The <see cref="RequestData"/> for the HTTP request.</param>
+	/// <param name="boundConfiguration">The <see cref="BoundConfiguration"/> for the HTTP request.</param>
 	/// <param name="responseStream">The readable <see cref="Stream"/> containing the response body.</param>
 	/// <param name="contentType">The value of the Content-Type header for the response.</param>
 	/// <param name="contentLength">The length of the content, if available in the response headers.</param>
 	/// <param name="cancellationToken">An optional <see cref="CancellationToken"/> that can trigger cancellation.</param>
 	/// <returns>A potentiall null response of type <typeparamref name="TResponse"/>.</returns>
-	Task<TResponse?> BuildAsync<TResponse>(ApiCallDetails apiCallDetails, RequestData requestData,
+	Task<TResponse?> BuildAsync<TResponse>(ApiCallDetails apiCallDetails, BoundConfiguration boundConfiguration,
 		Stream responseStream, string contentType, long contentLength, CancellationToken cancellationToken = default) where TResponse : TransportResponse, new();
 }

--- a/src/Elastic.Transport/Responses/Special/BytesResponseBuilder.cs
+++ b/src/Elastic.Transport/Responses/Special/BytesResponseBuilder.cs
@@ -10,13 +10,13 @@ namespace Elastic.Transport;
 
 internal class BytesResponseBuilder : TypedResponseBuilder<BytesResponse>
 {
-	protected override BytesResponse Build(ApiCallDetails apiCallDetails, RequestData requestData, Stream responseStream, string contentType, long contentLength) =>
-		BuildCoreAsync(false, apiCallDetails, requestData, responseStream).EnsureCompleted();
+	protected override BytesResponse Build(ApiCallDetails apiCallDetails, BoundConfiguration boundConfiguration, Stream responseStream, string contentType, long contentLength) =>
+		BuildCoreAsync(false, apiCallDetails, boundConfiguration, responseStream).EnsureCompleted();
 
-	protected override Task<BytesResponse> BuildAsync(ApiCallDetails apiCallDetails, RequestData requestData, Stream responseStream, string contentType, long contentLength, CancellationToken cancellationToken = default) =>
-		BuildCoreAsync(true, apiCallDetails, requestData, responseStream, cancellationToken).AsTask();
+	protected override Task<BytesResponse> BuildAsync(ApiCallDetails apiCallDetails, BoundConfiguration boundConfiguration, Stream responseStream, string contentType, long contentLength, CancellationToken cancellationToken = default) =>
+		BuildCoreAsync(true, apiCallDetails, boundConfiguration, responseStream, cancellationToken).AsTask();
 
-	private static async ValueTask<BytesResponse> BuildCoreAsync(bool isAsync, ApiCallDetails apiCallDetails, RequestData requestData, Stream responseStream, CancellationToken cancellationToken = default)
+	private static async ValueTask<BytesResponse> BuildCoreAsync(bool isAsync, ApiCallDetails apiCallDetails, BoundConfiguration boundConfiguration, Stream responseStream, CancellationToken cancellationToken = default)
 	{
 		BytesResponse response;
 
@@ -26,7 +26,7 @@ internal class BytesResponseBuilder : TypedResponseBuilder<BytesResponse>
 			return response;
 		}
 
-		var tempStream = requestData.MemoryStreamFactory.Create();
+		var tempStream = boundConfiguration.MemoryStreamFactory.Create();
 		await responseStream.CopyToAsync(tempStream, BufferedResponseHelpers.BufferSize, cancellationToken).ConfigureAwait(false);
 		apiCallDetails.ResponseBodyInBytes = BufferedResponseHelpers.SwapStreams(ref responseStream, ref tempStream);
 		response = new BytesResponse(apiCallDetails.ResponseBodyInBytes);

--- a/src/Elastic.Transport/Responses/Special/StreamResponseBuilder.cs
+++ b/src/Elastic.Transport/Responses/Special/StreamResponseBuilder.cs
@@ -10,10 +10,10 @@ namespace Elastic.Transport;
 
 internal class StreamResponseBuilder : TypedResponseBuilder<StreamResponse>
 {
-	protected override StreamResponse Build(ApiCallDetails apiCallDetails, RequestData requestData, Stream responseStream, string contentType, long contentLength) =>
+	protected override StreamResponse Build(ApiCallDetails apiCallDetails, BoundConfiguration boundConfiguration, Stream responseStream, string contentType, long contentLength) =>
 		new(responseStream, contentType);
 
-	protected override Task<StreamResponse> BuildAsync(ApiCallDetails apiCallDetails, RequestData requestData, Stream responseStream, string contentType,
+	protected override Task<StreamResponse> BuildAsync(ApiCallDetails apiCallDetails, BoundConfiguration boundConfiguration, Stream responseStream, string contentType,
 		long contentLength, CancellationToken cancellationToken = default) =>
 			Task.FromResult(new StreamResponse(responseStream, contentType));
 }

--- a/src/Elastic.Transport/Responses/Special/StringResponseBuilder.cs
+++ b/src/Elastic.Transport/Responses/Special/StringResponseBuilder.cs
@@ -16,7 +16,7 @@ namespace Elastic.Transport;
 
 internal class StringResponseBuilder : TypedResponseBuilder<StringResponse>
 {
-	protected override StringResponse Build(ApiCallDetails apiCallDetails, RequestData requestData, Stream responseStream, string contentType, long contentLength)
+	protected override StringResponse Build(ApiCallDetails apiCallDetails, BoundConfiguration boundConfiguration, Stream responseStream, string contentType, long contentLength)
 	{
 		string responseString;
 
@@ -42,7 +42,7 @@ internal class StringResponseBuilder : TypedResponseBuilder<StringResponse>
 		return new StringResponse(responseString);
 	}
 
-	protected override async Task<StringResponse> BuildAsync(ApiCallDetails apiCallDetails, RequestData requestData, Stream responseStream, string contentType, long contentLength,
+	protected override async Task<StringResponse> BuildAsync(ApiCallDetails apiCallDetails, BoundConfiguration boundConfiguration, Stream responseStream, string contentType, long contentLength,
 		CancellationToken cancellationToken = default)
 	{
 		string responseString;

--- a/src/Elastic.Transport/Responses/Special/VoidResponseBuilder.cs
+++ b/src/Elastic.Transport/Responses/Special/VoidResponseBuilder.cs
@@ -10,10 +10,10 @@ namespace Elastic.Transport;
 
 internal class VoidResponseBuilder : TypedResponseBuilder<VoidResponse>
 {
-	protected override VoidResponse Build(ApiCallDetails apiCallDetails, RequestData requestData, Stream responseStream, string contentType, long contentLength) =>
+	protected override VoidResponse Build(ApiCallDetails apiCallDetails, BoundConfiguration boundConfiguration, Stream responseStream, string contentType, long contentLength) =>
 		VoidResponse.Default;
 
-	protected override Task<VoidResponse> BuildAsync(ApiCallDetails apiCallDetails, RequestData requestData, Stream responseStream, string contentType, long contentLength,
+	protected override Task<VoidResponse> BuildAsync(ApiCallDetails apiCallDetails, BoundConfiguration boundConfiguration, Stream responseStream, string contentType, long contentLength,
 		CancellationToken cancellationToken = default) =>
 			Task.FromResult(VoidResponse.Default);
 }

--- a/src/Elastic.Transport/Responses/TypedResponseBuilder.cs
+++ b/src/Elastic.Transport/Responses/TypedResponseBuilder.cs
@@ -16,17 +16,17 @@ public abstract class TypedResponseBuilder<TResponse> : IResponseBuilder
 {
 	bool IResponseBuilder.CanBuild<T>() => typeof(TResponse) == typeof(T);
 
-	/// <inheritdoc cref="IResponseBuilder.Build{TResponse}(ApiCallDetails, RequestData, Stream, string, long)"/>
-	protected abstract TResponse? Build(ApiCallDetails apiCallDetails, RequestData requestData, Stream responseStream, string contentType, long contentLength);
+	/// <inheritdoc cref="IResponseBuilder.Build{TResponse}(ApiCallDetails, BoundConfiguration, Stream, string, long)"/>
+	protected abstract TResponse? Build(ApiCallDetails apiCallDetails, BoundConfiguration boundConfiguration, Stream responseStream, string contentType, long contentLength);
 
-	T IResponseBuilder.Build<T>(ApiCallDetails apiCallDetails, RequestData requestData, Stream responseStream, string contentType, long contentLength) =>
-		Build(apiCallDetails, requestData, responseStream, contentType, contentLength) as T;
+	T IResponseBuilder.Build<T>(ApiCallDetails apiCallDetails, BoundConfiguration boundConfiguration, Stream responseStream, string contentType, long contentLength) =>
+		Build(apiCallDetails, boundConfiguration, responseStream, contentType, contentLength) as T;
 
-	/// <inheritdoc cref="IResponseBuilder.BuildAsync{TResponse}(ApiCallDetails, RequestData, Stream, string, long, CancellationToken)"/>
-	protected abstract Task<TResponse?> BuildAsync(ApiCallDetails apiCallDetails, RequestData requestData, Stream responseStream,
+	/// <inheritdoc cref="IResponseBuilder.BuildAsync{TResponse}(ApiCallDetails, BoundConfiguration, Stream, string, long, CancellationToken)"/>
+	protected abstract Task<TResponse?> BuildAsync(ApiCallDetails apiCallDetails, BoundConfiguration boundConfiguration, Stream responseStream,
 		string contentType, long contentLength, CancellationToken cancellationToken = default);
 
-	Task<T> IResponseBuilder.BuildAsync<T>(ApiCallDetails apiCallDetails, RequestData requestData, Stream responseStream, string contentType,
+	Task<T> IResponseBuilder.BuildAsync<T>(ApiCallDetails apiCallDetails, BoundConfiguration boundConfiguration, Stream responseStream, string contentType,
 		long contentLength, CancellationToken cancellationToken) =>
-			BuildAsync(apiCallDetails, requestData, responseStream, contentType, contentLength, cancellationToken) as Task<T>;
+			BuildAsync(apiCallDetails, boundConfiguration, responseStream, contentType, contentLength, cancellationToken) as Task<T>;
 }

--- a/tests/Elastic.Transport.IntegrationTests/Plumbing/Stubs/TrackingRequestInvoker.cs
+++ b/tests/Elastic.Transport.IntegrationTests/Plumbing/Stubs/TrackingRequestInvoker.cs
@@ -29,18 +29,18 @@ public class TrackingRequestInvoker : IRequestInvoker
 			return _handler;
 		});
 
-	public TResponse Request<TResponse>(Endpoint endpoint, RequestData requestData, PostData postData)
+	public TResponse Request<TResponse>(Endpoint endpoint, BoundConfiguration boundConfiguration, PostData postData)
 		where TResponse : TransportResponse, new()
 	{
 		CallCount++;
-		return _requestInvoker.Request<TResponse>(endpoint, requestData, postData);
+		return _requestInvoker.Request<TResponse>(endpoint, boundConfiguration, postData);
 	}
 
-	public Task<TResponse> RequestAsync<TResponse>(Endpoint endpoint, RequestData requestData, PostData postData, CancellationToken cancellationToken)
+	public Task<TResponse> RequestAsync<TResponse>(Endpoint endpoint, BoundConfiguration boundConfiguration, PostData postData, CancellationToken cancellationToken)
 		where TResponse : TransportResponse, new()
 	{
 		CallCount++;
-		return _requestInvoker.RequestAsync<TResponse>(endpoint, requestData, postData, cancellationToken);
+		return _requestInvoker.RequestAsync<TResponse>(endpoint, boundConfiguration, postData, cancellationToken);
 	}
 
 	public void Dispose()

--- a/tests/Elastic.Transport.IntegrationTests/Responses/SpecialisedResponseTests.cs
+++ b/tests/Elastic.Transport.IntegrationTests/Responses/SpecialisedResponseTests.cs
@@ -937,14 +937,14 @@ public class SpecialisedResponseTests(TransportTestServer instance) : AssemblySe
 
 	private class TestResponseBuilder : TypedResponseBuilder<TestResponse>
 	{
-		protected override TestResponse Build(ApiCallDetails apiCallDetails, RequestData requestData, Stream responseStream, string contentType, long contentLength)
+		protected override TestResponse Build(ApiCallDetails apiCallDetails, BoundConfiguration boundConfiguration, Stream responseStream, string contentType, long contentLength)
 		{
 			var sr = new StreamReader(responseStream);
 			var value = sr.ReadToEnd();
 			return new TestResponse { Value = value };
 		}
 
-		protected override async Task<TestResponse> BuildAsync(ApiCallDetails apiCallDetails, RequestData requestData, Stream responseStream,
+		protected override async Task<TestResponse> BuildAsync(ApiCallDetails apiCallDetails, BoundConfiguration boundConfiguration, Stream responseStream,
 			string contentType, long contentLength, CancellationToken cancellationToken = default)
 		{
 			var sr = new StreamReader(responseStream);

--- a/tests/Elastic.Transport.Tests/ResponseFactoryDisposeTests.cs
+++ b/tests/Elastic.Transport.Tests/ResponseFactoryDisposeTests.cs
@@ -108,7 +108,7 @@ public class ResponseFactoryDisposeTests
 
 		var endpoint = new Endpoint(new EndpointPath(httpMethod, "/"), new Node(new Uri("http://localhost:9200")));
 
-		var requestData = new RequestData(config, null);
+		var boundConfiguration = new BoundConfiguration(config, null);
 
 		var stream = new TrackDisposeStream(responseStreamCanSeek);
 
@@ -118,7 +118,7 @@ public class ResponseFactoryDisposeTests
 			stream.Position = 0;
 		}
 
-		var response = config.RequestInvoker.ResponseFactory.Create<T>(endpoint, requestData, null, null, statusCode, null, stream, contentType, isChunked ? -1 : responseJson.Length, null, null);
+		var response = config.RequestInvoker.ResponseFactory.Create<T>(endpoint, boundConfiguration, null, null, statusCode, null, stream, contentType, isChunked ? -1 : responseJson.Length, null, null);
 
 		Validate(disableDirectStreaming, expectMemoryStreamDisposal, memoryStreamCreateExpected, memoryStreamFactory, stream, response);
 
@@ -130,7 +130,7 @@ public class ResponseFactoryDisposeTests
 			stream.Position = 0;
 		}
 
-		response = await config.RequestInvoker.ResponseFactory.CreateAsync<T>(endpoint, requestData, null, null, statusCode, null, stream, contentType, isChunked ? -1 : responseJson.Length, null, null);
+		response = await config.RequestInvoker.ResponseFactory.CreateAsync<T>(endpoint, boundConfiguration, null, null, statusCode, null, stream, contentType, isChunked ? -1 : responseJson.Length, null, null);
 
 		Validate(disableDirectStreaming, expectMemoryStreamDisposal, memoryStreamCreateExpected, memoryStreamFactory, stream, response);
 

--- a/tests/Elastic.Transport.Tests/Responses/Dynamic/DynamicResponseBuilderTests.cs
+++ b/tests/Elastic.Transport.Tests/Responses/Dynamic/DynamicResponseBuilderTests.cs
@@ -19,17 +19,17 @@ public class DynamicResponseBuilderTests
 
 		var config = new TransportConfiguration();
 		var apiCallDetails = new ApiCallDetails();
-		var requestData = new RequestData(config);
+		var boundConfiguration = new BoundConfiguration(config);
 
 		var data = Encoding.UTF8.GetBytes("{\"_index\":\"my-index\",\"_id\":\"pZqC6JIB9RdSpcF8-3lq\",\"_version\":1,\"result\":\"created\",\"_shards\":{\"total\":1,\"successful\":1,\"failed\":0},\"_seq_no\":2,\"_primary_term\":1}");
 		var stream = new MemoryStream(data);
 
-		var result = await sut.BuildAsync<DynamicResponse>(apiCallDetails, requestData, stream, RequestData.DefaultContentType, data.Length);
+		var result = await sut.BuildAsync<DynamicResponse>(apiCallDetails, boundConfiguration, stream, BoundConfiguration.DefaultContentType, data.Length);
 		result.Body.Get<string>("_index").Should().Be("my-index");
 
 		stream.Position = 0;
 
-		result = sut.Build<DynamicResponse>(apiCallDetails, requestData, stream, RequestData.DefaultContentType, data.Length);
+		result = sut.Build<DynamicResponse>(apiCallDetails, boundConfiguration, stream, BoundConfiguration.DefaultContentType, data.Length);
 		result.Body.Get<string>("_index").Should().Be("my-index");
 	}
 
@@ -40,17 +40,17 @@ public class DynamicResponseBuilderTests
 
 		var config = new TransportConfiguration();
 		var apiCallDetails = new ApiCallDetails();
-		var requestData = new RequestData(config);
+		var boundConfiguration = new BoundConfiguration(config);
 
 		var data = Encoding.UTF8.GetBytes("This is not JSON");
 		var stream = new MemoryStream(data);
 
-		var result = await sut.BuildAsync<DynamicResponse>(apiCallDetails, requestData, stream, "text/plain", data.Length);
+		var result = await sut.BuildAsync<DynamicResponse>(apiCallDetails, boundConfiguration, stream, "text/plain", data.Length);
 		result.Body.Get<string>("body").Should().Be("This is not JSON");
 
 		stream.Position = 0;
 
-		result = sut.Build<DynamicResponse>(apiCallDetails, requestData, stream, "text/plain", data.Length);
+		result = sut.Build<DynamicResponse>(apiCallDetails, boundConfiguration, stream, "text/plain", data.Length);
 		result.Body.Get<string>("body").Should().Be("This is not JSON");
 	}
 }

--- a/tests/Elastic.Transport.Tests/Responses/Special/BytesResponseBuilderTests.cs
+++ b/tests/Elastic.Transport.Tests/Responses/Special/BytesResponseBuilderTests.cs
@@ -26,14 +26,14 @@ public class BytesResponseBuilderTests
 		var memoryStreamFactory = new TrackingMemoryStreamFactory();
 		var config = new TransportConfiguration() { MemoryStreamFactory = memoryStreamFactory };
 		var apiCallDetails = new ApiCallDetails();
-		var requestData = new RequestData(config);
+		var boundConfiguration = new BoundConfiguration(config);
 		var stream = new MemoryStream(Data);
 
-		var result = await sut.BuildAsync<BytesResponse>(apiCallDetails, requestData, stream, RequestData.DefaultContentType, Data.Length);
+		var result = await sut.BuildAsync<BytesResponse>(apiCallDetails, boundConfiguration, stream, BoundConfiguration.DefaultContentType, Data.Length);
 
 		Validate(memoryStreamFactory, result);
 
-		result = sut.Build<BytesResponse>(apiCallDetails, requestData, stream, RequestData.DefaultContentType, Data.Length);
+		result = sut.Build<BytesResponse>(apiCallDetails, boundConfiguration, stream, BoundConfiguration.DefaultContentType, Data.Length);
 
 		Validate(memoryStreamFactory, result);
 
@@ -54,17 +54,17 @@ public class BytesResponseBuilderTests
 		var memoryStreamFactory = new TrackingMemoryStreamFactory();
 		var config = new TransportConfiguration() { DisableDirectStreaming = true, MemoryStreamFactory = memoryStreamFactory };
 		var apiCallDetails = new ApiCallDetails() { ResponseBodyInBytes = Data };
-		var requestData = new RequestData(config);
+		var boundConfiguration = new BoundConfiguration(config);
 		var stream = new MemoryStream(Data);
 
-		var result = await sut.BuildAsync<BytesResponse>(apiCallDetails, requestData, stream, RequestData.DefaultContentType, Data.Length);
+		var result = await sut.BuildAsync<BytesResponse>(apiCallDetails, boundConfiguration, stream, BoundConfiguration.DefaultContentType, Data.Length);
 
 		Validate(memoryStreamFactory, result);
 
 		memoryStreamFactory.Reset();
 		stream.Position = 0;
 
-		result = sut.Build<BytesResponse>(apiCallDetails, requestData, stream, RequestData.DefaultContentType, Data.Length);
+		result = sut.Build<BytesResponse>(apiCallDetails, boundConfiguration, stream, BoundConfiguration.DefaultContentType, Data.Length);
 
 		Validate(memoryStreamFactory, result);
 

--- a/tests/Elastic.Transport.Tests/Responses/Special/StreamResponseBuilderTests.cs
+++ b/tests/Elastic.Transport.Tests/Responses/Special/StreamResponseBuilderTests.cs
@@ -26,16 +26,16 @@ public class StreamResponseBuilderTests
 		var memoryStreamFactory = new TrackingMemoryStreamFactory();
 		var config = new TransportConfiguration() { MemoryStreamFactory = memoryStreamFactory };
 		var apiCallDetails = new ApiCallDetails();
-		var requestData = new RequestData(config);
+		var boundConfiguration = new BoundConfiguration(config);
 		var stream = new MemoryStream(Data);
 
-		var result = await sut.BuildAsync<StreamResponse>(apiCallDetails, requestData, stream, RequestData.DefaultContentType, Data.Length);
+		var result = await sut.BuildAsync<StreamResponse>(apiCallDetails, boundConfiguration, stream, BoundConfiguration.DefaultContentType, Data.Length);
 		await ValidateAsync(memoryStreamFactory, result);
 
 		memoryStreamFactory.Reset();
 		stream.Position = 0;
 
-		result = sut.Build<StreamResponse>(apiCallDetails, requestData, stream, RequestData.DefaultContentType, Data.Length);
+		result = sut.Build<StreamResponse>(apiCallDetails, boundConfiguration, stream, BoundConfiguration.DefaultContentType, Data.Length);
 		await ValidateAsync(memoryStreamFactory, result);
 	}
 
@@ -47,16 +47,16 @@ public class StreamResponseBuilderTests
 		var memoryStreamFactory = new TrackingMemoryStreamFactory();
 		var config = new TransportConfiguration() { MemoryStreamFactory = memoryStreamFactory, DisableDirectStreaming = true };
 		var apiCallDetails = new ApiCallDetails() { ResponseBodyInBytes = Data };
-		var requestData = new RequestData(config);
+		var boundConfiguration = new BoundConfiguration(config);
 		var stream = new MemoryStream(Data);
 
-		var result = await sut.BuildAsync<StreamResponse>(apiCallDetails, requestData, stream, RequestData.DefaultContentType, Data.Length);
+		var result = await sut.BuildAsync<StreamResponse>(apiCallDetails, boundConfiguration, stream, BoundConfiguration.DefaultContentType, Data.Length);
 		await ValidateAsync(memoryStreamFactory, result);
 
 		memoryStreamFactory.Reset();
 		stream.Position = 0;
 
-		result = sut.Build<StreamResponse>(apiCallDetails, requestData, stream, RequestData.DefaultContentType, Data.Length);
+		result = sut.Build<StreamResponse>(apiCallDetails, boundConfiguration, stream, BoundConfiguration.DefaultContentType, Data.Length);
 		await ValidateAsync(memoryStreamFactory, result);
 	}
 

--- a/tests/Elastic.Transport.Tests/Responses/Special/StringResponseBuilderTests.cs
+++ b/tests/Elastic.Transport.Tests/Responses/Special/StringResponseBuilderTests.cs
@@ -26,10 +26,10 @@ public class StringResponseBuilderTests
 		var memoryStreamFactory = new TrackingMemoryStreamFactory();
 		var config = new TransportConfiguration() { MemoryStreamFactory = memoryStreamFactory };
 		var apiCallDetails = new ApiCallDetails();
-		var requestData = new RequestData(config);
+		var boundConfiguration = new BoundConfiguration(config);
 		var stream = new MemoryStream(Data);
 
-		var result = await sut.BuildAsync<StringResponse>(apiCallDetails, requestData, stream, RequestData.DefaultContentType, Data.Length);
+		var result = await sut.BuildAsync<StringResponse>(apiCallDetails, boundConfiguration, stream, BoundConfiguration.DefaultContentType, Data.Length);
 		result.Body.Should().Be(Json);
 
 		memoryStreamFactory.Created.Count.Should().Be(0);
@@ -37,7 +37,7 @@ public class StringResponseBuilderTests
 		stream.Position = 0;
 		memoryStreamFactory.Reset();
 
-		result = sut.Build<StringResponse>(apiCallDetails, requestData, stream, RequestData.DefaultContentType, Data.Length);
+		result = sut.Build<StringResponse>(apiCallDetails, boundConfiguration, stream, BoundConfiguration.DefaultContentType, Data.Length);
 		result.Body.Should().Be(Json);
 
 		memoryStreamFactory.Created.Count.Should().Be(0);
@@ -70,10 +70,10 @@ public class StringResponseBuilderTests
 		var memoryStreamFactory = new TrackingMemoryStreamFactory();
 		var config = new TransportConfiguration() { MemoryStreamFactory = memoryStreamFactory };
 		var apiCallDetails = new ApiCallDetails();
-		var requestData = new RequestData(config);
+		var boundConfiguration = new BoundConfiguration(config);
 		var stream = new MemoryStream(data);
 
-		var result = await sut.BuildAsync<StringResponse>(apiCallDetails, requestData, stream, RequestData.DefaultContentType, data.Length);
+		var result = await sut.BuildAsync<StringResponse>(apiCallDetails, boundConfiguration, stream, BoundConfiguration.DefaultContentType, data.Length);
 		result.Body.Should().Be(largeJson);
 
 		memoryStreamFactory.Created.Count.Should().Be(0);
@@ -81,7 +81,7 @@ public class StringResponseBuilderTests
 		stream.Position = 0;
 		memoryStreamFactory.Reset();
 
-		result = sut.Build<StringResponse>(apiCallDetails, requestData, stream, RequestData.DefaultContentType, data.Length);
+		result = sut.Build<StringResponse>(apiCallDetails, boundConfiguration, stream, BoundConfiguration.DefaultContentType, data.Length);
 		result.Body.Should().Be(largeJson);
 
 		memoryStreamFactory.Created.Count.Should().Be(0);
@@ -114,10 +114,10 @@ public class StringResponseBuilderTests
 		var memoryStreamFactory = new TrackingMemoryStreamFactory();
 		var config = new TransportConfiguration() { MemoryStreamFactory = memoryStreamFactory };
 		var apiCallDetails = new ApiCallDetails();
-		var requestData = new RequestData(config);
+		var boundConfiguration = new BoundConfiguration(config);
 		var stream = new MemoryStream(data);
 
-		var result = await sut.BuildAsync<StringResponse>(apiCallDetails, requestData, stream, RequestData.DefaultContentType, -1);
+		var result = await sut.BuildAsync<StringResponse>(apiCallDetails, boundConfiguration, stream, BoundConfiguration.DefaultContentType, -1);
 		result.Body.Should().Be(largeJson);
 
 		memoryStreamFactory.Created.Count.Should().Be(0);
@@ -125,7 +125,7 @@ public class StringResponseBuilderTests
 		stream.Position = 0;
 		memoryStreamFactory.Reset();
 
-		result = sut.Build<StringResponse>(apiCallDetails, requestData, stream, RequestData.DefaultContentType, -1);
+		result = sut.Build<StringResponse>(apiCallDetails, boundConfiguration, stream, BoundConfiguration.DefaultContentType, -1);
 		result.Body.Should().Be(largeJson);
 
 		memoryStreamFactory.Created.Count.Should().Be(0);
@@ -139,10 +139,10 @@ public class StringResponseBuilderTests
 		var memoryStreamFactory = new TrackingMemoryStreamFactory();
 		var config = new TransportConfiguration() { MemoryStreamFactory = memoryStreamFactory, DisableDirectStreaming = true };
 		var apiCallDetails = new ApiCallDetails() { ResponseBodyInBytes = Data };
-		var requestData = new RequestData(config);
+		var boundConfiguration = new BoundConfiguration(config);
 		var stream = new MemoryStream(Data);
 
-		var result = await sut.BuildAsync<StringResponse>(apiCallDetails, requestData, stream, RequestData.DefaultContentType, -1);
+		var result = await sut.BuildAsync<StringResponse>(apiCallDetails, boundConfiguration, stream, BoundConfiguration.DefaultContentType, -1);
 		result.Body.Should().Be(Json);
 
 		memoryStreamFactory.Created.Count.Should().Be(0);
@@ -150,7 +150,7 @@ public class StringResponseBuilderTests
 		stream.Position = 0;
 		memoryStreamFactory.Reset();
 
-		result = sut.Build<StringResponse>(apiCallDetails, requestData, stream, RequestData.DefaultContentType, -1);
+		result = sut.Build<StringResponse>(apiCallDetails, boundConfiguration, stream, BoundConfiguration.DefaultContentType, -1);
 		result.Body.Should().Be(Json);
 
 		memoryStreamFactory.Created.Count.Should().Be(0);

--- a/tests/Elastic.Transport.Tests/Responses/Special/VoidResponseBuilderTests.cs
+++ b/tests/Elastic.Transport.Tests/Responses/Special/VoidResponseBuilderTests.cs
@@ -23,13 +23,13 @@ public class VoidResponseBuilderTests
 
 		var config = new TransportConfiguration();
 		var apiCallDetails = new ApiCallDetails();
-		var requestData = new RequestData(config);
+		var boundConfiguration = new BoundConfiguration(config);
 		var stream = new MemoryStream(Data);
 
-		var result = await sut.BuildAsync<VoidResponse>(apiCallDetails, requestData, stream, RequestData.DefaultContentType, Data.Length);
+		var result = await sut.BuildAsync<VoidResponse>(apiCallDetails, boundConfiguration, stream, BoundConfiguration.DefaultContentType, Data.Length);
 		result.Body.Should().BeOfType(typeof(VoidBody));
 
-		result = sut.Build<VoidResponse>(apiCallDetails, requestData, stream, RequestData.DefaultContentType, Data.Length);
+		result = sut.Build<VoidResponse>(apiCallDetails, boundConfiguration, stream, BoundConfiguration.DefaultContentType, Data.Length);
 		result.Body.Should().BeOfType(typeof(VoidBody));
 	}
 
@@ -40,13 +40,13 @@ public class VoidResponseBuilderTests
 
 		var config = new TransportConfiguration() { DisableDirectStreaming = true };
 		var apiCallDetails = new ApiCallDetails() { ResponseBodyInBytes = Data };
-		var requestData = new RequestData(config);
+		var boundConfiguration = new BoundConfiguration(config);
 		var stream = new MemoryStream(Data);
 
-		var result = await sut.BuildAsync<VoidResponse>(apiCallDetails, requestData, stream, RequestData.DefaultContentType, Data.Length);
+		var result = await sut.BuildAsync<VoidResponse>(apiCallDetails, boundConfiguration, stream, BoundConfiguration.DefaultContentType, Data.Length);
 		result.Body.Should().BeOfType(typeof(VoidBody));
 
-		result = sut.Build<VoidResponse>(apiCallDetails, requestData, stream, RequestData.DefaultContentType, Data.Length);
+		result = sut.Build<VoidResponse>(apiCallDetails, boundConfiguration, stream, BoundConfiguration.DefaultContentType, Data.Length);
 		result.Body.Should().BeOfType(typeof(VoidBody));
 	}
 }


### PR DESCRIPTION
This PR involves a comprehensive refactor to replace the `RequestData` class with a new class named `BoundConfiguration` across the codebase. The `BoundConfiguration` class encapsulates configuration details and implements the `IRequestConfiguration` interface, which avoids introducing new overloads of the `Request` \ `RequestAsync` methods. We type check in the transport, and when the provided `IRequestConfiguration` is a `BoundConfiguration`, we use that without rebinding.

Closes #138 