### PR TITLE
Cache pre-request `BoundConfiguration`s in `DistributedTransport`

### DIFF
--- a/src/Elastic.Transport/Configuration/IRequestConfiguration.cs
+++ b/src/Elastic.Transport/Configuration/IRequestConfiguration.cs
@@ -60,7 +60,7 @@ public interface IRequestConfiguration
 	bool? DisableSniff { get; }
 
 	/// <summary>
-	/// Whether or not this request should be pipelined. http://en.wikipedia.org/wiki/HTTP_pipelining defaults to true
+	/// Whether this request should be pipelined. <see href="http://en.wikipedia.org/wiki/HTTP_pipelining"/> defaults to <see langword="true"/>.
 	/// </summary>
 	bool? HttpPipeliningEnabled { get; }
 


### PR DESCRIPTION
Reduces frequent allocations of `BoundConfiguration` for requests with local `IRequestConfiguration`.