### PR TITLE
Fix REST API compatibility headers when overriding Accept or Content-Type

### DIFF
--- a/src/Elastic.Transport/Components/Pipeline/BoundConfiguration.cs
+++ b/src/Elastic.Transport/Components/Pipeline/BoundConfiguration.cs
@@ -48,8 +48,8 @@ public sealed record BoundConfiguration : IRequestConfiguration
 		DisablePings = global.DisablePings ?? !global.NodePool.SupportsPinging;
 		HttpPipeliningEnabled = local?.HttpPipeliningEnabled ?? global.HttpPipeliningEnabled ?? true;
 		HttpCompression = global.EnableHttpCompression ?? local?.EnableHttpCompression ?? true;
-		ContentType = local?.ContentType ?? global.Accept ?? DefaultContentType;
-		Accept = local?.Accept ?? global.Accept ?? DefaultContentType;
+		ContentType = global.ProductRegistration.TransformContentType(local?.ContentType ?? global.Accept ?? DefaultContentType)!;
+		Accept = global.ProductRegistration.TransformContentType(local?.Accept ?? global.Accept ?? DefaultContentType)!;
 		ThrowExceptions = local?.ThrowExceptions ?? global.ThrowExceptions ?? false;
 		RequestTimeout = local?.RequestTimeout ?? global.RequestTimeout ?? RequestConfiguration.DefaultRequestTimeout;
 		RequestMetaData = local?.RequestMetaData;

--- a/src/Elastic.Transport/Products/Elasticsearch/ElasticsearchProductRegistration.cs
+++ b/src/Elastic.Transport/Products/Elasticsearch/ElasticsearchProductRegistration.cs
@@ -3,12 +3,14 @@
 // See the LICENSE file in the project root for more information
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Elastic.Transport.Diagnostics;
@@ -20,12 +22,24 @@ namespace Elastic.Transport.Products.Elasticsearch;
 /// for Elasticsearch so that <see cref="RequestPipeline"/> knows how to ping and sniff if we setup
 /// <see cref="ITransport{TConfiguration}"/> to talk to Elasticsearch
 /// </summary>
