### PR TITLE
Rename ErrorSerializerContext and update related references

### DIFF
--- a/Playground/Program.cs
+++ b/Playground/Program.cs
@@ -23,6 +23,10 @@ Console.WriteLine(response.DebugInformation);
 var dynamicResponse = transport.Request<DynamicResponse>(HttpMethod.GET, "/");
 Console.WriteLine(dynamicResponse.Body.Get<string>("version.build_flavor"));
 
+var body = PostData.String("{\"name\": \"test\"}");
+var indexResponse = transport.Request<EsResponse>(HttpMethod.POST, "/does-not-exist/_doc", body);
+Console.WriteLine(indexResponse.DebugInformation);
+
 Console.WriteLine(registration.DefaultContentType ?? "NOT SPECIFIED");
 
 public class EsResponse : ElasticsearchResponse;

--- a/src/Elastic.Transport/Components/Serialization/Converters/DynamicDictionaryConverter.cs
+++ b/src/Elastic.Transport/Components/Serialization/Converters/DynamicDictionaryConverter.cs
@@ -19,7 +19,7 @@ internal class DynamicDictionaryConverter : JsonConverter<DynamicDictionary>
 	{
 		if (reader.TokenType == JsonTokenType.StartArray)
 		{
-			var array = JsonSerializer.Deserialize<object[]>(ref reader, ErrorSerializerContext.Default.ObjectArray); // TODO: Test! This might not work without adding `object[]` to `ErrorSerializationContext`
+			var array = JsonSerializer.Deserialize<object[]>(ref reader, ElasticsearchTransportSerializerContext.Default.ObjectArray); // TODO: Test! This might not work without adding `object[]` to `ErrorSerializationContext`
 			var arrayDict = new Dictionary<string, object>();
 			for (var i = 0; i < array.Length; i++)
 				arrayDict[i.ToString(CultureInfo.InvariantCulture)] = new DynamicValue(array[i]);
@@ -27,7 +27,7 @@ internal class DynamicDictionaryConverter : JsonConverter<DynamicDictionary>
 		}
 		if (reader.TokenType != JsonTokenType.StartObject) throw new JsonException();
 
-		var dict = JsonSerializer.Deserialize<Dictionary<string, object>>(ref reader, ErrorSerializerContext.Default.DictionaryStringObject); // TODO: Test! This might not work without adding `Dictionary<string, object>` to `ErrorSerializationContext`
+		var dict = JsonSerializer.Deserialize<Dictionary<string, object>>(ref reader, ElasticsearchTransportSerializerContext.Default.DictionaryStringObject); // TODO: Test! This might not work without adding `Dictionary<string, object>` to `ErrorSerializationContext`
 		return DynamicDictionary.Create(dict);
 	}
 

--- a/src/Elastic.Transport/Components/Serialization/Converters/ExceptionConverter.cs
+++ b/src/Elastic.Transport/Components/Serialization/Converters/ExceptionConverter.cs
@@ -72,7 +72,7 @@ internal class ExceptionConverter : JsonConverter<Exception>
 			foreach (var kv in flattenedException)
 			{
 				writer.WritePropertyName(kv.Key);
-				JsonSerializer.Serialize(writer, kv.Value, ErrorSerializerContext.Default.Object); // TODO: Test! This might not work without adding `KeyValuePair<string, object>` to `ErrorSerializationContext`
+				JsonSerializer.Serialize(writer, kv.Value, ElasticsearchTransportSerializerContext.Default.Object); // TODO: Test! This might not work without adding `KeyValuePair<string, object>` to `ErrorSerializationContext`
 			}
 			writer.WriteEndObject();
 		}

--- a/src/Elastic.Transport/Components/Serialization/LowLevelRequestResponseSerializer.cs
+++ b/src/Elastic.Transport/Components/Serialization/LowLevelRequestResponseSerializer.cs
@@ -38,7 +38,7 @@ internal sealed class LowLevelRequestResponseSerializer : SystemTextJsonSerializ
 		{
 			options.DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull;
 #pragma warning disable IL2026, IL3050
-			options.TypeInfoResolver = JsonTypeInfoResolver.Combine(new DefaultJsonTypeInfoResolver(), ErrorSerializerContext.Default);
+			options.TypeInfoResolver = JsonTypeInfoResolver.Combine(new DefaultJsonTypeInfoResolver(), ElasticsearchTransportSerializerContext.Default);
 #pragma warning restore IL2026, IL3050
 		})) { }
 

--- a/src/Elastic.Transport/Products/Elasticsearch/ErrorSerializationContext.cs
+++ b/src/Elastic.Transport/Products/Elasticsearch/ErrorSerializationContext.cs
@@ -21,4 +21,4 @@ namespace Elastic.Transport.Products.Elasticsearch;
 [JsonSerializable(typeof(IReadOnlyDictionary<string, string>))]
 [JsonSerializable(typeof(string))]
 [JsonSourceGenerationOptions(GenerationMode = JsonSourceGenerationMode.Default, UseStringEnumConverter = true)]
