### PR TITLE
Add `SystemTextJsonSerializer.SupportsFastPath` method

### DIFF
--- a/src/Elastic.Transport/Components/Serialization/SystemTextJsonSerializer.cs
+++ b/src/Elastic.Transport/Components/Serialization/SystemTextJsonSerializer.cs
@@ -101,8 +101,10 @@ public abstract class SystemTextJsonSerializer : Serializer
 	/// </para>
 	/// <para>
 	///	In some cases, when the concrete <see cref="SystemTextJsonSerializer"/> based serializer implementation overrides one or more of
-	/// the named methods, the default fast-path behavior might be undesired. The <see cref="SupportsFastPath"/> method can be used to
-	/// completely disable fast-path (de-)serialization or selectively use it for specific types only.
+	/// the previously named methods, the default fast-path behavior is probably undesired as it would prevent the user defined code in
+	/// the overwritten methods from being executed.
+	/// The <see cref="SupportsFastPath"/> method can be used to either completely disable fast-path (de-)serialization or to selectively
+	/// allow it for specific types only.
 	/// </para>
 	/// </remarks>
 	protected internal virtual bool SupportsFastPath(Type type) => true;

--- a/src/Elastic.Transport/Components/Serialization/SystemTextJsonSerializer.cs
+++ b/src/Elastic.Transport/Components/Serialization/SystemTextJsonSerializer.cs
@@ -85,6 +85,29 @@ public abstract class SystemTextJsonSerializer : Serializer
 	#endregion Serializer
 
 	/// <summary>
+	/// Override to (dis-)allow fast-path (de-)serialization for specific types.
+	/// </summary>
+	/// <param name="type">The <see cref="Type"/> that is being (de-)serialized.</param>
+	/// <returns>
+	/// <see langword="true"/> if the given <paramref name="type"/> supports fast-path (de-)serialization or
+	/// <see langword="false"/>, if not.
+	/// </returns>
+	/// <remarks>
+	/// <para>
+	///	Most extension methods in <see cref="Extensions.TransportSerializerExtensions"/> will prefer fast-path (de-)serialization, when
+	/// used with <see cref="SystemTextJsonSerializer"/> based serializer implementations.
+	/// Fast-path (de-)serialization bypasses the <see cref="Deserialize"/>, <see cref="Deserialize{T}"/>, <see cref="Serialize{T}"/>
+	/// methods and directly uses the <see cref="JsonSerializer"/> API instead.
+	/// </para>
+	/// <para>
+	///	In some cases, when the concrete <see cref="SystemTextJsonSerializer"/> based serializer implementation overrides one or more of
+	/// the named methods, the default fast-path behavior might be undesired. The <see cref="SupportsFastPath"/> method can be used to
+	/// completely disable fast-path (de-)serialization or selectively use it for specific types only.
+	/// </para>
+	/// </remarks>
+	protected internal virtual bool SupportsFastPath(Type type) => true;
+
+	/// <summary>
 	/// Returns the <see cref="JsonSerializerOptions"/> for this serializer, based on the given <paramref name="formatting"/>.
 	/// </summary>
 	/// <param name="formatting">The serialization formatting.</param>

