### PR TITLE
Move response Content-Type validation onto ProductRegistration; broaden vendor MIME match

### DIFF
--- a/src/Elastic.Transport/Products/Elasticsearch/ElasticsearchProductRegistration.cs
+++ b/src/Elastic.Transport/Products/Elasticsearch/ElasticsearchProductRegistration.cs
@@ -28,13 +28,13 @@ public partial class ElasticsearchProductRegistration : ProductRegistration
 	internal const string XFoundHandlingInstanceHeader = "X-Found-Handling-Instance";
 
 #if NET7_0_OR_GREATER
-	[GeneratedRegex(@"application/vnd\.elasticsearch\+(json|x-ndjson|vnd\.mapbox-vector-tile)", RegexOptions.IgnoreCase)]
+	[GeneratedRegex(@"application/vnd\.elasticsearch\+([A-Za-z0-9.\-+]+)", RegexOptions.IgnoreCase)]
 	private static partial Regex VendorMimeRegex();
 
 	private static readonly Regex _vendorMimeRegex = VendorMimeRegex();
 #else
 	private static readonly Regex _vendorMimeRegex = new(
-		@"application/vnd\.elasticsearch\+(json|x-ndjson|vnd\.mapbox-vector-tile)",
+		@"application/vnd\.elasticsearch\+([A-Za-z0-9.\-+]+)",
 		RegexOptions.Compiled | RegexOptions.IgnoreCase);
 #endif
 
@@ -112,11 +112,12 @@ public partial class ElasticsearchProductRegistration : ProductRegistration
 
 	/// <inheritdoc cref="ProductRegistration.TransformContentType"/>
 	/// <remarks>
-	/// Appends <c>;compatible-with=N</c> to a supported vendor MIME type
-	/// (<c>application/vnd.elasticsearch+json</c>, <c>+x-ndjson</c>, or
-	/// <c>+vnd.mapbox-vector-tile</c>) when the parameter is not already present.
-	/// Plain MIME types like <c>application/json</c> are returned unchanged so the
-	/// caller stays in control of the value they explicitly provided.
+	/// Appends <c>;compatible-with=N</c> to any <c>application/vnd.elasticsearch+SUBTYPE</c>
+	/// MIME type (e.g. <c>+json</c>, <c>+x-ndjson</c>, <c>+vnd.mapbox-vector-tile</c>)
+	/// when the parameter is not already present. Plain or third-party vendor MIME
+	/// types (<c>application/json</c>, <c>application/vnd.mapbox-vector-tile</c>, …)
+	/// are returned unchanged — appending a compatibility annotation to them is the
+	/// caller's responsibility.
 	/// </remarks>
 	public override string? TransformContentType(string? contentType)
 	{
@@ -138,6 +139,70 @@ public partial class ElasticsearchProductRegistration : ProductRegistration
 			return input;
 
 		return _vendorMimeRegex.Replace(input, $"$0;compatible-with={_clientMajorVersion!.Value}");
+	}
+
+	/// <inheritdoc cref="ProductRegistration.IsExpectedResponseContentType"/>
+	/// <remarks>
+	/// Extends the default rule with vendor-MIME equivalence: when the request's
+	/// <c>Accept</c> is <c>application/vnd.elasticsearch+SUBTYPE[;…]</c>, a response
+	/// is also accepted if its <c>Content-Type</c> matches the bare vendor form
+	/// (<c>application/vnd.elasticsearch+SUBTYPE</c>) or the bare form
+	/// (<c>application/SUBTYPE</c>) — Elasticsearch frequently omits the
+	/// <c>;compatible-with=N</c> annotation in responses (e.g. on 404, EQL, MVT)
+	/// and may strip the <c>vnd.elasticsearch+</c> wrapper too. Multi-value
+	/// <c>Accept</c> lists are checked entry-by-entry.
+	/// </remarks>
+	public override bool IsExpectedResponseContentType(string accept, string? responseContentType)
+	{
+		if (base.IsExpectedResponseContentType(accept, responseContentType))
+			return true;
+
+		if (string.IsNullOrEmpty(responseContentType))
+			return false;
+
+		var normalized = responseContentType!.Replace(" ", "");
+
+		foreach (var entry in accept.Split(','))
+		{
+			var trimmedEntry = entry.Replace(" ", "");
+			if (!TryParseElasticsearchVendorMime(trimmedEntry, out var bareVendor, out var bareForm))
+				continue;
+
+			if (normalized.Equals(bareVendor, StringComparison.OrdinalIgnoreCase)
+				|| normalized.StartsWith(bareVendor, StringComparison.OrdinalIgnoreCase)
+				|| normalized.Equals(bareForm, StringComparison.OrdinalIgnoreCase)
+				|| normalized.StartsWith(bareForm, StringComparison.OrdinalIgnoreCase))
+				return true;
+		}
+
+		return false;
+	}
+
+	private static bool TryParseElasticsearchVendorMime(string mime, out string bareVendor, out string bareForm)
+	{
+		const string prefix = "application/vnd.elasticsearch+";
+		if (!mime.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+		{
+			bareVendor = string.Empty;
+			bareForm = string.Empty;
+			return false;
+		}
+
+		var afterPlus = mime.AsSpan(prefix.Length);
+		var endIdx = afterPlus.IndexOfAny(';', ',');
+		var subtypeSpan = endIdx < 0 ? afterPlus : afterPlus[..endIdx];
+
+		if (subtypeSpan.Length == 0)
+		{
+			bareVendor = string.Empty;
+			bareForm = string.Empty;
+			return false;
+		}
+
+		var subtype = subtypeSpan.ToString();
+		bareVendor = prefix + subtype;
+		bareForm = "application/" + subtype;
+		return true;
 	}
 
 	/// <summary> Exposes the path used for sniffing in Elasticsearch </summary>

--- a/src/Elastic.Transport/Products/ProductRegistration.cs
+++ b/src/Elastic.Transport/Products/ProductRegistration.cs
@@ -39,6 +39,31 @@ public abstract class ProductRegistration
 	public virtual string? TransformContentType(string? contentType) => contentType;
 
 	/// <summary>
+	/// Decides whether a response <c>Content-Type</c> is acceptable given the
+	/// request's <c>Accept</c>. The default accepts an exact (case-insensitive)
+	/// match or a response Content-Type that starts with the Accept (so
+	/// <c>application/json</c> matches <c>application/json;charset=utf-8</c>).
+	/// Products override this to add their own equivalence rules — for example,
+	/// translating between a vendor MIME type and its bare form.
+	/// </summary>
+	/// <param name="accept">The <c>Accept</c> header sent on the request.</param>
+	/// <param name="responseContentType">The <c>Content-Type</c> returned by the server, if any.</param>
+	public virtual bool IsExpectedResponseContentType(string accept, string? responseContentType)
+	{
+		if (string.IsNullOrEmpty(responseContentType))
+			return false;
+
+		if (accept == responseContentType)
+			return true;
+
+		var trimmedAccept = accept.Replace(" ", "");
+		var normalized = responseContentType!.Replace(" ", "");
+
+		return normalized.Equals(trimmedAccept, StringComparison.OrdinalIgnoreCase)
+			|| normalized.StartsWith(trimmedAccept, StringComparison.OrdinalIgnoreCase);
+	}
+
+	/// <summary>
 	/// The name of the current product utilizing <see cref="ITransport{TConfiguration}"/>
 	/// <para>This name makes its way into the transport diagnostics sources and the default user agent string</para>
 	/// </summary>

--- a/src/Elastic.Transport/Responses/DefaultResponseFactory.cs
+++ b/src/Elastic.Transport/Responses/DefaultResponseFactory.cs
@@ -129,7 +129,7 @@ internal sealed class DefaultResponseFactory : ResponseFactory
 		}
 
 		// We only attempt to build a response when the Content-Type matches the accepted type.
