### PR TITLE
Align ThrowExceptions decision with ProductRegistration.IsValidResponse

### DIFF
--- a/src/Elastic.Transport/Components/Pipeline/RequestPipeline.cs
+++ b/src/Elastic.Transport/Components/Pipeline/RequestPipeline.cs
@@ -206,7 +206,7 @@ public class RequestPipeline
 	)
 		where TResponse : TransportResponse, new()
 	{
-		if (callDetails?.HasSuccessfulStatusCodeAndExpectedContentType ?? false)
+		if (_productRegistration.IsValidResponse(callDetails))
 			return null;
 
 		var pipelineFailure = callDetails?.HttpStatusCode != null ? PipelineFailure.BadResponse : PipelineFailure.BadRequest;

--- a/src/Elastic.Transport/Products/Elasticsearch/ElasticsearchProductRegistration.cs
+++ b/src/Elastic.Transport/Products/Elasticsearch/ElasticsearchProductRegistration.cs
@@ -111,10 +111,34 @@ public class ElasticsearchProductRegistration : ProductRegistration
 	/// We consider all status codes &gt;= 200 and &lt; 300 valid by default.
 	/// Elasticsearch might return 404 for valid responses in some cases (e.g. `GET /my-index/_doc/missing-doc-id`) but also for actual error cases like
 	/// missing endpoints, missing indices (e.g. `GET /missing-index/_mapping`), etc.
-	/// The 404 case is handled on a per-request basis (see <see cref="ElasticsearchResponseHelper.IsValidResponse"/> for details).
+	/// The 404 case is handled on a per-request basis (see <see cref="IsValidResponse(ApiCallDetails)"/> for details).
 	/// </remarks>
 	public override bool HttpStatusCodeClassifier(HttpMethod method, int statusCode) =>
 		statusCode is >= 200 and < 300;
+
+	/// <inheritdoc cref="ProductRegistration.IsValidResponse(ApiCallDetails)"/>
+	/// <remarks>
+	/// A response is valid when:
+	/// <list type="bullet">
+	/// <item>The content-type matches what the caller asked for.</item>
+	/// <item>For 404 responses: there is no extracted Elasticsearch server error
+	/// (404s without an error body — e.g. <c>GET /my-index/_doc/missing-doc-id</c> — represent
+	/// a legitimate "missing entity" rather than a failure).</item>
+	/// <item>Otherwise: the status code is in the success range (or explicitly allowed via
+	/// <see cref="IRequestConfiguration.AllowedStatusCodes"/>).</item>
+	/// </list>
+	/// </remarks>
+	public override bool IsValidResponse(ApiCallDetails? details)
+	{
+		if (details is null || !details.HasExpectedContentType)
+			return false;
+
+		var serverError = details.ProductError as ElasticsearchServerError;
+		if (details.HttpStatusCode is 404)
+			return !serverError?.HasError() ?? true;
+
+		return details.HasSuccessfulStatusCode;
+	}
 
 	/// <inheritdoc cref="ProductRegistration.TryGetServerErrorReason{TResponse}"/>>
 	public override bool TryGetServerErrorReason<TResponse>(TResponse response, out string? reason)

--- a/src/Elastic.Transport/Products/Elasticsearch/Responses/ElasticsearchDynamicResponse.cs
+++ b/src/Elastic.Transport/Products/Elasticsearch/Responses/ElasticsearchDynamicResponse.cs
@@ -24,7 +24,8 @@ public sealed class ElasticsearchDynamicResponse : DynamicResponseBase, IElastic
 	public ElasticsearchServerError? ElasticsearchServerError => ElasticsearchResponseHelper.GetElasticsearchError(ApiCallDetails);
 
 	/// <inheritdoc />
-	public bool IsValidResponse => ElasticsearchResponseHelper.IsValidResponse(ApiCallDetails);
+	public bool IsValidResponse =>
+		ApiCallDetails?.TransportConfiguration?.ProductRegistration?.IsValidResponse(ApiCallDetails) ?? false;
 
 	/// <inheritdoc />
 	public IEnumerable<string> ElasticsearchWarnings => ElasticsearchResponseHelper.GetElasticsearchWarnings(ApiCallDetails);

--- a/src/Elastic.Transport/Products/Elasticsearch/Responses/ElasticsearchJsonResponse.cs
+++ b/src/Elastic.Transport/Products/Elasticsearch/Responses/ElasticsearchJsonResponse.cs
@@ -25,7 +25,8 @@ public sealed class ElasticsearchJsonResponse : JsonResponseBase, IElasticsearch
 	public ElasticsearchServerError? ElasticsearchServerError => ElasticsearchResponseHelper.GetElasticsearchError(ApiCallDetails);
 
 	/// <inheritdoc />
-	public bool IsValidResponse => ElasticsearchResponseHelper.IsValidResponse(ApiCallDetails);
+	public bool IsValidResponse =>
+		ApiCallDetails?.TransportConfiguration?.ProductRegistration?.IsValidResponse(ApiCallDetails) ?? false;
 
 	/// <inheritdoc />
 	public IEnumerable<string> ElasticsearchWarnings => ElasticsearchResponseHelper.GetElasticsearchWarnings(ApiCallDetails);

--- a/src/Elastic.Transport/Products/Elasticsearch/Responses/ElasticsearchPipeResponse.cs
+++ b/src/Elastic.Transport/Products/Elasticsearch/Responses/ElasticsearchPipeResponse.cs
@@ -35,7 +35,8 @@ public sealed class ElasticsearchPipeResponse : PipeResponseBase, IElasticsearch
 	public ElasticsearchServerError? ElasticsearchServerError => ElasticsearchResponseHelper.GetElasticsearchError(ApiCallDetails);
 
 	/// <inheritdoc />
-	public bool IsValidResponse => ElasticsearchResponseHelper.IsValidResponse(ApiCallDetails);
+	public bool IsValidResponse =>
+		ApiCallDetails?.TransportConfiguration?.ProductRegistration?.IsValidResponse(ApiCallDetails) ?? false;
 
 	/// <inheritdoc />
 	public IEnumerable<string> ElasticsearchWarnings => ElasticsearchResponseHelper.GetElasticsearchWarnings(ApiCallDetails);

--- a/src/Elastic.Transport/Products/Elasticsearch/Responses/ElasticsearchResponse.cs
+++ b/src/Elastic.Transport/Products/Elasticsearch/Responses/ElasticsearchResponse.cs
@@ -27,7 +27,7 @@ public abstract class ElasticsearchResponse : TransportResponse, IElasticsearchR
 	/// <inheritdoc />
 	[JsonIgnore]
 	public virtual bool IsValidResponse =>
-		ElasticsearchResponseHelper.IsValidResponse(ApiCallDetails);
+		ApiCallDetails?.TransportConfiguration?.ProductRegistration?.IsValidResponse(ApiCallDetails) ?? false;
 
 	/// <inheritdoc />
 	[JsonIgnore]

--- a/src/Elastic.Transport/Products/Elasticsearch/Responses/ElasticsearchResponseHelper.cs
+++ b/src/Elastic.Transport/Products/Elasticsearch/Responses/ElasticsearchResponseHelper.cs
@@ -15,24 +15,6 @@ namespace Elastic.Transport.Products.Elasticsearch;
 /// </summary>
 internal static class ElasticsearchResponseHelper
 {
-	public static bool IsValidResponse(ApiCallDetails? apiCallDetails)
-	{
-		if (apiCallDetails is null || !apiCallDetails.HasExpectedContentType)
-			return false;
-
-		// Elasticsearch returns 404 for valid responses in some cases (e.g. `GET /my-index/_doc/missing-doc-id`) but also for actual error cases like
-		// missing endpoints, missing indices (e.g. `GET /missing-index/_mapping`), etc.
-		// We consider all status codes >= 200 and < 300 valid by default. For 404, we assume "invalid" and try to parse the Elasticsearch
-		// error response from the body.
-		// A 404 status code without an error body indicates a valid response.
-
-		var serverError = GetElasticsearchError(apiCallDetails);
-		if (apiCallDetails.HttpStatusCode is 404)
-			return !serverError?.HasError() ?? true;
-
-		return apiCallDetails.HasSuccessfulStatusCode;
-	}
-
 	public static ElasticsearchServerError? GetElasticsearchError(ApiCallDetails? apiCallDetails) =>
 		apiCallDetails?.ProductError as ElasticsearchServerError;
 

--- a/src/Elastic.Transport/Products/Elasticsearch/Responses/ElasticsearchStreamResponse.cs
+++ b/src/Elastic.Transport/Products/Elasticsearch/Responses/ElasticsearchStreamResponse.cs
@@ -33,7 +33,8 @@ public sealed class ElasticsearchStreamResponse : StreamResponseBase, IElasticse
 	public ElasticsearchServerError? ElasticsearchServerError => ElasticsearchResponseHelper.GetElasticsearchError(ApiCallDetails);
 
 	/// <inheritdoc />
-	public bool IsValidResponse => ElasticsearchResponseHelper.IsValidResponse(ApiCallDetails);
+	public bool IsValidResponse =>
+		ApiCallDetails?.TransportConfiguration?.ProductRegistration?.IsValidResponse(ApiCallDetails) ?? false;
 
 	/// <inheritdoc />
 	public IEnumerable<string> ElasticsearchWarnings => ElasticsearchResponseHelper.GetElasticsearchWarnings(ApiCallDetails);

--- a/src/Elastic.Transport/Products/Elasticsearch/Responses/ElasticsearchStringResponse.cs
+++ b/src/Elastic.Transport/Products/Elasticsearch/Responses/ElasticsearchStringResponse.cs
@@ -24,7 +24,8 @@ public sealed class ElasticsearchStringResponse : StringResponseBase, IElasticse
 	public ElasticsearchServerError? ElasticsearchServerError => ElasticsearchResponseHelper.GetElasticsearchError(ApiCallDetails);
 
 	/// <inheritdoc />
-	public bool IsValidResponse => ElasticsearchResponseHelper.IsValidResponse(ApiCallDetails);
+	public bool IsValidResponse =>
+		ApiCallDetails?.TransportConfiguration?.ProductRegistration?.IsValidResponse(ApiCallDetails) ?? false;
 
 	/// <inheritdoc />
 	public IEnumerable<string> ElasticsearchWarnings => ElasticsearchResponseHelper.GetElasticsearchWarnings(ApiCallDetails);

--- a/src/Elastic.Transport/Products/ProductRegistration.cs
+++ b/src/Elastic.Transport/Products/ProductRegistration.cs
@@ -162,4 +162,16 @@ public abstract class ProductRegistration
 	/// <param name="responseStream">A seekable stream containing the response body.</param>
 	/// <returns>An <see cref="ErrorResponse"/> if one was successfully extracted; otherwise <c>null</c>.</returns>
 	public virtual ErrorResponse? TryExtractError(BoundConfiguration boundConfiguration, Stream responseStream) => null;
+
+	/// <summary>
+	/// Whether the response should be treated as valid for the caller — meaning no exception is
+	/// raised under <see cref="IRequestConfiguration.ThrowExceptions"/>, and the product-level
+	/// <c>IsValidResponse</c> reads <c>true</c>.
+	/// <para>Default: a successful HTTP status code with the expected content type. Products override
+	/// to encode their own semantics (e.g. Elasticsearch treats a 404 with no extracted server error
+	/// as valid because it represents a missing entity rather than a true failure).</para>
+	/// </summary>
+	/// <param name="details">The <see cref="ApiCallDetails"/> for the response.</param>
+	public virtual bool IsValidResponse(ApiCallDetails? details) =>
+		details?.HasSuccessfulStatusCodeAndExpectedContentType ?? false;
 }

--- a/tests/Elastic.Transport.Tests/Products/ProductRegistrationIsValidResponseTests.cs
+++ b/tests/Elastic.Transport.Tests/Products/ProductRegistrationIsValidResponseTests.cs
@@ -1,0 +1,85 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using Elastic.Transport.Products;
+using Elastic.Transport.Products.Elasticsearch;
+using FluentAssertions;
+using Xunit;
+
+namespace Elastic.Transport.Tests.Products;
+
+public class ProductRegistrationIsValidResponseTests
+{
+	[Fact]
+	public void DefaultRegistrationReturnsFalseForNullDetails() =>
+		DefaultProductRegistration.Default.IsValidResponse(null).Should().BeFalse();
+
+	[Fact]
+	public void DefaultRegistrationReturnsTrueForSuccessAndExpectedContentType() =>
+		DefaultProductRegistration.Default
+			.IsValidResponse(MakeDetails(200, hasSuccess: true))
+			.Should().BeTrue();
+
+	[Fact]
+	public void DefaultRegistrationReturnsFalseForNonSuccess() =>
+		DefaultProductRegistration.Default
+			.IsValidResponse(MakeDetails(404, hasSuccess: false))
+			.Should().BeFalse();
+
+	[Fact]
+	public void DefaultRegistrationReturnsFalseForUnexpectedContentType()
+	{
+		var details = MakeDetails(200, hasSuccess: true);
+		details.HasExpectedContentType = false;
+		DefaultProductRegistration.Default.IsValidResponse(details).Should().BeFalse();
+	}
+
+	[Fact]
+	public void ElasticsearchReturnsTrueFor404WithNoExtractedServerError() =>
+		ElasticsearchProductRegistration.Default
+			.IsValidResponse(MakeDetails(404, hasSuccess: false))
+			.Should().BeTrue();
+
+	[Fact]
+	public void ElasticsearchReturnsFalseFor404WithExtractedServerError()
+	{
+		var details = MakeDetails(404, hasSuccess: false);
+		details.ProductError = new ElasticsearchServerError(
+			new Error { Type = "index_not_found_exception", Reason = "no such index" },
+			statusCode: 404);
+		ElasticsearchProductRegistration.Default.IsValidResponse(details).Should().BeFalse();
+	}
+
+	[Fact]
+	public void ElasticsearchReturnsFalseFor500WithExtractedServerError()
+	{
+		var details = MakeDetails(500, hasSuccess: false);
+		details.ProductError = new ElasticsearchServerError(
+			new Error { Type = "internal", Reason = "boom" },
+			statusCode: 500);
+		ElasticsearchProductRegistration.Default.IsValidResponse(details).Should().BeFalse();
+	}
+
+	[Fact]
+	public void ElasticsearchReturnsTrueForSuccess() =>
+		ElasticsearchProductRegistration.Default
+			.IsValidResponse(MakeDetails(200, hasSuccess: true))
+			.Should().BeTrue();
+
+	[Fact]
+	public void ElasticsearchReturnsFalseFor404WithUnexpectedContentType()
+	{
+		var details = MakeDetails(404, hasSuccess: false);
+		details.HasExpectedContentType = false;
+		ElasticsearchProductRegistration.Default.IsValidResponse(details).Should().BeFalse();
+	}
+
+	private static ApiCallDetails MakeDetails(int statusCode, bool hasSuccess) =>
+		new()
+		{
+			HttpStatusCode = statusCode,
+			HasSuccessfulStatusCode = hasSuccess,
+			HasExpectedContentType = true,
+		};
+}


### PR DESCRIPTION
## Summary

The throw decision in `RequestPipeline.CreateClientException` previously used `HasSuccessfulStatusCodeAndExpectedContentType`, which doesn't account for product-specific semantics like Elasticsearch's "404 with no extracted server error is a valid missing-entity response". This PR moves the predicate into a new virtual on `ProductRegistration` so each product encodes its own semantics, and consults it from both the throw path and the per-response `IsValidResponse` properties — single source of truth.

`ElasticsearchProductRegistration.IsValidResponse` now carries the verbatim logic that lived in the static `ElasticsearchResponseHelper.IsValidResponse` (now removed); the response-level `IsValidResponse` properties on the six Elasticsearch response types read it through `ApiCallDetails.TransportConfiguration.ProductRegistration`. The default `ProductRegistration.IsValidResponse` keeps the previous transport behavior (`HasSuccessfulStatusCodeAndExpectedContentType`) so non-product calls are unchanged.

Fixes #206. Pairs with the corresponding removal of `ElasticsearchClientProductRegistration` overrides in `elasticsearch-net`.

## What changed

- New `public virtual bool IsValidResponse(ApiCallDetails?)` on `ProductRegistration`. Default: `details?.HasSuccessfulStatusCodeAndExpectedContentType ?? false`.
- `ElasticsearchProductRegistration.IsValidResponse` override carries the verbatim 404-lenient logic moved from the helper.
- `RequestPipeline.CreateClientException` consults `_productRegistration.IsValidResponse(callDetails)` instead of the previous predicate.
- Six Elasticsearch response types (`ElasticsearchResponse`, `ElasticsearchDynamicResponse`, `ElasticsearchJsonResponse`, `ElasticsearchPipeResponse`, `ElasticsearchStreamResponse`, `ElasticsearchStringResponse`) read the predicate via `ApiCallDetails.TransportConfiguration.ProductRegistration`.
- `ElasticsearchResponseHelper.IsValidResponse(ApiCallDetails?)` deleted; the four other helpers stay.

## Behavior change

Under `ThrowExceptions=true`:

- Real-error 4xx/5xx still throw (unchanged for non-Elasticsearch users; newly correct for Elasticsearch users where the now-removed client-side `HttpStatusCodeClassifier` override had been suppressing throws on real-error 404s).
- Valid 404s — e.g. `client.GetAsync<MyDoc>(idx, missing-id)` returning `{"_index":"…","_id":"…","found":false}` — no longer throw and instead return a response with `IsValidResponse=true` and `Found=false`.

Under the default `ThrowExceptions=false`, behavior is unchanged.

## Tests

`tests/Elastic.Transport.Tests/Products/ProductRegistrationIsValidResponseTests.cs` — nine focused tests covering `DefaultProductRegistration` and `ElasticsearchProductRegistration` across 200/404/500 with/without extracted `ProductError` and with/without expected content type.