--- a/src/Elastic.Transport/Components/Serialization/TransportSerializerExtensions.cs
+++ b/src/Elastic.Transport/Components/Serialization/TransportSerializerExtensions.cs
@@ -47,7 +47,7 @@ public static class TransportSerializerExtensions
 		SerializationFormatting formatting = SerializationFormatting.None
 	)
 	{
-		if (serializer is SystemTextJsonSerializer stjSerializer)
+		if (serializer is SystemTextJsonSerializer stjSerializer && stjSerializer.SupportsFastPath(typeof(T)))
 		{
 			// When the serializer derives from `SystemTextJsonSerializer` we can avoid unnecessary allocations.
 			return JsonSerializer.SerializeToUtf8Bytes(data, stjSerializer.GetJsonSerializerOptions(formatting));
@@ -92,7 +92,7 @@ public static class TransportSerializerExtensions
 		SerializationFormatting formatting = SerializationFormatting.None
 	)
 	{
-		if (serializer is SystemTextJsonSerializer stjSerializer)
+		if (serializer is SystemTextJsonSerializer stjSerializer && stjSerializer.SupportsFastPath(type))
 		{
 			// When the serializer derives from `SystemTextJsonSerializer` we can avoid unnecessary allocations.
 			return JsonSerializer.SerializeToUtf8Bytes(data, type, stjSerializer.GetJsonSerializerOptions(formatting));
@@ -135,7 +135,7 @@ public static class TransportSerializerExtensions
 		SerializationFormatting formatting = SerializationFormatting.None
 	)
 	{
-		if (serializer is SystemTextJsonSerializer stjSerializer)
+		if (serializer is SystemTextJsonSerializer stjSerializer && stjSerializer.SupportsFastPath(typeof(T)))
 		{
 			// When the serializer derives from `SystemTextJsonSerializer` we can avoid unnecessary allocations and
 			// serialize straight into string.
@@ -183,7 +183,7 @@ public static class TransportSerializerExtensions
 		SerializationFormatting formatting = SerializationFormatting.None
 	)
 	{
-		if (serializer is SystemTextJsonSerializer stjSerializer)
+		if (serializer is SystemTextJsonSerializer stjSerializer && stjSerializer.SupportsFastPath(type))
 		{
 			// When the serializer derives from `SystemTextJsonSerializer` we can avoid unnecessary allocations and
 			// serialize straight into string.
@@ -234,7 +234,7 @@ public static class TransportSerializerExtensions
 		MemoryStreamFactory? memoryStreamFactory,
 		SerializationFormatting formatting = SerializationFormatting.None)
 	{
-		if (serializer is SystemTextJsonSerializer stjSerializer)
+		if (serializer is SystemTextJsonSerializer stjSerializer && stjSerializer.SupportsFastPath(typeof(T)))
 		{
 			// When the serializer derives from `SystemTextJsonSerializer` we can avoid unnecessary allocations and
 			// serialize straight into the writer.
@@ -294,7 +294,7 @@ public static class TransportSerializerExtensions
 		MemoryStreamFactory? memoryStreamFactory,
 		SerializationFormatting formatting = SerializationFormatting.None)
 	{
-		if (serializer is SystemTextJsonSerializer stjSerializer)
+		if (serializer is SystemTextJsonSerializer stjSerializer && stjSerializer.SupportsFastPath(type))
 		{
 			// When the serializer derives from `SystemTextJsonSerializer` we can avoid unnecessary allocations and
 			// serialize straight into the writer.
@@ -332,7 +332,7 @@ public static class TransportSerializerExtensions
 		string input,
 		MemoryStreamFactory? memoryStreamFactory = null)
 	{
-		if (serializer is SystemTextJsonSerializer stjSerializer)
+		if (serializer is SystemTextJsonSerializer stjSerializer && stjSerializer.SupportsFastPath(typeof(T)))
 		{
 			// When the serializer derives from `SystemTextJsonSerializer` we can avoid unnecessary allocations and
 			// deserialize straight from the span.
@@ -362,7 +362,7 @@ public static class TransportSerializerExtensions
 		Type type,
 		MemoryStreamFactory? memoryStreamFactory = null)
 	{
-		if (serializer is SystemTextJsonSerializer stjSerializer)
+		if (serializer is SystemTextJsonSerializer stjSerializer && stjSerializer.SupportsFastPath(type))
 		{
 			// When the serializer derives from `SystemTextJsonSerializer` we can avoid unnecessary allocations and
 			// deserialize straight from the span.
@@ -391,7 +391,7 @@ public static class TransportSerializerExtensions
 		ReadOnlySpan<byte> span,
 		MemoryStreamFactory? memoryStreamFactory = null)
 	{
-		if (serializer is SystemTextJsonSerializer stjSerializer)
+		if (serializer is SystemTextJsonSerializer stjSerializer && stjSerializer.SupportsFastPath(typeof(T)))
 		{
 			// When the serializer derives from `SystemTextJsonSerializer` we can avoid unnecessary allocations and
 			// deserialize straight from the span.
@@ -421,7 +421,7 @@ public static class TransportSerializerExtensions
 		Type type,
 		MemoryStreamFactory? memoryStreamFactory = null)
 	{
-		if (serializer is SystemTextJsonSerializer stjSerializer)
+		if (serializer is SystemTextJsonSerializer stjSerializer && stjSerializer.SupportsFastPath(type))
 		{
 			// When the serializer derives from `SystemTextJsonSerializer` we can avoid unnecessary allocations and
 			// deserialize straight from the span.
@@ -450,7 +450,7 @@ public static class TransportSerializerExtensions
 		ReadOnlySpan<char> span,
 		MemoryStreamFactory? memoryStreamFactory = null)
 	{
-		if (serializer is SystemTextJsonSerializer stjSerializer)
+		if (serializer is SystemTextJsonSerializer stjSerializer && stjSerializer.SupportsFastPath(typeof(T)))
 		{
 			// When the serializer derives from `SystemTextJsonSerializer` we can avoid unnecessary allocations and
 			// deserialize straight from the span.
@@ -480,7 +480,7 @@ public static class TransportSerializerExtensions
 		Type type,
 		MemoryStreamFactory? memoryStreamFactory = null)
 	{
-		if (serializer is SystemTextJsonSerializer stjSerializer)
+		if (serializer is SystemTextJsonSerializer stjSerializer && stjSerializer.SupportsFastPath(type))
 		{
 			// When the serializer derives from `SystemTextJsonSerializer` we can avoid unnecessary allocations and
 			// deserialize straight from the span.
@@ -509,7 +509,7 @@ public static class TransportSerializerExtensions
 		ref Utf8JsonReader reader,
 		MemoryStreamFactory? memoryStreamFactory = null)
 	{
-		if (serializer is SystemTextJsonSerializer stjSerializer)
+		if (serializer is SystemTextJsonSerializer stjSerializer && stjSerializer.SupportsFastPath(typeof(T)))
 		{
 			// When the serializer derives from `SystemTextJsonSerializer` we can avoid unnecessary allocations and
 			// deserialize straight from the reader.
@@ -546,7 +546,7 @@ public static class TransportSerializerExtensions
 		Type type,
 		MemoryStreamFactory? memoryStreamFactory = null)
 	{
-		if (serializer is SystemTextJsonSerializer stjSerializer)
+		if (serializer is SystemTextJsonSerializer stjSerializer && stjSerializer.SupportsFastPath(type))
 		{
 			// When the serializer derives from `SystemTextJsonSerializer` we can avoid unnecessary allocations and
 			// deserialize straight from the reader.
@@ -582,7 +582,7 @@ public static class TransportSerializerExtensions
 		JsonNode node,
 		MemoryStreamFactory? memoryStreamFactory = null)
 	{
-		if (serializer is SystemTextJsonSerializer stjSerializer)
+		if (serializer is SystemTextJsonSerializer stjSerializer && stjSerializer.SupportsFastPath(typeof(T)))
 		{
 			// When the serializer derives from `SystemTextJsonSerializer` we can avoid unnecessary allocations and
 			// deserialize straight from the node.
@@ -617,7 +617,7 @@ public static class TransportSerializerExtensions
 		Type type,
 		MemoryStreamFactory? memoryStreamFactory = null)
 	{
-		if (serializer is SystemTextJsonSerializer stjSerializer)
+		if (serializer is SystemTextJsonSerializer stjSerializer && stjSerializer.SupportsFastPath(type))
 		{
 			// When the serializer derives from `SystemTextJsonSerializer` we can avoid unnecessary allocations and
 			// deserialize straight from the node.
@@ -651,7 +651,7 @@ public static class TransportSerializerExtensions
 		JsonElement node,
 		MemoryStreamFactory? memoryStreamFactory = null)
 	{
-		if (serializer is SystemTextJsonSerializer stjSerializer)
+		if (serializer is SystemTextJsonSerializer stjSerializer && stjSerializer.SupportsFastPath(typeof(T)))
 		{
 			// When the serializer derives from `SystemTextJsonSerializer` we can avoid unnecessary allocations and
 			// deserialize straight from the node.
@@ -686,7 +686,7 @@ public static class TransportSerializerExtensions
 		Type type,
 		MemoryStreamFactory? memoryStreamFactory = null)
 	{
-		if (serializer is SystemTextJsonSerializer stjSerializer)
+		if (serializer is SystemTextJsonSerializer stjSerializer && stjSerializer.SupportsFastPath(type))
 		{
 			// When the serializer derives from `SystemTextJsonSerializer` we can avoid unnecessary allocations and
 			// deserialize straight from the node.

--- a/src/Elastic.Transport/Requests/IUrlParameter.cs
+++ b/src/Elastic.Transport/Requests/IUrlParameter.cs
@@ -7,6 +7,6 @@ namespace Elastic.Transport;
 /// <summary> Implementers define an object that can be serialized as a query string parameter </summary>
 public interface IUrlParameter
 {
-	/// <summary> Get the a string representation using <paramref name="settings"/> </summary>
-	string GetString(ITransportConfiguration settings);
+	/// <summary> Get the string representation using <paramref name="settings"/> </summary>
+	public string GetString(ITransportConfiguration settings);
 }


### PR DESCRIPTION
The `DefaultRequestResponseSerializer` implementation in the Elasticsearch client (based on `SystemTextJsonSerializer`) overrides the `Deserialize`/`Serialize` methods to drive special serialization, if the type implements `IStreamSerializable`. This is done to support e.g. NDJSON request/response bodies.

Fast-path (de-)serialization currently incorrectly bypasses this special handling.

This PR provides a way to selectively disable the fast-path (de-)serialization for specific types.