### PR TITLE
Pass `PostData` to `BoundConfigurationContent` when `TransferEncodingChunked` is enabled

### DIFF
--- a/src/Elastic.Transport/Components/TransportClient/Content/RequestDataContent.cs
+++ b/src/Elastic.Transport/Components/TransportClient/Content/RequestDataContent.cs
@@ -66,9 +66,10 @@ internal sealed class BoundConfigurationContent : HttpContent
 	}
 
 	/// <summary> Constructor used in asynchronous paths. </summary>
-	public BoundConfigurationContent(BoundConfiguration boundConfiguration, CancellationToken token)
+	public BoundConfigurationContent(BoundConfiguration boundConfiguration, PostData? postData, CancellationToken token)
 	{
 		_boundConfiguration = boundConfiguration;
+		_postData = postData;
 		_token = token;
 
 		Headers.TryAddWithoutValidation("Content-Type", boundConfiguration.ContentType);

--- a/src/Elastic.Transport/Components/TransportClient/HttpRequestInvoker.cs
+++ b/src/Elastic.Transport/Components/TransportClient/HttpRequestInvoker.cs
@@ -462,7 +462,7 @@ public class HttpRequestInvoker : IRequestInvoker
 	private static async Task SetContentAsync(HttpRequestMessage message, BoundConfiguration boundConfiguration, PostData postData, CancellationToken cancellationToken)
 	{
 		if (boundConfiguration.TransferEncodingChunked)
-			message.Content = new BoundConfigurationContent(boundConfiguration, cancellationToken);
+			message.Content = new BoundConfigurationContent(boundConfiguration, postData, cancellationToken);
 		else
 		{
 			var stream = boundConfiguration.MemoryStreamFactory.Create();


### PR DESCRIPTION
As titled.

Closes #188