### PR TITLE
Allow inheriting from `MemoryStreamFactory`

### DIFF
--- a/src/Elastic.Transport/Components/Providers/MemoryStreamFactory.cs
+++ b/src/Elastic.Transport/Components/Providers/MemoryStreamFactory.cs
@@ -11,7 +11,10 @@ namespace Elastic.Transport;
 /// </summary>
 public abstract class MemoryStreamFactory
 {
-	internal MemoryStreamFactory() { }
+	/// <summary>
+	/// Constructs a new instance of <see cref="MemoryStreamFactory"/>.
+	/// </summary>
+	protected MemoryStreamFactory() { }
 
 	/// <summary>
 	/// Creates a memory stream


### PR DESCRIPTION
As titled. I assume this was an oversight.