-public class ElasticsearchProductRegistration : ProductRegistration
+public partial class ElasticsearchProductRegistration : ProductRegistration
 {
 	internal const string XFoundHandlingClusterHeader = "X-Found-Handling-Cluster";
 	internal const string XFoundHandlingInstanceHeader = "X-Found-Handling-Instance";
 
+#if NET7_0_OR_GREATER
+	[GeneratedRegex(@"application/vnd\.elasticsearch\+(json|x-ndjson|vnd\.mapbox-vector-tile)", RegexOptions.IgnoreCase)]
+	private static partial Regex VendorMimeRegex();
+
+	private static readonly Regex _vendorMimeRegex = VendorMimeRegex();
+#else
+	private static readonly Regex _vendorMimeRegex = new(
+		@"application/vnd\.elasticsearch\+(json|x-ndjson|vnd\.mapbox-vector-tile)",
+		RegexOptions.Compiled | RegexOptions.IgnoreCase);
+#endif
+
 	private readonly int? _clientMajorVersion;
+	private readonly ConcurrentDictionary<string, string>? _contentTypeCache;
 
 	private static string? _clusterName;
 	private static readonly string[] _all = [XFoundHandlingClusterHeader, XFoundHandlingInstanceHeader];
@@ -56,7 +70,10 @@ public class ElasticsearchProductRegistration : ProductRegistration
 		// Only set this if we have a version.
 		// If we don't have a version we won't apply the vendor-based REST API compatibility Accept header.
 		if (clientVersionInfo.Major > 0)
+		{
 			_clientMajorVersion = clientVersionInfo.Major;
+			_contentTypeCache = new ConcurrentDictionary<string, string>(StringComparer.Ordinal);
+		}
 
 		ProductAssemblyVersion = markerType.Assembly
 			.GetCustomAttribute<AssemblyInformationalVersionAttribute>()
@@ -85,7 +102,43 @@ public class ElasticsearchProductRegistration : ProductRegistration
 	public override MetaHeaderProvider MetaHeaderProvider { get; }
 
 	/// <inheritdoc cref="ProductRegistration.DefaultContentType"/>
-	public override string? DefaultContentType => _clientMajorVersion.HasValue ? $"application/vnd.elasticsearch+json;compatible-with={_clientMajorVersion.Value}" : null;
+	/// <remarks>
+	/// Always returns the bare vendor MIME type. The <c>;compatible-with=N</c>
+	/// suffix is appended by <see cref="TransformContentType"/> when the value is
+	/// bound onto a request — but only when a client major version is known, so
+	/// the suffix is omitted for the parameterless registration.
+	/// </remarks>
+	public override string? DefaultContentType => "application/vnd.elasticsearch+json";
+
+	/// <inheritdoc cref="ProductRegistration.TransformContentType"/>
+	/// <remarks>
+	/// Appends <c>;compatible-with=N</c> to a supported vendor MIME type
+	/// (<c>application/vnd.elasticsearch+json</c>, <c>+x-ndjson</c>, or
+	/// <c>+vnd.mapbox-vector-tile</c>) when the parameter is not already present.
+	/// Plain MIME types like <c>application/json</c> are returned unchanged so the
+	/// caller stays in control of the value they explicitly provided.
+	/// </remarks>
+	public override string? TransformContentType(string? contentType)
+	{
+		if (string.IsNullOrEmpty(contentType) || !_clientMajorVersion.HasValue)
+			return contentType;
+
+		return _contentTypeCache!.GetOrAdd(contentType!, AppendCompatibleWithAnnotation);
+	}
+
+	private string AppendCompatibleWithAnnotation(string input)
+	{
+		// If a compatible-with parameter is already present anywhere in the
+		// value, treat it as user-controlled and leave it alone.
+		if (input.IndexOf("compatible-with=", StringComparison.OrdinalIgnoreCase) >= 0)
+			return input;
+
+		// If no supported vendor MIME type is present, nothing to do.
+		if (!_vendorMimeRegex.IsMatch(input))
+			return input;
+
+		return _vendorMimeRegex.Replace(input, $"$0;compatible-with={_clientMajorVersion!.Value}");
+	}
 
 	/// <summary> Exposes the path used for sniffing in Elasticsearch </summary>
 	public const string SniffPath = "_nodes/http,settings";

--- a/src/Elastic.Transport/Products/ProductRegistration.cs
+++ b/src/Elastic.Transport/Products/ProductRegistration.cs
@@ -30,6 +30,15 @@ public abstract class ProductRegistration
 	public abstract string? DefaultContentType { get; }
 
 	/// <summary>
+	/// Allows the product registration to rewrite the MIME type used in the
+	/// <c>Accept</c> and <c>Content-Type</c> request headers. The default
+	/// implementation returns the input unchanged. Products such as Elasticsearch
+	/// override this to append a REST API compatibility annotation
+	/// (<c>;compatible-with=N</c>) to supported vendor MIME types when missing.
+	/// </summary>
+	public virtual string? TransformContentType(string? contentType) => contentType;
+
+	/// <summary>
 	/// The name of the current product utilizing <see cref="ITransport{TConfiguration}"/>
 	/// <para>This name makes its way into the transport diagnostics sources and the default user agent string</para>
 	/// </summary>

--- a/tests/Elastic.Transport.IntegrationTests/Http/ApiCompatibilityHeaderTests.cs
+++ b/tests/Elastic.Transport.IntegrationTests/Http/ApiCompatibilityHeaderTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information
 
 using System.Linq;
+using System.Net.Http;
 using System.Threading.Tasks;
 using Elastic.Transport.IntegrationTests.Plumbing;
 using Elastic.Transport.IntegrationTests.Plumbing.Stubs;
@@ -15,6 +16,8 @@ namespace Elastic.Transport.IntegrationTests.Http;
 
 public class ApiCompatibilityHeaderTests(TestServerFixture instance) : AssemblyServerTestsBase(instance)
 {
+	private const string DefaultVendorMime = "application/vnd.elasticsearch+json;compatible-with=8";
+
 	[Fact]
 	public async Task AddsExpectedVendorInformationForRestApiCompaitbility()
 	{
@@ -25,18 +28,156 @@ public class ApiCompatibilityHeaderTests(TestServerFixture instance) : AssemblyS
 			_ = parameter.Name.Should().Be("compatible-with");
 			_ = parameter.Value.Should().Be("8");
 
-			var acceptValues = responseMessage.RequestMessage.Headers.GetValues("Accept");
-			_ = acceptValues.Single().Replace(" ", "").Should().Be("application/vnd.elasticsearch+json;compatible-with=8");
-
-			var contentTypeValues = responseMessage.RequestMessage.Content.Headers.GetValues("Content-Type");
-			_ = contentTypeValues.Single().Replace(" ", "").Should().Be("application/vnd.elasticsearch+json;compatible-with=8");
+			AssertHeader(responseMessage, "Accept", DefaultVendorMime);
+			AssertContentTypeHeader(responseMessage, DefaultVendorMime);
 		});
 
+		await SendAsync(requestInvoker);
+	}
+
+	[Fact]
+	public async Task OverridingAcceptWithVendorMimeAppendsCompatibleWith()
+	{
+		var requestInvoker = new TrackingRequestInvoker(responseMessage =>
+		{
+			AssertHeader(responseMessage, "Accept", DefaultVendorMime);
+			AssertContentTypeHeader(responseMessage, DefaultVendorMime);
+		});
+
+		await SendAsync(requestInvoker, new RequestConfiguration { Accept = "application/vnd.elasticsearch+json" });
+	}
+
+	[Fact]
+	public async Task OverridingAcceptWithExplicitCompatibleWithIsRespected()
+	{
+		var requestInvoker = new TrackingRequestInvoker(responseMessage =>
+		{
+			AssertHeader(responseMessage, "Accept", "application/vnd.elasticsearch+json;compatible-with=9");
+			AssertContentTypeHeader(responseMessage, DefaultVendorMime);
+		});
+
+		await SendAsync(requestInvoker, new RequestConfiguration { Accept = "application/vnd.elasticsearch+json;compatible-with=9" });
+	}
+
+	[Fact]
+	public async Task OverridingAcceptWithPlainJsonIsLeftUnchanged()
+	{
+		var requestInvoker = new TrackingRequestInvoker(responseMessage =>
+		{
+			AssertHeader(responseMessage, "Accept", "application/json");
+			AssertContentTypeHeader(responseMessage, DefaultVendorMime);
+		});
+
+		await SendAsync(requestInvoker, new RequestConfiguration { Accept = "application/json" });
+	}
+
+	[Fact]
+	public async Task OverridingAcceptWithTextPlainIsLeftUnchanged()
+	{
+		var requestInvoker = new TrackingRequestInvoker(responseMessage =>
+		{
+			AssertHeader(responseMessage, "Accept", "text/plain");
+			AssertContentTypeHeader(responseMessage, DefaultVendorMime);
+		});
+
+		await SendAsync(requestInvoker, new RequestConfiguration { Accept = "text/plain" });
+	}
+
+	[Fact]
+	public async Task OverridingContentTypeWithVendorMimeAppendsCompatibleWith()
+	{
+		var requestInvoker = new TrackingRequestInvoker(responseMessage =>
+		{
+			AssertHeader(responseMessage, "Accept", DefaultVendorMime);
+			AssertContentTypeHeader(responseMessage, "application/vnd.elasticsearch+x-ndjson;compatible-with=8");
+		});
+
+		await SendAsync(requestInvoker, new RequestConfiguration { ContentType = "application/vnd.elasticsearch+x-ndjson" });
+	}
+
+	[Fact]
+	public async Task WithoutClientMajorVersionDefaultsToBareVendorMime()
+	{
+		var requestInvoker = new TrackingRequestInvoker(responseMessage =>
+		{
+			AssertHeader(responseMessage, "Accept", "application/vnd.elasticsearch+json");
+			AssertContentTypeHeader(responseMessage, "application/vnd.elasticsearch+json");
+		});
+
+		await SendWithDefaultRegistrationAsync(requestInvoker, requestConfiguration: null);
+	}
+
+	[Fact]
+	public async Task WithoutClientMajorVersionHeaderOverridesAreNotTransformed()
+	{
+		var requestInvoker = new TrackingRequestInvoker(responseMessage =>
+		{
+			AssertHeader(responseMessage, "Accept", "application/vnd.elasticsearch+json");
+			AssertContentTypeHeader(responseMessage, "application/vnd.elasticsearch+json");
+		});
+
+		await SendWithDefaultRegistrationAsync(
+			requestInvoker,
+			new RequestConfiguration { Accept = "application/vnd.elasticsearch+json", ContentType = "application/vnd.elasticsearch+json" });
+	}
+
+	private async Task SendWithDefaultRegistrationAsync(TrackingRequestInvoker requestInvoker, IRequestConfiguration requestConfiguration)
+	{
+		var nodePool = new SingleNodePool(Server.Uri);
+		var config = new TransportConfiguration(nodePool, requestInvoker, productRegistration: ElasticsearchProductRegistration.Default);
+		var transport = new DistributedTransport(config);
+
+		_ = await transport.RequestAsync<StringResponse>(
+			new EndpointPath(HttpMethod.POST, "/metaheader"),
+			PostData.String("{}"),
+			default,
+			requestConfiguration,
+			TestContext.Current.CancellationToken);
+	}
+
+	[Fact]
+	public async Task MultiValueAcceptListAppendsCompatibleWithToEachVendorEntry()
+	{
+		var requestInvoker = new TrackingRequestInvoker(responseMessage =>
+		{
+			AssertHeader(
+				responseMessage,
+				"Accept",
+				"application/vnd.elasticsearch+json;compatible-with=8,application/vnd.elasticsearch+x-ndjson;compatible-with=8");
+			AssertContentTypeHeader(responseMessage, DefaultVendorMime);
+		});
+
+		await SendAsync(
+			requestInvoker,
+			new RequestConfiguration { Accept = "application/vnd.elasticsearch+json,application/vnd.elasticsearch+x-ndjson" });
+	}
+
+	private Task SendAsync(TrackingRequestInvoker requestInvoker) => SendAsync(requestInvoker, null);
+
+	private async Task SendAsync(TrackingRequestInvoker requestInvoker, IRequestConfiguration requestConfiguration)
+	{
 		var nodePool = new SingleNodePool(Server.Uri);
 		var config = new TransportConfiguration(nodePool, requestInvoker, productRegistration: new ElasticsearchProductRegistration(typeof(Clients.Elasticsearch.ElasticsearchClient)));
 		var transport = new DistributedTransport(config);
 
-		var response = await transport.PostAsync<StringResponse>("/metaheader", PostData.String("{}"), cancellationToken: TestContext.Current.CancellationToken);
+		_ = await transport.RequestAsync<StringResponse>(
+			new EndpointPath(HttpMethod.POST, "/metaheader"),
+			PostData.String("{}"),
+			default,
+			requestConfiguration,
+			TestContext.Current.CancellationToken);
+	}
+
+	private static void AssertHeader(System.Net.Http.HttpResponseMessage responseMessage, string headerName, string expected)
+	{
+		var values = responseMessage.RequestMessage.Headers.GetValues(headerName);
+		_ = string.Join(",", values).Replace(" ", "").Should().Be(expected);
+	}
+
+	private static void AssertContentTypeHeader(System.Net.Http.HttpResponseMessage responseMessage, string expected)
+	{
+		var values = responseMessage.RequestMessage.Content.Headers.GetValues("Content-Type");
+		_ = string.Join(",", values).Replace(" ", "").Should().Be(expected);
 	}
 }
 


