### PR TITLE
Add `JsonResponse` type and enhance `DynamicResponse` path traversal with array syntax

### DIFF
--- a/examples/transport-aot-example/Program.cs
+++ b/examples/transport-aot-example/Program.cs
@@ -2,10 +2,44 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 using Elastic.Transport;
 using Elastic.Transport.Products.Elasticsearch;
 
+// --- Inline AOT smoke tests (no server needed) ---
+
+// DynamicResponse inline test
+var dict = new DynamicDictionary
+{
+	["name"] = new DynamicValue("test"),
+	["count"] = new DynamicValue(42),
+	["nested"] = new DynamicValue(new DynamicDictionary
+	{
+		["value"] = new DynamicValue("deep")
+	})
+};
+var dr = new DynamicResponse(dict);
+Assert(dr.Get<string>("name") == "test", "DynamicResponse Get<string>");
+Assert(dr.Get<int>("count") == 42, "DynamicResponse Get<int>");
+Assert(dr.Get<string>("nested.value") == "deep", "DynamicResponse nested Get<string>");
+
+// JsonResponse inline test
+var node = JsonNode.Parse("""{"hits":{"total":42,"hits":[{"_source":{"name":"test"}},{"_source":{"name":"last"}}]}}""")!;
+var jr = new JsonResponse(node);
+Assert(jr.Get<int>("hits.total") == 42, "JsonResponse Get<int>");
+Assert(jr.Get<string>("hits.hits.[0]._source.name") == "test", "JsonResponse bracket index");
+Assert(jr.Get<string>("hits.hits._first_._source.name") == "test", "JsonResponse _first_");
+Assert(jr.Get<string>("hits.hits._last_._source.name") == "last", "JsonResponse _last_");
+Assert(jr.Get<string>("hits.hits.[last()]._source.name") == "last", "JsonResponse [last()]");
+
+// JsonResponse direct DOM access
+Assert(jr.Body!["hits"]!["total"]!.GetValue<int>() == 42, "JsonResponse DOM access");
+Assert(jr.Body["hits"]!["hits"]![0]!["_source"]!["name"]!.GetValue<string>() == "test", "JsonResponse DOM array access");
+
+Console.WriteLine("All inline AOT smoke tests passed.");
+
+// --- Server-based tests (only when configured) ---
 var apiKey = Environment.GetEnvironmentVariable("ELASTIC_API_KEY");
 var url = Environment.GetEnvironmentVariable("ELASTIC_URL");
 
@@ -17,9 +51,21 @@ var transport = new DistributedTransport(configuration);
 
 var rootResponse = transport.Get<DynamicResponse>("/");
 if (rootResponse.ApiCallDetails.HasSuccessfulStatusCode)
-	Console.WriteLine(rootResponse.Get<string>("tagline"));
+	Console.WriteLine($"DynamicResponse tagline: {rootResponse.Get<string>("tagline")}");
 else
 	Console.WriteLine(rootResponse);
+
+var jsonRootResponse = transport.Get<JsonResponse>("/");
+if (jsonRootResponse.ApiCallDetails.HasSuccessfulStatusCode)
+	Console.WriteLine($"JsonResponse tagline: {jsonRootResponse.Get<string>("tagline")}");
+else
+	Console.WriteLine(jsonRootResponse);
+
+static void Assert(bool condition, string message)
+{
+	if (!condition) throw new Exception($"Assertion failed: {message}");
+	Console.WriteLine($"  PASS: {message}");
+}
 
 public class MyDocument
 {

--- a/src/Elastic.Transport/Responses/DefaultResponseFactory.cs
+++ b/src/Elastic.Transport/Responses/DefaultResponseFactory.cs
@@ -28,6 +28,7 @@ internal sealed class DefaultResponseFactory : ResponseFactory
 		[typeof(StreamResponse)] = new StreamResponseBuilder(),
 		[typeof(StringResponse)] = new StringResponseBuilder(),
 		[typeof(DynamicResponse)] = new DynamicResponseBuilder(),
+		[typeof(JsonResponse)] = new JsonResponseBuilder(),
 		[typeof(VoidResponse)] = new VoidResponseBuilder()
 	};
 

--- a/src/Elastic.Transport/Responses/Dynamic/DynamicDictionary.cs
+++ b/src/Elastic.Transport/Responses/Dynamic/DynamicDictionary.cs
@@ -83,20 +83,42 @@ public sealed class DynamicDictionary
 		while (queue.Count > 0)
 		{
 			var key = queue.Dequeue().Replace(@"\.", ".");
-			if (key == "_arbitrary_key_")
-			{
-				if (queue.Count > 0) d = d[0];
-				else
-				{
-					var v = d?.ToDictionary()?.Keys.FirstOrDefault();
-					d = v != null ? new DynamicValue(v) : DynamicValue.NullValue;
-				}
-			}
-			else if (int.TryParse(key, out var i)) d = d[i];
-			else d = d[key];
+			d = ResolvePathSegment(d, key, queue.Count == 0);
 		}
 
 		return d.TryParse<T>();
