### PR TITLE
Cleanup unused dependencies

### DIFF
--- a/src/Elastic.Transport/Elastic.Transport.csproj
+++ b/src/Elastic.Transport/Elastic.Transport.csproj
@@ -30,15 +30,9 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'net8.0'">
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
-    <PackageReference Include="System.Buffers" Version="4.5.1" />
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' != 'net8.0'">
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.0" />
-    <PackageReference Include="System.Collections.Immutable" Version="8.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Solution compiles fine without these direct references:
```xml
<PackageReference Include="System.Buffers" Version="4.5.1" />
<PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
<PackageReference Include="System.Collections.Immutable" Version="8.0.0" />
```
Most already comes from [System.Text.Json](https://www.nuget.org/packages/System.Text.Json/8.0.5):
- [Microsoft.Bcl.AsyncInterfaces](https://www.nuget.org/packages/Microsoft.Bcl.AsyncInterfaces/) (>= 8.0.0)
- [System.Buffers](https://www.nuget.org/packages/System.Buffers/) (>= 4.5.1)
- [System.Memory](https://www.nuget.org/packages/System.Memory/) (>= 4.5.5)
- [System.Runtime.CompilerServices.Unsafe](https://www.nuget.org/packages/System.Runtime.CompilerServices.Unsafe/) (>= 6.0.0)
- [System.Text.Encodings.Web](https://www.nuget.org/packages/System.Text.Encodings.Web/) (>= 8.0.0)
- [System.Threading.Tasks.Extensions](https://www.nuget.org/packages/System.Threading.Tasks.Extensions/) (>= 4.5.4)

So the actual cleanup is only `System.Collections.Immutable`.