-		if (builder is not null && ValidateResponseContentType(boundConfiguration.Accept, contentType) && contentType is not null)
+		if (builder is not null && productRegistration.IsExpectedResponseContentType(boundConfiguration.Accept, contentType) && contentType is not null)
 		{
 			response = isAsync
 				? await builder.BuildAsync<TResponse>(details, boundConfiguration, responseStream, contentType, contentLength, cancellationToken).ConfigureAwait(false)

--- a/src/Elastic.Transport/Responses/ResponseFactory.cs
+++ b/src/Elastic.Transport/Responses/ResponseFactory.cs
@@ -77,7 +77,8 @@ public abstract class ResponseFactory
 
 		// We don't validate the content-type (MIME type) for HEAD requests or responses that have no content (204 status code).
 		// Elastic Cloud responses to HEAD requests strip the content-type header so we want to avoid validation in that case.
-		var hasExpectedContentType = !MayHaveBody(statusCode, endpoint.Method, contentLength) || ValidateResponseContentType(boundConfiguration.Accept, contentType);
+		var hasExpectedContentType = !MayHaveBody(statusCode, endpoint.Method, contentLength)
+			|| boundConfiguration.ConnectionSettings.ProductRegistration.IsExpectedResponseContentType(boundConfiguration.Accept, contentType);
 
 		var details = new ApiCallDetails
 		{
@@ -108,27 +109,4 @@ public abstract class ResponseFactory
 	protected static bool MayHaveBody(int? statusCode, HttpMethod httpMethod, long contentLength) =>
 		contentLength != 0 && (!statusCode.HasValue || (statusCode.Value != 204 && httpMethod != HttpMethod.HEAD));
 
-	internal static bool ValidateResponseContentType(string accept, string? responseContentType)
-	{
-		if (string.IsNullOrEmpty(responseContentType))
-			return false;
-
-		if (accept == responseContentType)
-			return true;
-
-		// TODO - Performance: Review options to avoid the replace here and compare more efficiently.
-		// At this point, responseContentType is guaranteed to be non-null due to the check at line 116
-		var trimmedAccept = accept.Replace(" ", "");
-		var normalizedResponseContentType = responseContentType!.Replace(" ", "");
-
-		return normalizedResponseContentType.Equals(trimmedAccept, StringComparison.OrdinalIgnoreCase)
-			|| normalizedResponseContentType.StartsWith(trimmedAccept, StringComparison.OrdinalIgnoreCase)
-
-			// ES specific fallback required because:
-			// - 404 responses from ES8 don't include the vendored header
-			// - ES8 EQL responses don't include vendored type
-
-			|| (trimmedAccept.Contains("application/vnd.elasticsearch+json")
-			&& normalizedResponseContentType.StartsWith(BoundConfiguration.DefaultContentType, StringComparison.OrdinalIgnoreCase));
-	}
 }

--- a/tests/Elastic.Transport.Tests/Products/DefaultProductRegistrationContentTypeTests.cs
+++ b/tests/Elastic.Transport.Tests/Products/DefaultProductRegistrationContentTypeTests.cs
@@ -1,0 +1,33 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+#nullable enable
+
+using Elastic.Transport.Products;
+using FluentAssertions;
+using Xunit;
+
+namespace Elastic.Transport.Tests.Products;
+
+public class DefaultProductRegistrationContentTypeTests
+{
+	[Theory]
+	[InlineData("application/json", "application/json")]
+	[InlineData("application/json", "application/json;charset=utf-8")]
+	[InlineData("application/json", "APPLICATION/JSON")]
+	[InlineData("text/event-stream", "text/event-stream")]
+	[InlineData("application/vnd.elasticsearch+json;compatible-with=8", "application/vnd.elasticsearch+json;compatible-with=8")]
+	public void ReturnsTrueForExactOrPrefixMatch(string accept, string responseContentType) =>
+		DefaultProductRegistration.Default.IsExpectedResponseContentType(accept, responseContentType).Should().BeTrue();
+
+	[Theory]
+	[InlineData("application/json", "text/plain")]
+	[InlineData("application/json", "application/xml")]
+	[InlineData("application/vnd.elasticsearch+json;compatible-with=8", "application/json")]
+	[InlineData("application/vnd.elasticsearch+json;compatible-with=8", "application/vnd.elasticsearch+json")]
+	[InlineData("application/json", null)]
+	[InlineData("application/json", "")]
+	public void ReturnsFalseForMismatchOrEmpty(string accept, string? responseContentType) =>
+		DefaultProductRegistration.Default.IsExpectedResponseContentType(accept, responseContentType).Should().BeFalse();
+}

--- a/tests/Elastic.Transport.Tests/Products/Elasticsearch/IsExpectedResponseContentTypeTests.cs
+++ b/tests/Elastic.Transport.Tests/Products/Elasticsearch/IsExpectedResponseContentTypeTests.cs
@@ -1,0 +1,57 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+#nullable enable
+
+using Elastic.Transport.Products.Elasticsearch;
+using FluentAssertions;
+using Xunit;
+
+namespace Elastic.Transport.Tests.Products.Elasticsearch;
+
+public class IsExpectedResponseContentTypeTests
+{
+	[Theory]
+	// Exact match
+	[InlineData("application/vnd.elasticsearch+json;compatible-with=8", "application/vnd.elasticsearch+json;compatible-with=8")]
+	// Response is more verbose (extra parameters)
+	[InlineData("application/vnd.elasticsearch+json;compatible-with=8", "application/vnd.elasticsearch+json;compatible-with=8;charset=utf-8")]
+	// Vendor MIME with compat-with stripped from the response
+	[InlineData("application/vnd.elasticsearch+json;compatible-with=8", "application/vnd.elasticsearch+json")]
+	// Bare form (the part after the +)
+	[InlineData("application/vnd.elasticsearch+json;compatible-with=8", "application/json")]
+	[InlineData("application/vnd.elasticsearch+json;compatible-with=8", "application/json;charset=utf-8")]
+	// x-ndjson bare form
+	[InlineData("application/vnd.elasticsearch+x-ndjson;compatible-with=8", "application/vnd.elasticsearch+x-ndjson")]
+	[InlineData("application/vnd.elasticsearch+x-ndjson;compatible-with=8", "application/x-ndjson")]
+	// Canonical mapbox bare form (the SearchMvt path)
+	[InlineData("application/vnd.elasticsearch+vnd.mapbox-vector-tile;compatible-with=8", "application/vnd.mapbox-vector-tile")]
+	[InlineData("application/vnd.elasticsearch+vnd.mapbox-vector-tile;compatible-with=8", "application/vnd.elasticsearch+vnd.mapbox-vector-tile")]
+	// Multi-value Accept — any vendor entry's bare form is acceptable
+	[InlineData("application/vnd.elasticsearch+json,application/vnd.elasticsearch+x-ndjson", "application/x-ndjson")]
+	[InlineData("application/vnd.elasticsearch+json,application/vnd.elasticsearch+x-ndjson", "application/json")]
+	// Case-insensitive
+	[InlineData("application/vnd.elasticsearch+json;compatible-with=8", "APPLICATION/JSON")]
+	public void Accepts(string accept, string responseContentType) =>
+		new ElasticsearchProductRegistration(typeof(ElasticsearchProductRegistration))
+			.IsExpectedResponseContentType(accept, responseContentType).Should().BeTrue();
+
+	[Theory]
+	// Plain Accept — bare-form rule must NOT trigger; only exact / prefix matches.
+	[InlineData("application/json", "text/plain")]
+	[InlineData("text/event-stream", "application/json")]
+	// Non-elasticsearch vendor MIME as Accept — bare-form rule must NOT trigger
+	// (third-party vendor MIMEs aren't owned by this product).
+	[InlineData("application/vnd.mapbox-vector-tile", "application/json")]
+	[InlineData("application/vnd.mapbox-vector-tile;compatible-with=8", "application/json")]
+	// Vendor Accept — completely different MIME on response
+	[InlineData("application/vnd.elasticsearch+json;compatible-with=8", "text/html")]
+	[InlineData("application/vnd.elasticsearch+x-ndjson;compatible-with=8", "application/json")]
+	// Empty / null response
+	[InlineData("application/vnd.elasticsearch+json;compatible-with=8", null)]
+	[InlineData("application/vnd.elasticsearch+json;compatible-with=8", "")]
+	public void Rejects(string accept, string? responseContentType) =>
+		new ElasticsearchProductRegistration(typeof(ElasticsearchProductRegistration))
+			.IsExpectedResponseContentType(accept, responseContentType).Should().BeFalse();
+}


### PR DESCRIPTION
Two changes that landed while debugging elastic/elasticsearch-net#8867 against ES 8.19.12.

## Move response validation onto `ProductRegistration` (the actual fix)

`ResponseFactory.ValidateResponseContentType` carried a hardcoded `application/vnd.elasticsearch+json → application/json` fallback that:

- was product-specific (Elasticsearch-shaped) but lived in generic transport code; and
- never generalised. ES routinely strips the `;compatible-with=N` annotation and the `vnd.elasticsearch+` wrapper in responses (404, EQL, MVT, …). The hardcoded branch only covered the JSON case; `+x-ndjson` and the canonical `+vnd.mapbox-vector-tile → application/vnd.mapbox-vector-tile` translation were left out, so `IsValidResponse` was false even for legitimate `_mvt` responses.

Move the rule to a new `ProductRegistration.IsExpectedResponseContentType` virtual:

- Base: exact match or response Content-Type that starts with the Accept (covers `application/json` ↔ `application/json;charset=utf-8`).
- `ElasticsearchProductRegistration` overrides: for any `application/vnd.elasticsearch+SUBTYPE[;…]` Accept entry (incl. multi-value lists), additionally accept the bare vendor form (`application/vnd.elasticsearch+SUBTYPE`) and the bare form (`application/SUBTYPE`).

`ResponseFactory.InitializeApiCallDetails` and `DefaultResponseFactory.CreateCoreAsync` now delegate to the registration. The static helper and its hardcoded fallback are gone.

## Broaden the vendor MIME regex (small forward-compat tweak)

The pattern introduced in #207 enumerated the three known vendor subtypes:

    application/vnd\.elasticsearch\+(json|x-ndjson|vnd\.mapbox-vector-tile)

Replace with:

    application/vnd\.elasticsearch\+([A-Za-z0-9.\-+]+)

Same coverage today; forward-compatible with any new `application/vnd.elasticsearch+SUBTYPE` ES might add. Plain MIMEs and third-party vendor MIMEs (`application/vnd.mapbox-vector-tile` etc.) stay untouched — those are the caller's to set.

## Tests

- `Products/DefaultProductRegistrationContentTypeTests` pins the base contract.
- `Products/Elasticsearch/IsExpectedResponseContentTypeTests` covers the vendor matrix: exact, more-verbose response, vendor compat-stripped, bare form for `+json` / `+x-ndjson` / `+vnd.mapbox-vector-tile`, multi-value Accept, case-insensitive matching, plain Accept, and third-party vendor MIMEs that must not trigger the bare-form rule.