### PR DESCRIPTION
## Summary

Elasticsearch's REST API compatibility mode requires `Accept` and `Content-Type` to be in sync — either both carry the `;compatible-with=N` annotation or neither does. When a caller overrode `IRequestConfiguration.Accept` (or `ContentType`) the override flowed through `BoundConfiguration` verbatim while the other header still carried the annotation from the default, producing a mismatch that the server rejects (see https://github.com/elastic/elasticsearch-net/issues/8867).

## Approach

- Add a `TransformContentType` virtual on `ProductRegistration` (default identity).
- Override it in `ElasticsearchProductRegistration` to append `;compatible-with=N` to a supported vendor MIME type — `application/vnd.elasticsearch+(json|x-ndjson|vnd.mapbox-vector-tile)` — only when the parameter is not already present. Results are cached per-instance.
- `BoundConfiguration` runs both `Accept` and `ContentType` through the hook, so the default and override paths share the same logic.
- `DefaultContentType` always returns the bare vendor MIME (`application/vnd.elasticsearch+json`); the version suffix is appended by the transform when a client major version is known.

## Design notes (intentionally different from `elasticsearch-py`)

- Plain MIME types like `application/json` are **not** rewritten to vendor form. If the caller supplies a plain MIME, that intent is respected; keeping `Accept` and `Content-Type` in sync is the caller's responsibility.
- Consuming clients are expected to emit the vendor MIME (`application/vnd.elasticsearch+json`) without `;compatible-with=`. The transport adds the version suffix.
- A value that already contains `compatible-with=` is treated as user-controlled and left alone (including for explicit major-version overrides like `compatible-with=9`).
- Multi-value `Accept` lists are handled — every vendor MIME entry independently gains the suffix.