### PR TITLE
Set default stats collection flags to false in BoundConfiguration

### DIFF
--- a/src/Elastic.Transport/Components/Pipeline/BoundConfiguration.cs
+++ b/src/Elastic.Transport/Components/Pipeline/BoundConfiguration.cs
@@ -57,8 +57,8 @@ public sealed record BoundConfiguration : IRequestConfiguration
 		AllowedStatusCodes = local?.AllowedStatusCodes ?? EmptyReadOnly<int>.Collection;
 		ClientCertificates = local?.ClientCertificates ?? global.ClientCertificates;
 		TransferEncodingChunked = local?.TransferEncodingChunked ?? global.TransferEncodingChunked ?? false;
-		EnableTcpStats = local?.EnableTcpStats ?? global.EnableTcpStats ?? true;
-		EnableThreadPoolStats = local?.EnableThreadPoolStats ?? global.EnableThreadPoolStats ?? true;
+		EnableTcpStats = local?.EnableTcpStats ?? global.EnableTcpStats ?? false;
+		EnableThreadPoolStats = local?.EnableThreadPoolStats ?? global.EnableThreadPoolStats ?? false;
 		ParseAllHeaders = local?.ParseAllHeaders ?? global.ParseAllHeaders ?? false;
 		ResponseHeadersToParse = local is not null
 			? new HeadersList(local.ResponseHeadersToParse, global.ResponseHeadersToParse)


### PR DESCRIPTION
The defaults for `EnableTcpStats` and `EnableThreadPoolStats` were changed from `true` to `false`. This ensures a more conservative approach to resource usage unless explicitly enabled.
