### PR TITLE
fix: add explicit permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: Always be deploying
 
 on:
   pull_request:
-    paths-ignore: 
+    paths-ignore:
       - 'README.md'
       - '.editorconfig'
   push:
@@ -10,9 +10,13 @@ on:
       - 'README.md'
       - '.editorconfig'
     branches:
-      - main 
+      - main
     tags:
       - "*.*.*"
+
+permissions:
+  contents: write
+  packages: write
 
 jobs:
   aot-validate:


### PR DESCRIPTION
## Summary

- InfoSec is changing `GITHUB_TOKEN` default permissions from read/write to read-only on July 15th
- Added a top-level `permissions:` block to `.github/workflows/ci.yml` with the permissions the workflow actually uses:
  - `packages: write` — needed for `dotnet nuget push` to `nuget.pkg.github.com` using `GITHUB_TOKEN` (canary package publishing)
  - `contents: write` — needed for `createreleaseongithub` script that creates/updates GitHub releases using `GITHUB_TOKEN` on tag pushes

## Test plan

- [ ] Verify CI passes on this PR (no release or package publishing steps run on PRs, so only the build/test/AOT jobs execute)
- [ ] After merge, verify the next canary push to `main` still publishes packages to GitHub Package Registry successfully
- [ ] After merge, verify the next tag push still creates a GitHub release successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)