### PR TITLE
Fix JsonResponseBuilder treating application/vnd.elasticsearch+json as non-JSON

### DIFF
--- a/src/Elastic.Transport/Products/Elasticsearch/ElasticsearchProductRegistration.cs
+++ b/src/Elastic.Transport/Products/Elasticsearch/ElasticsearchProductRegistration.cs
@@ -178,6 +178,17 @@ public partial class ElasticsearchProductRegistration : ProductRegistration
 		return false;
 	}
 
+	/// <inheritdoc cref="ProductRegistration.IsJsonContentType"/>
+	/// <remarks>
+	/// In addition to the base <c>application/json</c> check, accepts
+	/// <c>application/vnd.elasticsearch+json</c> (and any <c>;compatible-with=N</c>
+	/// suffix variant), which Elasticsearch returns when the client sends
+	/// <c>Accept: application/vnd.elasticsearch+json</c>.
+	/// </remarks>
+	public override bool IsJsonContentType(string? contentType) =>
+		base.IsJsonContentType(contentType) ||
+		(contentType != null && contentType.StartsWith("application/vnd.elasticsearch+json", StringComparison.OrdinalIgnoreCase));
+
 	private static bool TryParseElasticsearchVendorMime(string mime, out string bareVendor, out string bareForm)
 	{
 		const string prefix = "application/vnd.elasticsearch+";

--- a/src/Elastic.Transport/Products/Elasticsearch/ElasticsearchProductRegistration.cs
+++ b/src/Elastic.Transport/Products/Elasticsearch/ElasticsearchProductRegistration.cs
@@ -400,10 +400,7 @@ public partial class ElasticsearchProductRegistration : ProductRegistration
 	];
 
 	/// <inheritdoc />
-	public override bool IsErrorContentType(string? contentType) =>
-		contentType is not null && (
-			contentType.StartsWith("application/json", StringComparison.OrdinalIgnoreCase) ||
-			contentType.StartsWith("application/vnd.elasticsearch+json", StringComparison.OrdinalIgnoreCase));
+	public override bool IsErrorContentType(string? contentType) => IsJsonContentType(contentType);
 
 	/// <inheritdoc />
 	public override ErrorResponse? TryExtractError(BoundConfiguration boundConfiguration, Stream responseStream)

--- a/src/Elastic.Transport/Products/ProductRegistration.cs
+++ b/src/Elastic.Transport/Products/ProductRegistration.cs
@@ -178,6 +178,17 @@ public abstract class ProductRegistration
 	public virtual IReadOnlyCollection<IResponseBuilder> ResponseBuilders { get; } = [new DefaultResponseBuilder()];
 
 	/// <summary>
+	/// Determines whether the response <c>Content-Type</c> indicates that the body should be
+	/// parsed as a JSON document. The default accepts any <c>application/json</c> type
+	/// (including those with parameters such as <c>;charset=utf-8</c>). Products that use
+	/// vendor MIME types for JSON payloads (e.g. <c>application/vnd.elasticsearch+json</c>)
+	/// should override this to return <c>true</c> for those types too.
+	/// </summary>
+	/// <param name="contentType">The <c>Content-Type</c> header value from the response.</param>
+	public virtual bool IsJsonContentType(string? contentType) =>
+		contentType != null && contentType.StartsWith("application/json", StringComparison.OrdinalIgnoreCase);
+
+	/// <summary>
 	/// Determines whether the given response content-type indicates a product-specific error body
 	/// that can be deserialized by <see cref="TryExtractError"/>.
 	/// <para>This is checked before attempting error extraction to avoid parsing non-error content