-public partial class ErrorSerializerContext : JsonSerializerContext;
+public partial class ElasticsearchTransportSerializerContext : JsonSerializerContext;

--- a/src/Elastic.Transport/Products/Elasticsearch/Failures/Error.cs
+++ b/src/Elastic.Transport/Products/Elasticsearch/Failures/Error.cs
@@ -52,14 +52,14 @@ public sealed class ErrorConverter : JsonConverter<Error>
 
 				if (reader.ValueTextEquals("root_cause"))
 				{
-					var value = JsonSerializer.Deserialize<IReadOnlyCollection<ErrorCause>>(ref reader, ErrorSerializerContext.Default.IReadOnlyCollectionErrorCause);
+					var value = JsonSerializer.Deserialize<IReadOnlyCollection<ErrorCause>>(ref reader, ElasticsearchTransportSerializerContext.Default.IReadOnlyCollectionErrorCause);
 					error.RootCause = value;
 					continue;
 				}
 
 				if (reader.ValueTextEquals("caused_by"))
 				{
-					var value = JsonSerializer.Deserialize<ErrorCause>(ref reader, ErrorSerializerContext.Default.ErrorCause);
+					var value = JsonSerializer.Deserialize<ErrorCause>(ref reader, ElasticsearchTransportSerializerContext.Default.ErrorCause);
 					error.CausedBy = value;
 					continue;
 				}
@@ -73,49 +73,49 @@ public sealed class ErrorConverter : JsonConverter<Error>
 
 				if (reader.ValueTextEquals("headers"))
 				{
-					var value = JsonSerializer.Deserialize<IReadOnlyDictionary<string, string>>(ref reader, ErrorSerializerContext.Default.IReadOnlyDictionaryStringString); // TODO: Test! This might not work without adding `IReadOnlyDictionary<string, string>` to `ErrorSerializationContext`
+					var value = JsonSerializer.Deserialize<IReadOnlyDictionary<string, string>>(ref reader, ElasticsearchTransportSerializerContext.Default.IReadOnlyDictionaryStringString); // TODO: Test! This might not work without adding `IReadOnlyDictionary<string, string>` to `ErrorSerializationContext`
 					error.Headers = value;
 					continue;
 				}
 
 				if (reader.ValueTextEquals("stack_trace"))
 				{
-					var value = JsonSerializer.Deserialize<string>(ref reader, ErrorSerializerContext.Default.String);
+					var value = JsonSerializer.Deserialize<string>(ref reader, ElasticsearchTransportSerializerContext.Default.String);
 					error.StackTrace = value;
 					continue;
 				}
 
 				if (reader.ValueTextEquals("type"))
 				{
-					var value = JsonSerializer.Deserialize<string>(ref reader, ErrorSerializerContext.Default.String);
+					var value = JsonSerializer.Deserialize<string>(ref reader, ElasticsearchTransportSerializerContext.Default.String);
 					error.Type = value;
 					continue;
 				}
 
 				if (reader.ValueTextEquals("index"))
 				{
-					var value = JsonSerializer.Deserialize<string>(ref reader, ErrorSerializerContext.Default.String);
+					var value = JsonSerializer.Deserialize<string>(ref reader, ElasticsearchTransportSerializerContext.Default.String);
 					error.Index = value;
 					continue;
 				}
 
 				if (reader.ValueTextEquals("index_uuid"))
 				{
-					var value = JsonSerializer.Deserialize<string>(ref reader, ErrorSerializerContext.Default.String);
+					var value = JsonSerializer.Deserialize<string>(ref reader, ElasticsearchTransportSerializerContext.Default.String);
 					error.IndexUUID = value;
 					continue;
 				}
 
 				if (reader.ValueTextEquals("reason"))
 				{
-					var value = JsonSerializer.Deserialize<string>(ref reader, ErrorSerializerContext.Default.String);
+					var value = JsonSerializer.Deserialize<string>(ref reader, ElasticsearchTransportSerializerContext.Default.String);
 					error.Reason = value;
 					continue;
 				}
 
 				additional ??= new Dictionary<string, object>();
 				var key = reader.GetString();
-				var additionaValue = JsonSerializer.Deserialize<object>(ref reader, ErrorSerializerContext.Default.Object);
+				var additionaValue = JsonSerializer.Deserialize<object>(ref reader, ElasticsearchTransportSerializerContext.Default.Object);
 				additional.Add(key, additionaValue);
 			}
 


### PR DESCRIPTION
Renamed `ErrorSerializerContext` to `ElasticsearchTransportSerializerContext` for improved clarity and consistency. Updated all references across serialization logic and tests to align with the new context name. This ensures correct deserialization behavior and avoids potential conflicts with outdated naming.