+	}
+
+	internal static DynamicValue ResolvePathSegment(DynamicValue d, string key, bool isLast)
+	{
+		if (key == "_arbitrary_key_")
+		{
+			var dict = d?.ToDictionary();
+			if (dict == null || dict.Count == 0) return DynamicValue.NullValue;
+
+			var firstKey = dict.Keys.First();
+			if (isLast) return new DynamicValue(firstKey);
+			return dict[firstKey];
+		}
+
+		if (key == "_first_" || key == "[first()]")
+			return d[0];
+
+		if (key == "_last_" || key == "[last()]")
+		{
+			var count = d.Count;
+			return count > 0 ? d[count - 1] : DynamicValue.NullValue;
+		}
+
+		// Bracket index: [N]
+		if (key.Length > 2 && key[0] == '[' && key[key.Length - 1] == ']' && int.TryParse(key.Substring(1, key.Length - 2), out var bracketIndex))
+			return d[bracketIndex];
+
+		// Plain numeric index
+		if (int.TryParse(key, out var i))
+			return d[i];
+
+		return d[key];
 	}
 
 	/// <summary>

--- a/src/Elastic.Transport/Responses/Dynamic/DynamicValue.cs
+++ b/src/Elastic.Transport/Responses/Dynamic/DynamicValue.cs
@@ -390,6 +390,11 @@ public sealed class DynamicValue : DynamicObject, IEquatable<DynamicValue>, ICon
 			return true;
 		}
 