--- a/src/Elastic.Transport/Responses/Dynamic/DynamicResponseBuilder.cs
+++ b/src/Elastic.Transport/Responses/Dynamic/DynamicResponseBuilder.cs
@@ -25,7 +25,7 @@ internal class DynamicResponseBuilder<T> : TypedResponseBuilder<T> where T : Dyn
 		string contentType, long contentLength, CancellationToken cancellationToken = default)
 	{
 		//if not json store the result under "body"
-		if (contentType == null || !contentType.StartsWith(BoundConfiguration.DefaultContentType, StringComparison.Ordinal))
+		if (!boundConfiguration.ConnectionSettings.ProductRegistration.IsJsonContentType(contentType))
 		{
 			DynamicDictionary dictionary;
 			string stringValue;

--- a/src/Elastic.Transport/Responses/Json/JsonResponseBuilder.cs
+++ b/src/Elastic.Transport/Responses/Json/JsonResponseBuilder.cs
@@ -27,7 +27,7 @@ internal class JsonResponseBuilder<T> : TypedResponseBuilder<T> where T : JsonRe
 		string contentType, long contentLength, CancellationToken cancellationToken = default)
 	{
 		// If not JSON, store the result under "body"
-		if (contentType == null || !contentType.StartsWith(BoundConfiguration.DefaultContentType, StringComparison.Ordinal))
+		if (!boundConfiguration.ConnectionSettings.ProductRegistration.IsJsonContentType(contentType))
 		{
 			string stringValue;
 

--- a/tests/Elastic.Transport.Tests/Responses/Json/JsonResponseTests.cs
+++ b/tests/Elastic.Transport.Tests/Responses/Json/JsonResponseTests.cs
@@ -7,6 +7,7 @@ using System.IO;
 using System.Text;
 using System.Text.Json.Nodes;
 using System.Threading.Tasks;
+using Elastic.Transport.Products.Elasticsearch;
 using FluentAssertions;
 using Xunit;
 
@@ -55,6 +56,46 @@ public class JsonResponseTests
 
 		result = sut.Build<JsonResponse>(apiCallDetails, boundConfiguration, stream, "text/plain", data.Length);
 		result.Get<string>("body").Should().Be("This is not JSON");
+	}
+
+	[Theory]
+	[InlineData("application/vnd.elasticsearch+json")]
+	[InlineData("application/vnd.elasticsearch+json;compatible-with=8")]
+	[InlineData("application/vnd.elasticsearch+json; compatible-with=8")]
+	public async Task BuilderElasticsearchVendorJsonContentType(string vendorContentType)
+	{
+		IResponseBuilder sut = new JsonResponseBuilder();
+		var config = new TransportConfiguration(productRegistration: ElasticsearchProductRegistration.Default);
+		var apiCallDetails = new ApiCallDetails();
+		var boundConfiguration = new BoundConfiguration(config);
+
+		var data = Encoding.UTF8.GetBytes("""{"task":"abc123:1"}""");
+		var stream = new MemoryStream(data);
+
+		var result = await sut.BuildAsync<JsonResponse>(apiCallDetails, boundConfiguration, stream, vendorContentType, data.Length);
+		result.Get<string>("task").Should().Be("abc123:1");
+
+		stream.Position = 0;
+
+		result = sut.Build<JsonResponse>(apiCallDetails, boundConfiguration, stream, vendorContentType, data.Length);
+		result.Get<string>("task").Should().Be("abc123:1");
+	}
+
+	[Theory]
+	[InlineData("application/vnd.elasticsearch+x-ndjson")]
+	[InlineData("application/vnd.elasticsearch+vnd.mapbox-vector-tile")]
+	public async Task BuilderElasticsearchVendorNonJsonContentType(string vendorContentType)
+	{
+		IResponseBuilder sut = new JsonResponseBuilder();
+		var config = new TransportConfiguration(productRegistration: ElasticsearchProductRegistration.Default);
+		var apiCallDetails = new ApiCallDetails();
+		var boundConfiguration = new BoundConfiguration(config);
+
+		var data = Encoding.UTF8.GetBytes("raw body");
+		var stream = new MemoryStream(data);
+
+		var result = await sut.BuildAsync<JsonResponse>(apiCallDetails, boundConfiguration, stream, vendorContentType, data.Length);
+		result.Get<string>("body").Should().Be("raw body");
 	}
 
 	// --- Direct DOM access ---


### PR DESCRIPTION
## Summary

- `JsonResponseBuilder` and `DynamicResponseBuilder` both gated JSON parsing on `contentType.StartsWith("application/json")`. When Elasticsearch returns `application/vnd.elasticsearch+json` (its default when the client sends a matching `Accept` header), that check fails and the body is wrapped as a raw string under `{"body": "..."}` instead of being parsed as a `JsonNode`.
- This broke `ServerReindex.StartReindexAsync` in `Elastic.Ingest.Elasticsearch`: `val.Get<string>("task")` returned `null` → "Reindex response did not contain a 'task' field."

## Changes

- **`ProductRegistration`**: new virtual `IsJsonContentType(string?)` — defaults to `application/json` prefix match.
- **`ElasticsearchProductRegistration`**: overrides to also accept `application/vnd.elasticsearch+json` (and `;compatible-with=N` variants); `+x-ndjson` and binary subtypes remain unaffected.
- **`JsonResponseBuilder` / `DynamicResponseBuilder`**: replace hardcoded `StartsWith("application/json")` with `boundConfiguration.ConnectionSettings.ProductRegistration.IsJsonContentType(contentType)`.
- **`JsonResponseTests`**: two new theory tests — one confirming vendor JSON types are parsed, one confirming non-JSON vendor types still fall through to raw-string mode.

## Test plan

- [x] `BuilderElasticsearchVendorJsonContentType` — `application/vnd.elasticsearch+json` (bare, `;compatible-with=8`, with space) all parse the JSON body correctly
- [x] `BuilderElasticsearchVendorNonJsonContentType` — `+x-ndjson` and `+vnd.mapbox-vector-tile` still wrap as raw string under `body`
- [x] All existing tests pass (205/205 on net10.0, 202/203 on net481 — the one net481 failure is pre-existing and unrelated)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)