### PR TITLE
Fix a null check for response which may happen during tests

### DIFF
--- a/src/Elastic.Transport/DistributedTransport.cs
+++ b/src/Elastic.Transport/DistributedTransport.cs
@@ -248,11 +248,13 @@ public class DistributedTransport<TConfiguration> : ITransport<TConfiguration>
 				}
 			}
 
+			if (response is not null)
+			{
 #if NET6_0_OR_GREATER
-			activity?.SetStatus(response.ApiCallDetails.HasSuccessfulStatusCodeAndExpectedContentType ? ActivityStatusCode.Ok : ActivityStatusCode.Error);
+				activity?.SetStatus(response.ApiCallDetails.HasSuccessfulStatusCodeAndExpectedContentType ? ActivityStatusCode.Ok : ActivityStatusCode.Error);
 #endif
-
-			activity?.SetTag(SemanticConventions.HttpResponseStatusCode, response.ApiCallDetails.HttpStatusCode);
+				activity?.SetTag(SemanticConventions.HttpResponseStatusCode, response.ApiCallDetails.HttpStatusCode);
+			}
 			activity?.SetTag(OpenTelemetryAttributes.ElasticTransportAttemptedNodes, attemptedNodes);
 
 			// We don't check IsAllDataRequested here as that's left to the consumer.


### PR DESCRIPTION
Observed here during release: https://github.com/elastic/elastic-transport-net/actions/runs/15298217514/job/43032254002

These UsageTests were never actual tests but now we are running them hopefully this fixes it.