+		if (Value is IDictionary<string, DynamicValue> dv)
+		{
+			result = dv.TryGetValue(name, out var r) ? r : NullValue;
+			return true;
+		}
 		if (Value is IDictionary<string, object> d)
 		{
 			result = d.TryGetValue(name, out var r) ? SelfOrNew(r) : NullValue;

--- a/src/Elastic.Transport/Responses/Json/JsonNodePathTraversal.cs
+++ b/src/Elastic.Transport/Responses/Json/JsonNodePathTraversal.cs
@@ -1,0 +1,191 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Linq;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Text.RegularExpressions;
+
+namespace Elastic.Transport;
+
+internal static class JsonNodePathTraversal
+{
+	private static readonly Regex SplitRegex = new(@"(?<!\\)\.");
+
+	public static T Get<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(JsonNode node, string path)
+	{
+		if (path == null || node == null) return default;
+
+		var split = SplitRegex.Split(path);
+		if (split.Length == 0) return default;
+
+		var current = node;
+		for (var i = 0; i < split.Length; i++)
+		{
+			if (current == null) return default;
+
+			var key = split[i].Replace(@"\.", ".");
+			var isLast = i == split.Length - 1;
+			current = ResolveSegment(current, key, isLast);
+		}
+
+		return ConvertNode<T>(current);
+	}
+
+	private static JsonNode ResolveSegment(JsonNode current, string key, bool isLast)
+	{
+		if (key == "_arbitrary_key_")
+		{
+			if (current is JsonObject obj)
+			{
+				if (!isLast)
+				{
+					// Traverse into first key's value
+					var first = obj.FirstOrDefault();
+					return first.Value;
+				}
+				// Return the key name
+				var firstKey = obj.FirstOrDefault();
+				return firstKey.Key != null ? JsonValue.Create(firstKey.Key) : null;
+			}
+			return null;
+		}
+
+		if (key == "_first_" || key == "[first()]")
+		{
+			if (current is JsonArray arr && arr.Count > 0)
+				return arr[0];
+			return null;
+		}
+
+		if (key == "_last_" || key == "[last()]")
+		{
+			if (current is JsonArray arr && arr.Count > 0)
+				return arr[arr.Count - 1];
+			return null;
+		}
+
+		// Bracket index: [N]
+		if (key.Length > 2 && key[0] == '[' && key[key.Length - 1] == ']')
+		{
+#if NETSTANDARD2_0 || NET462
+			var inner = key.Substring(1, key.Length - 2);
+			if (int.TryParse(inner, out var bracketIndex))
+#else
+			if (int.TryParse(key.AsSpan(1, key.Length - 2), out var bracketIndex))
+#endif
+			{
+				if (current is JsonArray bArr && bracketIndex >= 0 && bracketIndex < bArr.Count)
+					return bArr[bracketIndex];
+				return null;
+			}
+		}
+
+		// Plain numeric index
+		if (int.TryParse(key, out var index))
+		{
+			if (current is JsonArray nArr && index >= 0 && index < nArr.Count)
+				return nArr[index];
+			// Also allow numeric keys on objects
+			if (current is JsonObject nObj && nObj.ContainsKey(key))
+				return nObj[key];
+			return null;
+		}
+
+		// Object property lookup
+		if (current is JsonObject propObj && propObj.ContainsKey(key))
+			return propObj[key];
+
+		return null;
+	}
+
+	private static T ConvertNode<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(JsonNode node)
+	{
+		if (node == null) return default;
+
+		var targetType = typeof(T);
+		if (targetType == typeof(JsonNode)) return (T)(object)node;
+
+		if (node is JsonValue val)
+		{
+			// Try direct extraction for common types
+			if (targetType == typeof(string))
+			{
+				if (val.TryGetValue<string>(out var s)) return (T)(object)s;
+				// For numbers/bools stored as JsonValue, convert to string
+				return (T)(object)node.ToJsonString().Trim('"');
+			}
+			if (targetType == typeof(int))
+			{
+				if (val.TryGetValue<int>(out var i)) return (T)(object)i;
+				if (val.TryGetValue<long>(out var l)) return (T)(object)(int)l;
+				if (val.TryGetValue<string>(out var s) && int.TryParse(s, out var parsed)) return (T)(object)parsed;
+				return default;
+			}
+			if (targetType == typeof(long))
+			{
+				if (val.TryGetValue<long>(out var l)) return (T)(object)l;
+				if (val.TryGetValue<int>(out var i)) return (T)(object)(long)i;
+				return default;
+			}
+			if (targetType == typeof(double))
+			{
+				if (val.TryGetValue<double>(out var d)) return (T)(object)d;
+				return default;
+			}
+			if (targetType == typeof(float))
+			{
+				if (val.TryGetValue<float>(out var f)) return (T)(object)f;
+				if (val.TryGetValue<double>(out var d)) return (T)(object)(float)d;
+				return default;
+			}
+			if (targetType == typeof(decimal))
+			{
+				if (val.TryGetValue<decimal>(out var d)) return (T)(object)d;
+				return default;
+			}
+			if (targetType == typeof(bool))
+			{
+				if (val.TryGetValue<bool>(out var b)) return (T)(object)b;
+				return default;
+			}
+			if (targetType == typeof(DateTime))
+			{
+				if (val.TryGetValue<DateTime>(out var dt)) return (T)(object)dt;
+				if (val.TryGetValue<string>(out var s) && DateTime.TryParse(s, CultureInfo.InvariantCulture, DateTimeStyles.None, out var parsed))
+					return (T)(object)parsed;
+				return default;
+			}
+			if (targetType == typeof(DateTimeOffset))
+			{
+				if (val.TryGetValue<DateTimeOffset>(out var dto)) return (T)(object)dto;
+				return default;
+			}
+			if (targetType == typeof(Guid))
+			{
+				if (val.TryGetValue<Guid>(out var g)) return (T)(object)g;
+				if (val.TryGetValue<string>(out var s) && Guid.TryParse(s, out var parsed)) return (T)(object)parsed;
+				return default;
+			}
+
+			// Fallback: try GetValue<T>
+			try
+			{
+				return val.GetValue<T>();
+			}
+			catch
+			{
+				return default;
+			}
+		}
+
+		// For JsonObject/JsonArray, if T is object just return as-is
+		if (targetType == typeof(object)) return (T)(object)node;
+
+		return default;
+	}
+}

--- a/src/Elastic.Transport/Responses/Json/JsonResponse.cs
+++ b/src/Elastic.Transport/Responses/Json/JsonResponse.cs
@@ -1,0 +1,36 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json.Nodes;
+
+namespace Elastic.Transport;
+
+/// <summary>
+/// A response type backed by <see cref="JsonNode"/> from System.Text.Json.
+///
+/// <para>Provides direct DOM access via <see cref="TransportResponse{T}.Body"/> (e.g. <c>response.Body["hits"]["hits"][0]</c>)</para>
+/// <para>Also exposes a safe path traversal mechanism via <see cref="Get{T}"/> using dot-notation paths.</para>
+/// </summary>
+public sealed class JsonResponse : TransportResponse<JsonNode>
+{
+	/// <inheritdoc cref="JsonResponse"/>
+	public JsonResponse() { }
+
+	/// <inheritdoc cref="JsonResponse"/>
+	public JsonResponse(JsonNode node) => Body = node;
+
+	/// <summary>
+	/// Traverses data using path notation.
+	/// <para><c>e.g some.deep.nested.json.path</c></para>
+	/// <para>Supports bracket index syntax: <c>hits.hits.[0]._source</c></para>
+	/// <para>Supports first/last: <c>hits.hits.[first()]._source</c>, <c>hits.hits._last_</c></para>
+	/// <para>Supports arbitrary key: <c>some._arbitrary_key_.value</c></para>
+	/// </summary>
+	/// <param name="path">path into the stored object, keys are separated with a dot and the last key is returned as T</param>
+	/// <typeparam name="T"></typeparam>
+	/// <returns>T or default</returns>
+	public T Get<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(string path) =>
+		JsonNodePathTraversal.Get<T>(Body, path);
+}

--- a/src/Elastic.Transport/Responses/Json/JsonResponseBuilder.cs
+++ b/src/Elastic.Transport/Responses/Json/JsonResponseBuilder.cs
@@ -1,0 +1,83 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+#if NET8_0_OR_GREATER
+using System;
+using System.Buffers;
+#endif
+
+using System.IO;
+using System.Text;
+using System.Text.Json.Nodes;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Elastic.Transport;
+
+internal class JsonResponseBuilder : TypedResponseBuilder<JsonResponse>
+{
+	protected override JsonResponse Build(ApiCallDetails apiCallDetails, BoundConfiguration boundConfiguration, Stream responseStream, string contentType, long contentLength) =>
+		BuildCoreAsync(false, apiCallDetails, boundConfiguration, responseStream, contentType, contentLength).EnsureCompleted();
+
+	protected override Task<JsonResponse> BuildAsync(ApiCallDetails apiCallDetails, BoundConfiguration boundConfiguration, Stream responseStream, string contentType, long contentLength, CancellationToken cancellationToken = default) =>
+		BuildCoreAsync(true, apiCallDetails, boundConfiguration, responseStream, contentType, contentLength, cancellationToken).AsTask();
+
+	private static async ValueTask<JsonResponse> BuildCoreAsync(bool isAsync, ApiCallDetails apiCallDetails, BoundConfiguration boundConfiguration, Stream responseStream,
+		string contentType, long contentLength, CancellationToken cancellationToken = default)
+	{
+		// If not JSON, store the result under "body"
+		if (contentType == null || !contentType.StartsWith(BoundConfiguration.DefaultContentType))
+		{
+			string stringValue;
+
+			if (apiCallDetails.ResponseBodyInBytes is not null)
+			{
+				stringValue = Encoding.UTF8.GetString(apiCallDetails.ResponseBodyInBytes);
+				return new JsonResponse(new JsonObject { ["body"] = stringValue });
+			}
+
+#if NET8_0_OR_GREATER
+			if (contentLength > -1 && contentLength <= 1_048_576)
+			{
+				var buffer = ArrayPool<byte>.Shared.Rent((int)contentLength);
+				responseStream.ReadExactly(buffer, 0, (int)contentLength);
+				stringValue = Encoding.UTF8.GetString(buffer.AsSpan(0, (int)contentLength));
+				ArrayPool<byte>.Shared.Return(buffer);
+				return new JsonResponse(new JsonObject { ["body"] = stringValue });
+			}
+#endif
+
+			var sr = new StreamReader(responseStream);
+
+			if (isAsync)
+			{
+				stringValue = await sr.ReadToEndAsync
+				(
+#if NET8_0_OR_GREATER
+					cancellationToken
+#endif
+				).ConfigureAwait(false);
+			}
+			else
+			{
+				stringValue = sr.ReadToEnd();
+			}
+
+			return new JsonResponse(new JsonObject { ["body"] = stringValue });
+		}
+
+		// JSON content: parse into JsonNode
+		JsonNode node;
+		if (isAsync)
+		{
+			node = await JsonNode.ParseAsync(responseStream, cancellationToken: cancellationToken).ConfigureAwait(false);
+		}
+		else
+		{
+			node = JsonNode.Parse(responseStream);
+		}
+
+		return new JsonResponse(node);
+	}
+}

--- a/tests/Elastic.Transport.Tests/Responses/Dynamic/DynamicDictionaryGetTests.cs
+++ b/tests/Elastic.Transport.Tests/Responses/Dynamic/DynamicDictionaryGetTests.cs
@@ -1,0 +1,217 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.IO;
+using System.Text;
+using FluentAssertions;
+using Xunit;
+
+namespace Elastic.Transport.Tests.Responses.Dynamic;
+
+public class DynamicDictionaryGetTests
+{
+	private static DynamicDictionary Deserialize(string json)
+	{
+		var bytes = Encoding.UTF8.GetBytes(json);
+		using var stream = new MemoryStream(bytes);
+		return LowLevelRequestResponseSerializer.Instance.Deserialize<DynamicDictionary>(stream);
+	}
+
+	// --- Flat primitives ---
+
+	[Fact]
+	public void FlatString() => Deserialize("""{"name":"hello"}""").Get<string>("name").Should().Be("hello");
+
+	[Fact]
+	public void FlatInt() => Deserialize("""{"count":42}""").Get<int>("count").Should().Be(42);
+
+	[Fact]
+	public void FlatLong() => Deserialize("""{"big":9999999999}""").Get<long>("big").Should().Be(9999999999L);
+
+	[Fact]
+	public void FlatDouble() => Deserialize("""{"pi":3.14}""").Get<double>("pi").Should().BeApproximately(3.14, 0.001);
+
+	[Fact]
+	public void FlatBoolTrue() => Deserialize("""{"flag":true}""").Get<bool>("flag").Should().BeTrue();
+
+	[Fact]
+	public void FlatBoolFalse() => Deserialize("""{"flag":false}""").Get<bool>("flag").Should().BeFalse();
+
+	[Fact]
+	public void FlatNull() => Deserialize("""{"val":null}""").Get<string>("val").Should().BeNull();
+
+	// --- Nested objects ---
+
+	[Fact]
+	public void NestedTwoLevels() =>
+		Deserialize("""{"a":{"b":"deep"}}""").Get<string>("a.b").Should().Be("deep");
+
+	[Fact]
+	public void NestedThreeLevels() =>
+		Deserialize("""{"a":{"b":{"c":99}}}""").Get<int>("a.b.c").Should().Be(99);
+
+	// --- Array properties ---
+
+	[Fact]
+	public void ArrayPropertyByNumericIndex() =>
+		Deserialize("""{"items":[10,20,30]}""").Get<int>("items.0").Should().Be(10);
+
+	[Fact]
+	public void ArrayPropertyByNumericIndex_Second() =>
+		Deserialize("""{"items":[10,20,30]}""").Get<int>("items.1").Should().Be(20);
+
+	[Fact]
+	public void ArrayOfObjectsByIndex() =>
+		Deserialize("""{"hits":[{"name":"a"},{"name":"b"}]}""").Get<string>("hits.0.name").Should().Be("a");
+
+	[Fact]
+	public void ArrayOfObjectsByIndex_Second() =>
+		Deserialize("""{"hits":[{"name":"a"},{"name":"b"}]}""").Get<string>("hits.1.name").Should().Be("b");
+
+	// --- Bracket index syntax [N] ---
+
+	[Fact]
+	public void BracketIndex() =>
+		Deserialize("""{"items":[10,20,30]}""").Get<int>("items.[0]").Should().Be(10);
+
+	[Fact]
+	public void BracketIndex_Second() =>
+		Deserialize("""{"items":[10,20,30]}""").Get<int>("items.[2]").Should().Be(30);
+
+	[Fact]
+	public void BracketIndexOnNestedArrayOfObjects() =>
+		Deserialize("""{"hits":{"hits":[{"_source":{"name":"first"}},{"_source":{"name":"second"}}]}}""")
+			.Get<string>("hits.hits.[0]._source.name").Should().Be("first");
+
+	[Fact]
+	public void BracketIndexOnNestedArrayOfObjects_Last() =>
+		Deserialize("""{"hits":{"hits":[{"_source":{"name":"first"}},{"_source":{"name":"second"}}]}}""")
+			.Get<string>("hits.hits.[1]._source.name").Should().Be("second");
+
+	// --- [first()] and _first_ ---
+
+	[Fact]
+	public void BracketFirst() =>
+		Deserialize("""{"items":["a","b","c"]}""").Get<string>("items.[first()]").Should().Be("a");
+
+	[Fact]
+	public void UnderscoreFirst() =>
+		Deserialize("""{"items":["a","b","c"]}""").Get<string>("items._first_").Should().Be("a");
+
+	[Fact]
+	public void BracketFirstOnObjects() =>
+		Deserialize("""{"hits":{"hits":[{"_source":{"name":"first"}},{"_source":{"name":"second"}}]}}""")
+			.Get<string>("hits.hits.[first()]._source.name").Should().Be("first");
+
+	[Fact]
+	public void UnderscoreFirstOnObjects() =>
+		Deserialize("""{"hits":{"hits":[{"_source":{"name":"first"}},{"_source":{"name":"second"}}]}}""")
+			.Get<string>("hits.hits._first_._source.name").Should().Be("first");
+
+	// --- [last()] and _last_ ---
+
+	[Fact]
+	public void BracketLast() =>
+		Deserialize("""{"items":["a","b","c"]}""").Get<string>("items.[last()]").Should().Be("c");
+
+	[Fact]
+	public void UnderscoreLast() =>
+		Deserialize("""{"items":["a","b","c"]}""").Get<string>("items._last_").Should().Be("c");
+
+	[Fact]
+	public void BracketLastOnObjects() =>
+		Deserialize("""{"hits":{"hits":[{"_source":{"name":"first"}},{"_source":{"name":"second"}}]}}""")
+			.Get<string>("hits.hits.[last()]._source.name").Should().Be("second");
+
+	[Fact]
+	public void UnderscoreLastOnObjects() =>
+		Deserialize("""{"hits":{"hits":[{"_source":{"name":"first"}},{"_source":{"name":"second"}}]}}""")
+			.Get<string>("hits.hits._last_._source.name").Should().Be("second");
+
+	// --- Deep nesting: objects containing arrays containing objects ---
+
+	[Fact]
+	public void DeepNesting() =>
+		Deserialize("""{"response":{"data":{"items":[{"sub":{"value":42}}]}}}""")
+			.Get<int>("response.data.items.0.sub.value").Should().Be(42);
+
+	[Fact]
+	public void DeepNestingWithBrackets() =>
+		Deserialize("""{"response":{"data":{"items":[{"sub":{"value":42}}]}}}""")
+			.Get<int>("response.data.items.[0].sub.value").Should().Be(42);
+
+	// --- _arbitrary_key_ ---
+
+	[Fact]
+	public void ArbitraryKeyTraversesIntoFirstKey() =>
+		Deserialize("""{"data":{"some_key":{"value":1}}}""")
+			.Get<int>("data._arbitrary_key_.value").Should().Be(1);
+
+	[Fact]
+	public void ArbitraryKeyReturnsKeyName() =>
+		Deserialize("""{"data":{"first_key":"v1","second_key":"v2"}}""")
+			.Get<string>("data._arbitrary_key_").Should().NotBeNull();
+
+	// --- Edge cases ---
+
+	[Fact]
+	public void MissingPath() =>
+		Deserialize("""{"a":1}""").Get<string>("b").Should().BeNull();
+
+	[Fact]
+	public void DeepMissingPath() =>
+		Deserialize("""{"a":{"b":1}}""").Get<string>("a.c.d").Should().BeNull();
+
+	[Fact]
+	public void NullPath() =>
+		Deserialize("""{"a":1}""").Get<string>(null).Should().BeNull();
+
+	[Fact]
+	public void EmptyObject() =>
+		Deserialize("""{}""").Get<string>("a").Should().BeNull();
+
+	[Fact]
+	public void OutOfBoundsIndex() =>
+		Deserialize("""{"items":[1]}""").Get<int>("items.99").Should().Be(0);
+
+	[Fact]
+	public void OutOfBoundsFirstOnEmpty()
+	{
+		// _first_ on empty array returns NullValue
+		var result = Deserialize("""{"items":[]}""").Get<string>("items._first_");
+		result.Should().BeNull();
+	}
+
+	[Fact]
+	public void OutOfBoundsLastOnEmpty()
+	{
+		var result = Deserialize("""{"items":[]}""").Get<string>("items._last_");
+		result.Should().BeNull();
+	}
+
+	// --- Type conversions ---
+
+	[Fact]
+	public void IntAsLong() =>
+		Deserialize("""{"v":42}""").Get<long>("v").Should().Be(42L);
+
+	[Fact]
+	public void DoubleAsFloat() =>
+		Deserialize("""{"v":3.14}""").Get<float>("v").Should().BeApproximately(3.14f, 0.001f);
+
+	[Fact]
+	public void DateTimeParsing() =>
+		Deserialize("""{"d":"2024-01-15T10:30:00Z"}""").Get<DateTime>("d").Should().Be(new DateTime(2024, 1, 15, 10, 30, 0, DateTimeKind.Utc));
+
+	// --- Root-level array ---
+
+	[Fact]
+	public void RootLevelArrayByIndex() =>
+		Deserialize("""[{"name":"a"},{"name":"b"}]""").Get<string>("0.name").Should().Be("a");
+
+	[Fact]
+	public void RootLevelArraySecondElement() =>
+		Deserialize("""[{"name":"a"},{"name":"b"}]""").Get<string>("1.name").Should().Be("b");
+}

--- a/tests/Elastic.Transport.Tests/Responses/Json/JsonResponseTests.cs
+++ b/tests/Elastic.Transport.Tests/Responses/Json/JsonResponseTests.cs
@@ -1,0 +1,225 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.IO;
+using System.Text;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+
+namespace Elastic.Transport.Tests.Responses.Json;
+
+public class JsonResponseTests
+{
+	// --- Builder tests ---
+
+	[Fact]
+	public async Task Builder_JsonContent()
+	{
+		IResponseBuilder sut = new JsonResponseBuilder();
+		var config = new TransportConfiguration();
+		var apiCallDetails = new ApiCallDetails();
+		var boundConfiguration = new BoundConfiguration(config);
+
+		var data = Encoding.UTF8.GetBytes("""{"_index":"my-index","_id":"1","found":true}""");
+		var stream = new MemoryStream(data);
+
+		var result = await sut.BuildAsync<JsonResponse>(apiCallDetails, boundConfiguration, stream, BoundConfiguration.DefaultContentType, data.Length);
+		result.Get<string>("_index").Should().Be("my-index");
+		result.Get<bool>("found").Should().BeTrue();
+
+		stream.Position = 0;
+
+		result = sut.Build<JsonResponse>(apiCallDetails, boundConfiguration, stream, BoundConfiguration.DefaultContentType, data.Length);
+		result.Get<string>("_index").Should().Be("my-index");
+	}
+
+	[Fact]
+	public async Task Builder_NonJsonContent()
+	{
+		IResponseBuilder sut = new JsonResponseBuilder();
+		var config = new TransportConfiguration();
+		var apiCallDetails = new ApiCallDetails();
+		var boundConfiguration = new BoundConfiguration(config);
+
+		var data = Encoding.UTF8.GetBytes("This is not JSON");
+		var stream = new MemoryStream(data);
+
+		var result = await sut.BuildAsync<JsonResponse>(apiCallDetails, boundConfiguration, stream, "text/plain", data.Length);
+		result.Get<string>("body").Should().Be("This is not JSON");
+
+		stream.Position = 0;
+
+		result = sut.Build<JsonResponse>(apiCallDetails, boundConfiguration, stream, "text/plain", data.Length);
+		result.Get<string>("body").Should().Be("This is not JSON");
+	}
+
+	// --- Direct DOM access ---
+
+	[Fact]
+	public void DirectDomAccess()
+	{
+		var node = JsonNode.Parse("""{"hits":{"total":42}}""");
+		var response = new JsonResponse(node);
+
+		response.Body["hits"]["total"].GetValue<int>().Should().Be(42);
+	}
+
+	[Fact]
+	public void DirectDomAccess_Array()
+	{
+		var node = JsonNode.Parse("""{"items":["a","b","c"]}""");
+		var response = new JsonResponse(node);
+
+		response.Body["items"][0].GetValue<string>().Should().Be("a");
+		response.Body["items"][2].GetValue<string>().Should().Be("c");
+	}
+
+	// --- Get<T> path traversal ---
+
+	[Fact]
+	public void FlatString()
+	{
+		var response = new JsonResponse(JsonNode.Parse("""{"name":"hello"}"""));
+		response.Get<string>("name").Should().Be("hello");
+	}
+
+	[Fact]
+	public void FlatInt()
+	{
+		var response = new JsonResponse(JsonNode.Parse("""{"count":42}"""));
+		response.Get<int>("count").Should().Be(42);
+	}
+
+	[Fact]
+	public void FlatLong()
+	{
+		var response = new JsonResponse(JsonNode.Parse("""{"big":9999999999}"""));
+		response.Get<long>("big").Should().Be(9999999999L);
+	}
+
+	[Fact]
+	public void FlatDouble()
+	{
+		var response = new JsonResponse(JsonNode.Parse("""{"pi":3.14}"""));
+		response.Get<double>("pi").Should().BeApproximately(3.14, 0.001);
+	}
+
+	[Fact]
+	public void FlatBool()
+	{
+		var response = new JsonResponse(JsonNode.Parse("""{"flag":true}"""));
+		response.Get<bool>("flag").Should().BeTrue();
+	}
+
+	[Fact]
+	public void NestedPath()
+	{
+		var response = new JsonResponse(JsonNode.Parse("""{"a":{"b":{"c":"deep"}}}"""));
+		response.Get<string>("a.b.c").Should().Be("deep");
+	}
+
+	[Fact]
+	public void ArrayByNumericIndex()
+	{
+		var response = new JsonResponse(JsonNode.Parse("""{"items":[10,20,30]}"""));
+		response.Get<int>("items.0").Should().Be(10);
+		response.Get<int>("items.2").Should().Be(30);
+	}
+
+	[Fact]
+	public void ArrayOfObjectsByIndex()
+	{
+		var response = new JsonResponse(JsonNode.Parse("""{"hits":[{"name":"a"},{"name":"b"}]}"""));
+		response.Get<string>("hits.0.name").Should().Be("a");
+		response.Get<string>("hits.1.name").Should().Be("b");
+	}
+
+	[Fact]
+	public void BracketIndex()
+	{
+		var response = new JsonResponse(JsonNode.Parse("""{"items":[10,20,30]}"""));
+		response.Get<int>("items.[0]").Should().Be(10);
+		response.Get<int>("items.[2]").Should().Be(30);
+	}
+
+	[Fact]
+	public void BracketFirst()
+	{
+		var response = new JsonResponse(JsonNode.Parse("""{"items":["a","b","c"]}"""));
+		response.Get<string>("items.[first()]").Should().Be("a");
+	}
+
+	[Fact]
+	public void UnderscoreFirst()
+	{
+		var response = new JsonResponse(JsonNode.Parse("""{"items":["a","b","c"]}"""));
+		response.Get<string>("items._first_").Should().Be("a");
+	}
+
+	[Fact]
+	public void BracketLast()
+	{
+		var response = new JsonResponse(JsonNode.Parse("""{"items":["a","b","c"]}"""));
+		response.Get<string>("items.[last()]").Should().Be("c");
+	}
+
+	[Fact]
+	public void UnderscoreLast()
+	{
+		var response = new JsonResponse(JsonNode.Parse("""{"items":["a","b","c"]}"""));
+		response.Get<string>("items._last_").Should().Be("c");
+	}
+
+	[Fact]
+	public void DeepNestedWithArrays()
+	{
+		var response = new JsonResponse(JsonNode.Parse("""{"hits":{"hits":[{"_source":{"name":"first"}},{"_source":{"name":"second"}}]}}"""));
+		response.Get<string>("hits.hits.[0]._source.name").Should().Be("first");
+		response.Get<string>("hits.hits.[last()]._source.name").Should().Be("second");
+	}
+
+	[Fact]
+	public void ArbitraryKey_TraversesIntoFirstKey()
+	{
+		var response = new JsonResponse(JsonNode.Parse("""{"data":{"some_key":{"value":1}}}"""));
+		response.Get<int>("data._arbitrary_key_.value").Should().Be(1);
+	}
+
+	[Fact]
+	public void ArbitraryKey_ReturnsKeyName()
+	{
+		var response = new JsonResponse(JsonNode.Parse("""{"data":{"first_key":"v1","second_key":"v2"}}"""));
+		response.Get<string>("data._arbitrary_key_").Should().NotBeNull();
+	}
+
+	[Fact]
+	public void MissingPath() =>
+		new JsonResponse(JsonNode.Parse("""{"a":1}""")).Get<string>("b").Should().BeNull();
+
+	[Fact]
+	public void NullPath() =>
+		new JsonResponse(JsonNode.Parse("""{"a":1}""")).Get<string>(null).Should().BeNull();
+
+	[Fact]
+	public void NullBody() =>
+		new JsonResponse(null).Get<string>("a").Should().BeNull();
+
+	[Fact]
+	public void OutOfBoundsIndex() =>
+		new JsonResponse(JsonNode.Parse("""{"items":[1]}""")).Get<int>("items.99").Should().Be(0);
+
+	[Fact]
+	public void NumberAsString() =>
+		new JsonResponse(JsonNode.Parse("""{"v":42}""")).Get<string>("v").Should().Be("42");
+
+	[Fact]
+	public void DateTimeParsing()
+	{
+		var response = new JsonResponse(JsonNode.Parse("""{"d":"2024-01-15T10:30:00Z"}"""));
+		response.Get<DateTime>("d").Should().Be(new DateTime(2024, 1, 15, 10, 30, 0, DateTimeKind.Utc));
+	}
+}


### PR DESCRIPTION
## Summary

- **New `JsonResponse` type** backed by `System.Text.Json`'s `JsonNode` DOM, providing
  direct DOM access (`response.Body["hits"]["hits"][0]`) and the same `Get<T>(path)`
  safe traversal syntax as `DynamicResponse` for easy, type-safe value extraction.
  Fully AOT-safe — uses `JsonNode.Parse` with no custom converters.
- **Enhanced array access syntax** in `DynamicDictionary.Get<T>` path traversal:
  bracket index (`items.[0]`), `[first()]`/`_first_`, `[last()]`/`_last_`.
  Plain numeric segments (`items.0`) continue to work as before.
- **Fixed `_arbitrary_key_`** to work correctly when underlying values are `JsonElement`
  objects (previously threw `KeyNotFoundException`).
- **Comprehensive test coverage**: 69 new tests across `DynamicDictionaryGetTests` and
  `JsonResponseTests` covering primitives, nested paths, array access patterns, edge cases,
  and builder behavior.
- **AOT smoke tests** in the example project for both `DynamicResponse` and `JsonResponse`
  using inline JSON (no server needed).

## New files

- `src/Elastic.Transport/Responses/Json/JsonResponse.cs`
- `src/Elastic.Transport/Responses/Json/JsonResponseBuilder.cs`
- `src/Elastic.Transport/Responses/Json/JsonNodePathTraversal.cs`
- `tests/Elastic.Transport.Tests/Responses/Dynamic/DynamicDictionaryGetTests.cs`
- `tests/Elastic.Transport.Tests/Responses/Json/JsonResponseTests.cs`
